### PR TITLE
[FEAT] 이벤트 상세 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/EventController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/EventController.java
@@ -57,12 +57,12 @@ public class EventController {
      * 3. 이벤트 상세 조회
      * [GET] /api/events/{id}
      */
-    @Operation(summary = "이벤트 상세 조회", description = "특정 이벤트의 상세 정보를 조회합니다.")
+    @Operation(summary = "이벤트 상세 조회", description = "특정 이벤트의 모든 상세 정보를 조회합니다.")
     @GetMapping("/{id}")
     public ResponseEntity<EventDetailResponse> getEventDetail(
-            @Parameter(description = "이벤트 ID") @PathVariable Long id
+            @Parameter(description = "조회할 이벤트 ID", required = true)
+            @PathVariable Long id
     ) {
-        EventDetailResponse response = eventService.getEventDetail(id);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(eventService.getEventDetail(id));
     }
 }

--- a/backend/src/main/java/com/dailo/backend/dto/EventDetailResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/EventDetailResponse.java
@@ -1,21 +1,49 @@
 package com.dailo.backend.dto;
 
+import com.dailo.backend.entity.Event;
 import com.dailo.backend.domain.enums.EventCategory;
-import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record EventDetailResponse(
-        Long id,
-        String title,
-        List<String> posterUrls,
-        LocalDateTime startDateTime,
-        LocalDateTime endDateTime,
-        String placeName,
-        String placeAddress,
-        Double latitude,
-        Double longitude,
-        String description,
-        List<EventCategory> categories
-) {
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventDetailResponse {
+    private Long id;
+    private String title;
+    private List<String> posterUrls;     // 포스터 이미지 리스트
+    private LocalDateTime startAt;       // 시작 일시
+    private LocalDateTime endAt;         // 종료 일시
+    private String placeName;            // 장소명
+    private String placeAddress;         // 상세 주소
+    private Double latitude;             // 위도
+    private Double longitude;            // 경도
+    private String description;          // 상세 설명 (본문)
+    private List<EventCategory> categories; // 카테고리 리스트
+    private String hostContact;          // 주최측 연락처
+    private String status;               // 행사 상태 (ACTIVE/DRAFT 등)
+
+    public static EventDetailResponse from(Event event) {
+        return EventDetailResponse.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .posterUrls(event.getPosterUrls())
+                .startAt(event.getStartAt())
+                .endAt(event.getEndAt())
+                .placeName(event.getPlaceName())
+                .placeAddress(event.getPlaceAddress())
+                .latitude(event.getLatitude())
+                .longitude(event.getLongitude())
+                .description(event.getDescription())
+                .categories(event.getCategories())
+                .hostContact(event.getHostContact())
+                .status(event.getStatus().name())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/dailo/backend/service/EventService.java
+++ b/backend/src/main/java/com/dailo/backend/service/EventService.java
@@ -1,12 +1,14 @@
 package com.dailo.backend.service;
 
-import com.dailo.backend.dto.EventMapResponse;
-import com.dailo.backend.entity.Event;
-import com.dailo.backend.domain.enums.EventStatus;
-import com.dailo.backend.repository.EventRepository;
+// 패키지 경로가 변경되었으므로 import 수정
 import com.dailo.backend.dto.EventDetailResponse;
 import com.dailo.backend.dto.EventListRequest;
 import com.dailo.backend.dto.EventListResponse;
+import com.dailo.backend.dto.EventMapResponse;
+
+import com.dailo.backend.entity.Event;
+import com.dailo.backend.domain.enums.EventStatus;
+import com.dailo.backend.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,43 +24,49 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 최적화를 위한 읽기 전용
+@Transactional(readOnly = true)
 public class EventService {
 
     private final EventRepository eventRepository;
 
-    /**
-     * 이벤트 리스트 조회 (필터링 + 페이징)
-     * - ACTIVE (진행 중) 이벤트만 조회
-     * - 카테고리 필터가 있으면 해당 카테고리만, 없으면 전체 조회
-     */
+    // 상세 조회
+
+    public EventDetailResponse getEventDetail(Long eventId) {
+        return eventRepository.findById(eventId)
+                .map(EventDetailResponse::from) // Entity -> DTO 변환 위임
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이벤트입니다. id=" + eventId));
+    }
+
+    // 지도 마커 조회 (Bounds)
+    public List<EventMapResponse> getEventsInMap(Double swLat, Double neLat, Double swLng, Double neLng) {
+        return eventRepository.findEventsInBounds(swLat, neLat, swLng, neLng, EventStatus.ACTIVE)
+                .stream()
+                .map(EventMapResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    // 리스트 조회
     public Page<EventListResponse> getEventList(EventListRequest request) {
         Pageable pageable = PageRequest.of(request.page() - 1, request.size(), Sort.by(Sort.Direction.ASC, "startAt"));
 
         Page<Event> events;
 
-
         LocalDateTime searchStart = (request.startDateTime() != null) ? request.startDateTime().atStartOfDay() : LocalDateTime.MIN;
         LocalDateTime searchEnd = (request.endDateTime() != null) ? request.endDateTime().atTime(LocalTime.MAX) : LocalDateTime.MAX;
 
-        // 날짜 필터 유무에 따라 다른 메서드 호출
         if (request.hasDateFilter()) {
             if (request.hasCategory()) {
-                // 기간 O + 카테고리 O
                 events = eventRepository.findByStatusAndCategoriesAndDate(
                         EventStatus.ACTIVE, request.categories(), searchStart, searchEnd, pageable);
             } else {
-                // 기간 O + 카테고리 X
                 events = eventRepository.findByStatusAndDate(
                         EventStatus.ACTIVE, searchStart, searchEnd, pageable);
             }
         } else {
             if (request.hasCategory()) {
-                // 기간 X + 카테고리 O
                 events = eventRepository.findDistinctByStatusAndCategoriesIn(
                         EventStatus.ACTIVE, request.categories(), pageable);
             } else {
-                // 기간 X + 카테고리 X (전체 목록)
                 events = eventRepository.findAllByStatus(EventStatus.ACTIVE, pageable);
             }
         }
@@ -66,13 +74,7 @@ public class EventService {
         return events.map(this::convertToEventListResponse);
     }
 
-    // 상세 조회
-    public EventDetailResponse getEventDetail(Long eventId) {
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이벤트입니다. id=" + eventId));
-        return convertToEventDetailResponse(event);
-    }
-
+    // 리스트 변환용 메서드
     private EventListResponse convertToEventListResponse(Event event) {
         return new EventListResponse(
                 event.getId(),
@@ -82,31 +84,5 @@ public class EventService {
                 event.getEndAt(),
                 event.getPlaceName()
         );
-    }
-
-    private EventDetailResponse convertToEventDetailResponse(Event event) {
-        return new EventDetailResponse(
-                event.getId(),
-                event.getTitle(),
-                event.getPosterUrls(),
-                event.getStartAt(),
-                event.getEndAt(),
-                event.getPlaceName(),
-                event.getPlaceAddress(),
-                event.getLatitude(),
-                event.getLongitude(),
-                event.getDescription(),
-                event.getCategories()
-        );
-    }
-
-    // 지도 마커 조회
-    // 현재 지도 화면 안에 포함되면서, ACTIVE 상태 행사만 반환
-    @Transactional(readOnly = true)
-    public List<EventMapResponse> getEventsInMap(Double swLat, Double neLat, Double swLng, Double neLng) {
-        return eventRepository.findEventsInBounds(swLat, neLat, swLng, neLng, EventStatus.ACTIVE)
-                .stream()
-                .map(EventMapResponse::from)
-                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #62 

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용

- [x] 상세 조회용 DTO (EventDetailResponse) 구현 (상세 설명, 포스터 이미지 리스트 등 포함)
- [x] Service 조회 로직 구현 (findById 활용 및 예외 처리)
- [x] 상세 조회 API (GET /api/events/{id}) Controller 구현
- [x] Swagger API 문서화 설정

## 체크리스트

- [x] 유효한 id 요청 시 이벤트의 모든 상세 정보(제목, 설명, 일시, 장소, 이미지, 카테고리 등)가 반환되는가?
- [x] 존재하지 않는 id 요청 시 404 Not Found 에러(또는 예외 메시지)가 반환되는가?
- [x] 삭제된(deleted_at 존재) 이벤트 요청 시 조회되지 않는가?
- [x] 포스터 이미지(posterUrls)와 카테고리(categories)가 리스트 형태로 정상 반환되는가? 행사는 조회되지 않는가?
- [ ] 