### PR TITLE
[FEAT] Post Entity 및 CRUD API 구현 #50

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/PostController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/PostController.java
@@ -1,0 +1,87 @@
+package com.dailo.backend.controller;
+
+import com.dailo.backend.dto.PostListResponseDto;
+import com.dailo.backend.dto.PostRequestDto;
+import com.dailo.backend.dto.PostResponseDto;
+import com.dailo.backend.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping
+    public ResponseEntity<Page<PostListResponseDto>> getAllPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "createdAt") String sort,
+            @RequestParam(defaultValue = "DESC") String direction) {
+
+        Sort.Direction sortDirection = Sort.Direction.fromString(direction);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+
+        return ResponseEntity.ok(postService.getAllPosts(pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PostResponseDto> getPostById(@PathVariable Long id) {
+        return ResponseEntity.ok(postService.getPostById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<PostResponseDto> createPost(
+            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId,
+            @RequestBody PostRequestDto requestDto) {
+
+        PostResponseDto response = postService.createPost(requestDto, userId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PostResponseDto> updatePost(
+            @PathVariable Long id,
+            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId,
+            @RequestBody PostRequestDto requestDto) {
+
+        return ResponseEntity.ok(postService.updatePost(id, requestDto, userId));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePost(
+            @PathVariable Long id,
+            @RequestHeader(value = "X-User-Id", defaultValue = "1") Long userId) {
+
+        postService.deletePost(id, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/category/{categoryType}")
+    public ResponseEntity<Page<PostListResponseDto>> getPostsByCategory(
+            @PathVariable String categoryType,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return ResponseEntity.ok(postService.getPostsByCategory(categoryType, pageable));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<PostListResponseDto>> searchPosts(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return ResponseEntity.ok(postService.searchPosts(keyword, pageable));
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/domain/enums/PostStatus.java
+++ b/backend/src/main/java/com/dailo/backend/domain/enums/PostStatus.java
@@ -1,0 +1,7 @@
+package com.dailo.backend.domain.enums;
+
+public enum PostStatus {
+    PUBLISHED,
+    HIDDEN,
+    DELETED
+}

--- a/backend/src/main/java/com/dailo/backend/dto/PostListResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/PostListResponseDto.java
@@ -1,0 +1,38 @@
+package com.dailo.backend.dto;
+
+import com.dailo.backend.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostListResponseDto {
+
+    private Long id;
+    private Long authorId;
+    private String title;
+    private String categoryType;
+    private Integer viewCount;
+    private Integer likeCount;
+    private Integer commentCount;
+    private LocalDateTime createdAt;
+
+    public static PostListResponseDto from(Post post) {
+        return PostListResponseDto.builder()
+                .id(post.getId())
+                .authorId(post.getAuthorId())
+                .title(post.getTitle())
+                .categoryType(post.getCategoryType())
+                .viewCount(post.getViewCount())
+                .likeCount(post.getLikeCount())
+                .commentCount(post.getCommentCount())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/dto/PostRequestDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/PostRequestDto.java
@@ -1,0 +1,25 @@
+package com.dailo.backend.dto;
+
+import com.dailo.backend.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequestDto {
+
+    private String title;
+    private String content;
+    private String categoryType;
+
+    public Post toEntity(Long authorId) {
+        return Post.builder()
+                .authorId(authorId)
+                .title(this.title)
+                .content(this.content)
+                .categoryType(this.categoryType)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/dto/PostResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/PostResponseDto.java
@@ -1,0 +1,45 @@
+package com.dailo.backend.dto;
+
+import com.dailo.backend.domain.enums.PostStatus;
+import com.dailo.backend.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostResponseDto {
+
+    private Long id;
+    private Long authorId;
+    private String title;
+    private String content;
+    private String categoryType;
+    private Integer viewCount;
+    private Integer likeCount;
+    private Integer commentCount;
+    private PostStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostResponseDto from(Post post) {
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .authorId(post.getAuthorId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .categoryType(post.getCategoryType())
+                .viewCount(post.getViewCount())
+                .likeCount(post.getLikeCount())
+                .commentCount(post.getCommentCount())
+                .status(post.getStatus())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/entity/Post.java
+++ b/backend/src/main/java/com/dailo/backend/entity/Post.java
@@ -1,0 +1,104 @@
+package com.dailo.backend.entity;
+
+import com.dailo.backend.domain.enums.PostStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@SQLDelete(sql = "UPDATE posts SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "author_id", nullable = false)
+    private Long authorId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "category_type", length = 50)
+    private String categoryType;
+
+    @Column(name = "view_count")
+    @Builder.Default
+    private Integer viewCount = 0;
+
+    @Column(name = "like_count")
+    @Builder.Default
+    private Integer likeCount = 0;
+
+    @Column(name = "comment_count")
+    @Builder.Default
+    private Integer commentCount = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    @Builder.Default
+    private PostStatus status = PostStatus.PUBLISHED;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 비즈니스 메서드
+    public void update(String title, String content, String categoryType) {
+        this.title = title;
+        this.content = content;
+        this.categoryType = categoryType;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        if (this.commentCount > 0) {
+            this.commentCount--;
+        }
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/repository/PostRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/PostRepository.java
@@ -1,0 +1,24 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByAuthorId(Long authorId, Pageable pageable);
+
+    Page<Post> findByCategoryType(String categoryType, Pageable pageable);
+
+    Page<Post> findByTitleContaining(String keyword, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
+    void increaseViewCount(@Param("id") Long id);
+}

--- a/backend/src/main/java/com/dailo/backend/service/PostService.java
+++ b/backend/src/main/java/com/dailo/backend/service/PostService.java
@@ -1,0 +1,79 @@
+package com.dailo.backend.service;
+
+import com.dailo.backend.dto.PostListResponseDto;
+import com.dailo.backend.dto.PostRequestDto;
+import com.dailo.backend.dto.PostResponseDto;
+import com.dailo.backend.entity.Post;
+import com.dailo.backend.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    public Page<PostListResponseDto> getAllPosts(Pageable pageable) {
+        return postRepository.findAll(pageable)
+                .map(PostListResponseDto::from);
+    }
+
+    @Transactional
+    public PostResponseDto getPostById(Long id) {
+        // 조회수 먼저 증가 (동시성 안전한 UPDATE 쿼리)
+        postRepository.increaseViewCount(id);
+
+        // 증가된 조회수 반영된 데이터 조회
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Post not found: " + id));
+
+        return PostResponseDto.from(post);
+    }
+
+    @Transactional
+    public PostResponseDto createPost(PostRequestDto requestDto, Long authorId) {
+        Post post = requestDto.toEntity(authorId);
+        Post savedPost = postRepository.save(post);
+        return PostResponseDto.from(savedPost);
+    }
+
+    @Transactional
+    public PostResponseDto updatePost(Long id, PostRequestDto requestDto, Long authorId) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Post not found: " + id));
+
+        if (!post.getAuthorId().equals(authorId)) {
+            throw new RuntimeException("You are not the author of this post");
+        }
+
+        post.update(requestDto.getTitle(), requestDto.getContent(), requestDto.getCategoryType());
+        return PostResponseDto.from(post);
+    }
+
+    @Transactional
+    public void deletePost(Long id, Long authorId) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Post not found: " + id));
+
+        if (!post.getAuthorId().equals(authorId)) {
+            throw new RuntimeException("You are not the author of this post");
+        }
+
+        postRepository.delete(post);
+    }
+
+    public Page<PostListResponseDto> getPostsByCategory(String categoryType, Pageable pageable) {
+        return postRepository.findByCategoryType(categoryType, pageable)
+                .map(PostListResponseDto::from);
+    }
+
+    public Page<PostListResponseDto> searchPosts(String keyword, Pageable pageable) {
+        return postRepository.findByTitleContaining(keyword, pageable)
+                .map(PostListResponseDto::from);
+    }
+}


### PR DESCRIPTION
## 📝 개요 (Summary)

커뮤니티 서비스의 핵심인 **게시글(Post) 도메인**을 구축하였습니다.  
단순한 데이터 저장을 넘어 **소프트 삭제(Soft Delete)**, 조회수 증가 로직, 카테고리 필터링 등  
실제 운영 환경에서 필수적인 기능을 포함한 CRUD API를 구현하였습니다.

close #50 
---

## 🛠 작업 내용 (Task)

- [x] **Entity & Repository**
  - Post 엔티티 설계 및 JPA 기반 데이터 접근 계층 구축
- [x] **DTO**
  - 계층 간 데이터 전송을 위한 DTO 3종 정의  
    (`PostRequestDto`, `PostResponseDto`, `PostListResponseDto`)
- [x] **Service & Controller**
  - 게시글 생성/조회/수정/삭제 및 검색을 포함한  
    **7개의 핵심 비즈니스 로직 및 REST API 엔드포인트 구현**
- [x] **검색 및 필터링**
  - 제목 기반 키워드 검색
  - 카테고리별 게시글 목록 조회
- [x] **테스트**
  - Postman을 통한 전 기능 검증
  - 한글 데이터 저장/조회 정상 동작 확인

---

## 🔍 핵심 설계 결정 (Key Design Decisions)

### 1️⃣ 소프트 삭제(Soft Delete) 도입

**도입 이유**
- 사용자 실수로 인한 삭제 복구 가능성
- 삭제된 데이터에 대한 통계 및 이력 유지 필요

**구현 방식**
- `@SQLDelete` 어노테이션을 사용하여 DELETE 요청을 UPDATE 쿼리로 변환
- `@Where(clause = "deleted_at IS NULL")` 적용으로  
  일반 조회 시 삭제된 데이터 자동 제외

---

### 2️⃣ DTO 분리 정책

**도입 이유**
- 목록 조회 시 본문(Content)과 같은 무거운 데이터를 제외하여  
  네트워크 비용 및 응답 시간을 최소화하기 위함

**구조**
- `PostResponseDto` : 상세 조회용 (모든 필드 포함)
- `PostListResponseDto` : 목록 조회용 (요약 정보만 포함)

---

## ✅ 체크리스트 (Acceptance Criteria)

- [x] **Post Entity**
  - 12개 필드 및 JPA 매핑 완료
- [x] **소프트 삭제**
  - `deleted_at`에 삭제 시점 기록
  - 일반 조회 시 삭제된 게시글 미노출
- [x] **권한 확인**
  - 수정/삭제 시 작성자(`authorId`) 일치 여부 검증
- [x] **페이징/정렬**
  - 최신순 정렬 및 페이지 번호 처리 정상 동작
- [x] **빌드**
  - 로컬 및 CI 환경에서 빌드 에러 없음

---

## 📊 API 명세서 (상호 담당)

| Method | Endpoint | 설명 |
|------|---------|------|
| GET | `/api/posts` | 게시글 전체 목록 조회 (페이징/정렬) |
| GET | `/api/posts/{id}` | 게시글 단건 조회 (조회수 +1) |
| POST | `/api/posts` | 신규 게시글 작성 |
| PUT | `/api/posts/{id}` | 게시글 수정 (작성자 확인) |
| DELETE | `/api/posts/{id}` | 게시글 소프트 삭제 |
| GET | `/api/posts/category/{type}` | 카테고리별 게시글 조회 |
| GET | `/api/posts/search` | 제목 키워드 검색 (`?keyword=`) |

---