### PR TITLE
[FEAT] EventController CRUD API 구현 Closes 35#

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/EventController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/EventController.java
@@ -1,0 +1,68 @@
+package com.dailo.backend.controller;
+
+import com.dailo.backend.entity.Event;
+import com.dailo.backend.repository.EventRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+
+    private final EventRepository eventRepository;
+
+    // 생성자 주입 (DI)
+    public EventController(EventRepository eventRepository) {
+        this.eventRepository = eventRepository;
+    }
+
+    // 1. 전체 조회 (GET /api/events)
+    @GetMapping
+    public List<Event> getAllEvents() {
+        return eventRepository.findAll();
+    }
+
+    // 2. 단건 조회 (GET /api/events/{id})
+    @GetMapping("/{id}")
+    public ResponseEntity<Event> getEventById(@PathVariable Long id) {
+        return eventRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // 3. 생성 (POST /api/events)
+    @PostMapping
+    public Event createEvent(@RequestBody Event event) {
+        return eventRepository.save(event);
+    }
+
+    // 4. 수정 (PUT /api/events/{id})
+    @PutMapping("/{id}")
+    public ResponseEntity<Event> updateEvent(@PathVariable Long id, @RequestBody Event eventDetails) {
+        return eventRepository.findById(id)
+                .map(event -> {
+                    event.setTitle(eventDetails.getTitle());
+                    event.setLocation(eventDetails.getLocation());
+                    event.setStartDate(eventDetails.getStartDate());
+                    event.setEndDate(eventDetails.getEndDate());
+                    event.setCategory(eventDetails.getCategory());
+                    event.setDescription(eventDetails.getDescription());
+                    Event updatedEvent = eventRepository.save(event);
+                    return ResponseEntity.ok(updatedEvent);
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // 5. 삭제 (DELETE /api/events/{id})
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
+        return eventRepository.findById(id)
+                .map(event -> {
+                    eventRepository.delete(event);
+                    return ResponseEntity.ok().<Void>build();
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+}


### PR DESCRIPTION
## 개요

EventController를 생성하여 Event Entity의 CRUD API를 완성했습니다.

## 관련 이슈

- Closes #33

## 작업 내용

- [x] EventController.java 클래스 생성
- [x] EventRepository 의존성 주입
- [x] 5개 CRUD API 구현
- [x] Postman 테스트 완료
- [x] MySQL 데이터 저장 확인
- [x] 한글 데이터 정상 처리 확인

## API 명세

| Method | URL | 설명 | Status |
|--------|-----|------|--------|
| GET | /api/events | 전체 조회 | ✅ |
| GET | /api/events/{id} | 단건 조회 | ✅ |
| POST | /api/events | 생성 | ✅ |
| PUT | /api/events/{id} | 수정 | ✅ |
| DELETE | /api/events/{id} | 삭제 | ✅ |

## 테스트 결과

### ✅ Postman 테스트

- 생성 API: 정상 작동 (Status 200)
- 전체 조회 API: 정상 작동
- 단건 조회 API: 정상 작동
- 수정 API: 정상 작동
- 삭제 API: 정상 작동
- 404 에러 처리: 정상 작동

### ✅ MySQL 데이터 확인
```sql
mysql> SELECT * FROM events;
-- 한글 데이터 정상 출력 확인
```

## 체크리스트

- [x] 빌드가 에러 없이 수행되는가?
- [x] 모든 API가 정상 작동하는가?
- [x] 한글 데이터가 정상 처리되는가?
- [x] MySQL에 데이터가 저장되는가?
- [x] 404 에러가 올바르게 처리되는가?
