### PR TITLE
[FEAT] 인증(AUTH) API 및 토큰 관리 시스템 구현-1

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,15 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Spring Security && Validation
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// JWT 라이브러리(jjwt 0.11.5)
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/dailo/backend/auth/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/dailo/backend/auth/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+// 유저 조회
+package com.dailo.backend.auth;
+
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
+
+        // Spring Security의 User 객체로 변환
+        return User.builder()
+                .username(member.getEmail())
+                .password(member.getPassword())
+                .roles(member.getRole().name())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/auth/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/dailo/backend/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,39 @@
+// 인증 필터
+package com.dailo.backend.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/auth/JwtTokenProvider.java
+++ b/backend/src/main/java/com/dailo/backend/auth/JwtTokenProvider.java
@@ -1,0 +1,63 @@
+// 토큰 생성
+package com.dailo.backend.auth;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final UserDetailsService userDetailsService;
+
+    // application.yml에 jwt.secret 설정이 없다면 기본값 사용
+    @Value("${jwt.secret:default_secret_key_must_be_over_32_bytes_long_1234}")
+    private String secretKey;
+    private final long validTime = 1000L * 60 * 60 * 24; // 24시간
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    // 토큰 생성
+    public String createToken(String email, String role) {
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("role", role);
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + validTime))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // 인증 정보 조회
+    public Authentication getAuthentication(String token) {
+        String email = Jwts.parserBuilder().setSigningKey(getSigningKey()).build()
+                .parseClaimsJws(token).getBody().getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.dailo.backend.config;
+
+import com.dailo.backend.auth.JwtAuthenticationFilter;
+import com.dailo.backend.auth.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    // 이제 import 경로가 맞으므로, 여기서 에러가 나지 않아야 합니다.
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll() // 로그인, 회원가입은 누구나 접근 가능
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 페이지는 ADMIN 권한만
+                        .anyRequest().permitAll() // 그 외 요청은 일단 허용 (필요시 .authenticated()로 변경)
+                )
+                // JWT 인증 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.dailo.backend.controller;
+
+import com.dailo.backend.service.AuthService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public String signup(@RequestBody SignupRequest request) {
+        authService.signup(request.email, request.password, request.nickname);
+        return "회원가입 성공";
+    }
+
+    @PostMapping("/login")
+    public TokenResponse login(@RequestBody LoginRequest request) {
+        String token = authService.login(request.email, request.password);
+        return new TokenResponse(token);
+    }
+
+    // DTO 클래스들 (편의상 내부에 작성)
+    @Data
+    static class SignupRequest { private String email; private String password; private String nickname; }
+
+    @Data
+    static class LoginRequest { private String email; private String password; }
+
+    @Data
+    @AllArgsConstructor // 롬복 필요
+    static class TokenResponse { private String accessToken; }
+}

--- a/backend/src/main/java/com/dailo/backend/domain/enums/Role.java
+++ b/backend/src/main/java/com/dailo/backend/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package com.dailo.backend.domain.enums;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/backend/src/main/java/com/dailo/backend/entity/Member.java
+++ b/backend/src/main/java/com/dailo/backend/entity/Member.java
@@ -1,0 +1,34 @@
+package com.dailo.backend.entity;
+
+import com.dailo.backend.domain.enums.Role;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Builder
+    public Member(String email, String password, String nickname, Role role) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.role = role;
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/repository/MemberRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/com/dailo/backend/service/AuthService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AuthService.java
@@ -1,0 +1,48 @@
+// 로그인 회원가입 로직
+package com.dailo.backend.service;
+
+import com.dailo.backend.domain.enums.Role;
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.auth.JwtTokenProvider;
+import com.dailo.backend.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 회원가입
+    @Transactional
+    public Long signup(String email, String password, String nickname) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new RuntimeException("이미 가입된 이메일입니다.");
+        }
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .nickname(nickname)
+                .role(Role.USER) // 기본은 USER
+                .build();
+        return memberRepository.save(member).getId();
+    }
+
+    // 로그인
+    @Transactional(readOnly = true)
+    public String login(String email, String password) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("가입되지 않은 이메일입니다."));
+
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return jwtTokenProvider.createToken(member.getEmail(), member.getRole().name());
+    }
+}


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #52 

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->

- [ ] 소셜 로그인

> - [ ] Provider 구분 로직
> - [ ] isNewMember 판별 로직
> - [ ] 0Auth 토큰 검증 및 사용자 식별
> - [ ] FCM Token 저장 처리

- [x] 자체 회원가입 및 로그인

> - [x] 회원가입 구현
> - [x] 이메일/비밀번호 검증 및 토큰 발급
> - [ ] 인증 코드 생성 및 이메일 발송

- [ ] 토큰 관리

> - [ ] Refresh Token

## 체크리스트
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 신규 유저가 소셜 로그인 응답 시 isNewMember : ture 가 반환되는가?
- [ ] 로그인 성공 시 Access Token, Refresh Token이 정상 발급되는가?
- [ ] 토큰 재발급 요청 시 기존 Refresh Token은 폐기되고 새로운 토근이 발급되는가?
- [ ] 비밀번호 재설정 이메일이 정상적으로 발송되는가?
