### PR TITLE
[FEAT] 지도 마커 조회 API 구현 (Bounds 기반)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
 	//  웹소켓 라이브러리 추가
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// Swagger (Spring Boot 3용)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,9 +31,10 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
+
                         .requestMatchers("/api/auth/**").permitAll() // 로그인, 회원가입은 누구나 접근 가능
                         .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 페이지는 ADMIN 권한만
                         .anyRequest().permitAll() // 그 외 요청은 일단 허용 (필요시 .authenticated()로 변경)

--- a/backend/src/main/java/com/dailo/backend/controller/EventController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/EventController.java
@@ -3,74 +3,66 @@ package com.dailo.backend.controller;
 import com.dailo.backend.dto.EventDetailResponse;
 import com.dailo.backend.dto.EventListRequest;
 import com.dailo.backend.dto.EventListResponse;
+import com.dailo.backend.dto.EventMapResponse;
 import com.dailo.backend.service.EventService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/events")
-@RequiredArgsConstructor // final 필드 생성자 자동 생성 (DI)
+@RequiredArgsConstructor
+@Tag(name = "Event API", description = "이벤트 조회 (지도/리스트/상세) 관련 API")
 public class EventController {
 
     private final EventService eventService;
 
-    // ==========================================
-    // [Issue 1] 이벤트 조회 API 구현 (Service 연결)
-    // ==========================================
+    /**
+     * 1. 지도 마커 조회 (Bounds 기반)
+     * [GET] /api/events/map?swLat=...&neLat=...&swLng=...&neLng=...
+     * 현재 보고 있는 지도 화면(좌표 범위) 내의 행사 마커를 조회합니다.
+     */
+    @Operation(summary = "지도 마커 조회 (Bounds)", description = "현재 지도 화면(남서~북동 좌표) 내의 행사 마커 리스트를 반환합니다.")
+    @GetMapping("/map")
+    public ResponseEntity<List<EventMapResponse>> getEventsOnMap(
+            @Parameter(description = "남서쪽(좌하단) 위도", required = true, example = "37.1234") @RequestParam Double swLat,
+            @Parameter(description = "북동쪽(우상단) 위도", required = true, example = "37.5678") @RequestParam Double neLat,
+            @Parameter(description = "남서쪽(좌하단) 경도", required = true, example = "126.1234") @RequestParam Double swLng,
+            @Parameter(description = "북동쪽(우상단) 경도", required = true, example = "127.5678") @RequestParam Double neLng
+    ) {
+        return ResponseEntity.ok(eventService.getEventsInMap(swLat, neLat, swLng, neLng));
+    }
 
     /**
-     * 1. 이벤트 리스트 조회 (페이징 + 필터링)
+     * 2. 이벤트 리스트 조회 (페이징 + 필터링)
      * [GET] /api/events?page=1&size=20&categories=FESTIVAL
      */
+    @Operation(summary = "이벤트 리스트 조회", description = "필터 조건(카테고리, 날짜 등)에 맞는 이벤트 목록을 페이징하여 조회합니다.")
     @GetMapping
     public ResponseEntity<Page<EventListResponse>> getEventList(
             @ModelAttribute EventListRequest request
     ) {
-        // DTO의 page, size를 이용하여 Pageable 객체 생성
-        Pageable pageable = PageRequest.of(request.page() - 1, request.size());
-
+        // Service 내부에서 PageRequest 생성 및 로직 처리한다고 가정하고 호출
         Page<EventListResponse> response = eventService.getEventList(request);
         return ResponseEntity.ok(response);
     }
 
     /**
-     * 2. 이벤트 상세 조회
+     * 3. 이벤트 상세 조회
      * [GET] /api/events/{id}
      */
+    @Operation(summary = "이벤트 상세 조회", description = "특정 이벤트의 상세 정보를 조회합니다.")
     @GetMapping("/{id}")
-    public ResponseEntity<EventDetailResponse> getEventDetail(@PathVariable Long id) {
+    public ResponseEntity<EventDetailResponse> getEventDetail(
+            @Parameter(description = "이벤트 ID") @PathVariable Long id
+    ) {
         EventDetailResponse response = eventService.getEventDetail(id);
         return ResponseEntity.ok(response);
     }
-
-    // ==========================================
-    // [TODO] 생성/수정/삭제 API 리팩토링 필요
-    // Entity 구조가 변경(위치 분리, 카테고리 리스트 등)되어 기존 코드는 동작하지 않습니다.
-    // 추후 '이벤트 등록/수정 API' 구현 시점에 맞춰 재작성해야 합니다.
-    // ==========================================
-
-    /*
-    @PostMapping
-    public ResponseEntity<Event> createEvent(@RequestBody Event event) {
-        // TODO: DTO를 통해 입력받고 Service에서 Entity로 변환하여 저장하도록 수정 필요
-        return ResponseEntity.ok(eventRepository.save(event));
-    }
-
-    @PutMapping("/{id}")
-    public ResponseEntity<Event> updateEvent(@PathVariable Long id, @RequestBody Event eventDetails) {
-        // TODO: 변경된 Entity 필드(placeName, latitude, categories 등)에 맞춰 수정 로직 변경 필요
-        // 기존 코드(setLocation 등)는 필드가 없어져서 컴파일 에러 발생함
-        return ResponseEntity.notFound().build();
-    }
-
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
-        // TODO: Service를 통해 삭제하도록 수정 필요
-        return ResponseEntity.ok().build();
-    }
-    */
 }

--- a/backend/src/main/java/com/dailo/backend/dto/EventMapResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/EventMapResponse.java
@@ -1,0 +1,38 @@
+package com.dailo.backend.dto;
+
+import com.dailo.backend.entity.Event;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventMapResponse {
+    private Long id;
+    private String title;
+    private Double latitude;
+    private Double longitude;
+    private String category;      // 대표 카테고리 1개 (핀 색상 구분용)
+    private String thumbnailUrl;
+    private String status;        // 행사 상태 (ACTIVE 등)
+
+    public static EventMapResponse from(Event event) {
+        String mainCategory = "ETC";
+        if (event.getCategories() != null && !event.getCategories().isEmpty()) {
+            mainCategory = event.getCategories().get(0).name();
+        }
+
+        return EventMapResponse.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .latitude(event.getLatitude())
+                .longitude(event.getLongitude())
+                .category(mainCategory)
+                .thumbnailUrl(event.getThumbnailUrl())
+                .status(event.getStatus().name())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/entity/Event.java
+++ b/backend/src/main/java/com/dailo/backend/entity/Event.java
@@ -111,12 +111,12 @@ public class Event {
         this.longitude = longitude;
         this.startAt = startAt;
         this.endAt = endAt;
-        this.categories = categories; // 리스트 교체
+        this.categories = categories;
         this.status = status;
         this.thumbnailUrl = thumbnailUrl;
-        this.posterUrls = posterUrls; // 리스트 교체
+        this.posterUrls = posterUrls;
         this.description = description;
         this.hostContact = hostContact;
-        this.isAdminManaged = true; // 관리자가 수정했으므로 true로 변경
+        this.isAdminManaged = true;
     }
 }

--- a/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
@@ -16,17 +16,47 @@ import java.util.List;
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 
+
+    // 지도 뷰 - Bounds 기반 조회
+
+    /**
+     * 지도 화면(Viewport) 내의 행사 마커를 조회합니다.
+     * deleted_at IS NULL 조건은 Entity의 @Where 어노테이션에 의해 자동 적용됩니다.
+     */
+    @Query("SELECT e FROM Event e " +
+            "WHERE e.latitude BETWEEN :swLat AND :neLat " +
+            "AND e.longitude BETWEEN :swLng AND :neLng " +
+            "AND e.status = :status")
+    List<Event> findEventsInBounds(
+            @Param("swLat") Double swLat, @Param("neLat") Double neLat,
+            @Param("swLng") Double swLng, @Param("neLng") Double neLng,
+            @Param("status") EventStatus status
+    );
+
+
+    //  리스트 뷰
+
+
     // 관리자용 전체 조회
     Page<Event> findAll(Pageable pageable);
-
-    // 상태 + 카테고리 필터링 (기간 X)
-    Page<Event> findDistinctByStatusAndCategoriesIn(EventStatus status, List<EventCategory> categories, Pageable pageable);
 
     // 상태만 필터링
     Page<Event> findAllByStatus(EventStatus status, Pageable pageable);
 
-    // 상태 + 카테고리 + 기간 필터링
-    // startDateTime -> startAt / endDateTime -> endAt 로 변경
+    // 상태 + 카테고리 필터링 (기간 X)
+    Page<Event> findDistinctByStatusAndCategoriesIn(EventStatus status, List<EventCategory> categories, Pageable pageable);
+
+    // 상태 + 기간 필터링 (카테고리 X)
+    @Query("SELECT e FROM Event e WHERE e.status = :status " +
+            "AND e.startAt <= :searchEnd " +
+            "AND e.endAt >= :searchStart")
+    Page<Event> findByStatusAndDate(
+            @Param("status") EventStatus status,
+            @Param("searchStart") LocalDateTime searchStart,
+            @Param("searchEnd") LocalDateTime searchEnd,
+            Pageable pageable);
+
+    // 상태 + 카테고리 + 기간 필터링 (풀 옵션)
     @Query("SELECT DISTINCT e FROM Event e " +
             "JOIN e.categories c " +
             "WHERE e.status = :status " +
@@ -36,16 +66,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Page<Event> findByStatusAndCategoriesAndDate(
             @Param("status") EventStatus status,
             @Param("categories") List<EventCategory> categories,
-            @Param("searchStart") LocalDateTime searchStart,
-            @Param("searchEnd") LocalDateTime searchEnd,
-            Pageable pageable);
-
-    // 상태 + 기간 필터링 (카테고리 없을 때)
-    @Query("SELECT e FROM Event e WHERE e.status = :status " +
-            "AND e.startAt <= :searchEnd " +
-            "AND e.endAt >= :searchStart")
-    Page<Event> findByStatusAndDate(
-            @Param("status") EventStatus status,
             @Param("searchStart") LocalDateTime searchStart,
             @Param("searchEnd") LocalDateTime searchEnd,
             Pageable pageable);

--- a/backend/src/main/java/com/dailo/backend/service/EventService.java
+++ b/backend/src/main/java/com/dailo/backend/service/EventService.java
@@ -1,5 +1,6 @@
 package com.dailo.backend.service;
 
+import com.dailo.backend.dto.EventMapResponse;
 import com.dailo.backend.entity.Event;
 import com.dailo.backend.domain.enums.EventStatus;
 import com.dailo.backend.repository.EventRepository;
@@ -16,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -95,5 +98,15 @@ public class EventService {
                 event.getDescription(),
                 event.getCategories()
         );
+    }
+
+    // 지도 마커 조회
+    // 현재 지도 화면 안에 포함되면서, ACTIVE 상태 행사만 반환
+    @Transactional(readOnly = true)
+    public List<EventMapResponse> getEventsInMap(Double swLat, Double neLat, Double swLng, Double neLng) {
+        return eventRepository.findEventsInBounds(swLat, neLat, swLng, neLng, EventStatus.ACTIVE)
+                .stream()
+                .map(EventMapResponse::from)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #60 

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->

- [x] 지도 조회 전용 경량 DTO (EventMapResponse) 생성
- [x] Repository 범위 검색 쿼리 (findEventsInBounds) 구현 (BETWEEN 절 활용)
- [x] 지도 마커 조회 API (GET /api/events/map) Controller 및 Service 로직 구현

## 체크리스트
<!-- [ ] 옆 내용을 수정해주세요 -->

- [x] 요청 파라미터로 neLat, neLng, swLat, swLng (북동/남서 좌표)를 정확히 받는가?
- [x] 지정된 사각형 범위(Viewport) 내의 행사 데이터만 필터링되어 반환되는가?
- [x] 응답 데이터가 지도 렌더링에 필요한 최소 필드(id, 좌표, 제목, 썸네일 등)만 포함하는가?
- [x] 삭제되거나 비공개 상태인 행사는 조회되지 않는가?
