### PR TITLE
[FEAT] EventRepository 생성

### DIFF
--- a/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
@@ -1,0 +1,18 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+// 해당 인터페이스는 Repository -> 자동 구현체 구현
+@Repository
+// event -> 다룰 entity 타입, long -> event의 id 타입
+public interface EventRepository extends JpaRepository<Event, Long> {
+    // 기본 CRUD 메서드 자동 제공:
+    // - List<Event> findAll() 전체 조회
+    // - Optional<Event> findById(Long id) ID로 조회
+    // - Event save(Event event) 저장/수정
+    // - void deleteById(Long id) ID로 삭제
+    // - long count() 개수 조회
+    // - boolean existsById(Long id) 존재 여부 확인
+}


### PR DESCRIPTION
Closes #32
## 개요

EventRepository 인터페이스를 생성하여 Event Entity의 데이터베이스 접근 계층을 완성했습니다.

## 관련 이슈

- Closes #32

## 작업 내용

- [x] EventRepository.java 인터페이스 생성
- [x] JpaRepository<Event, Long> 상속
- [x] @Repository 어노테이션 적용
- [x] 컴파일 에러 없음 확인
- [x] TestController에서 동작 테스트

## 변경 사항

### 📁 새로 생성된 파일

- `backend/src/main/java/com/dailo/backend/repository/EventRepository.java`

### 📚 자동 제공되는 메서드

| 메서드 | 설명 |
|--------|------|
| findAll() | 모든 Event 조회 |
| findById(Long id) | ID로 Event 조회 |
| save(Event event) | Event 저장/수정 |
| deleteById(Long id) | ID로 Event 삭제 |
| count() | 전체 개수 조회 |
| existsById(Long id) | 존재 여부 확인 |

## 테스트 결과

- ✅ 빌드 성공
- ✅ 컴파일 에러 없음
- ✅ GET /test/events 정상 응답 (빈 배열)

## 체크리스트

- [x] 빌드가 에러 없이 수행되는가?
- [x] Repository 인터페이스가 올바르게 생성되었는가?
- [x] JpaRepository를 상속받았는가?
- [x] @Repository 어노테이션이 적용되었는가?