### PR TITLE
[FEAT] Event Entity 생성

### DIFF
--- a/backend/src/main/java/com/dailo/backend/entity/Event.java
+++ b/backend/src/main/java/com/dailo/backend/entity/Event.java
@@ -1,0 +1,38 @@
+package com.dailo.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "events")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(length = 200)
+    private String location;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date")
+    private LocalDateTime endDate;
+
+    @Column(length = 50)
+    private String category;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+}


### PR DESCRIPTION
## 개요

Event Entity를 생성하여 행사 정보를 데이터베이스에 저장할 수 있는 구조를 완성했습니다.

## 관련 이슈

- Closes #31

## 작업 내용

- [x] Event.java Entity 파일 생성
- [x] JPA 어노테이션 설정 (@Entity, @Table, @Id, @GeneratedValue, @Column)
- [x] Lombok 어노테이션 적용 (@Getter, @Setter, @NoArgsConstructor)
- [x] 7개 필드 정의 (id, title, location, startDate, endDate, category, description)
- [x] MySQL `events` 테이블 자동 생성 확인
- [x] 한글 데이터 저장/조회 테스트 완료

## 변경 사항

### 📁 새로 생성된 파일

- `backend/src/main/java/com/dailo/backend/entity/Event.java`

### 📊 Entity 필드 상세

| 필드명 | Java 타입 | DB 타입 | 제약조건 | 설명 |
|--------|----------|---------|----------|------|
| id | Long | BIGINT | PK, Auto Increment | 기본키 |
| title | String | VARCHAR(100) | NOT NULL | 행사명 |
| location | String | VARCHAR(200) | | 장소 |
| startDate | LocalDateTime | DATETIME(6) | NOT NULL | 시작일시 |
| endDate | LocalDateTime | DATETIME(6) | | 종료일시 |
| category | String | VARCHAR(50) | | 카테고리 |
| description | String | TEXT | | 상세설명 |

## 테스트 결과

### ✅ 서버 실행 성공****