### PR TITLE
[FEAT] 이벤트 리스트 검색 및 필터링(Search/Filter) API 구현

### DIFF
--- a/backend/src/main/java/com/dailo/backend/dto/EventListRequest.java
+++ b/backend/src/main/java/com/dailo/backend/dto/EventListRequest.java
@@ -10,27 +10,32 @@ public record EventListRequest(
         Integer size,
 
         @DateTimeFormat(pattern = "yyyy-MM-dd")
-        LocalDate startDateTime,
+        LocalDate startAt,
 
         @DateTimeFormat(pattern = "yyyy-MM-dd")
-        LocalDate endDateTime,
+        LocalDate endAt,
 
         List<EventCategory> categories,
-        String sort
+
+        String region,  // 지역 필터
+        String keyword, // 검색어
+        String sort     // 정렬
 ) {
-    // page, size가 null인 경우 기본값 설정
     public EventListRequest {
         if (page == null) page = 1;
         if (size == null) size = 20;
     }
 
-    // 리스트가 비어있지 않은지 확인
     public boolean hasCategory() {
         return categories != null && !categories.isEmpty();
     }
 
-    // 날짜 필터 여부 확인
+    // [수정] 변수명이 바뀌었으니 여기도 startAt, endAt으로 변경
     public boolean hasDateFilter() {
-        return startDateTime != null && endDateTime != null;
+        return startAt != null && endAt != null;
+    }
+
+    public boolean hasKeyword() {
+        return keyword != null && !keyword.isBlank();
     }
 }

--- a/backend/src/main/java/com/dailo/backend/dto/EventListResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/EventListResponse.java
@@ -7,7 +7,7 @@ public record EventListResponse(
         Long id,
         String title,
         String thumbnailUrl,
-        LocalDateTime startDateTime,
-        LocalDateTime endDateTime,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
         String placeName
 ) {}

--- a/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
@@ -16,13 +16,7 @@ import java.util.List;
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-
-    // 지도 뷰 - Bounds 기반 조회
-
-    /**
-     * 지도 화면(Viewport) 내의 행사 마커를 조회합니다.
-     * deleted_at IS NULL 조건은 Entity의 @Where 어노테이션에 의해 자동 적용됩니다.
-     */
+    // 지도 뷰
     @Query("SELECT e FROM Event e " +
             "WHERE e.latitude BETWEEN :swLat AND :neLat " +
             "AND e.longitude BETWEEN :swLng AND :neLng " +
@@ -34,39 +28,37 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     );
 
 
-    //  리스트 뷰
+
+    // 리스트 뷰 - 통합 검색 쿼리
 
 
-    // 관리자용 전체 조회
-    Page<Event> findAll(Pageable pageable);
-
-    // 상태만 필터링
-    Page<Event> findAllByStatus(EventStatus status, Pageable pageable);
-
-    // 상태 + 카테고리 필터링 (기간 X)
-    Page<Event> findDistinctByStatusAndCategoriesIn(EventStatus status, List<EventCategory> categories, Pageable pageable);
-
-    // 상태 + 기간 필터링 (카테고리 X)
-    @Query("SELECT e FROM Event e WHERE e.status = :status " +
-            "AND e.startAt <= :searchEnd " +
-            "AND e.endAt >= :searchStart")
-    Page<Event> findByStatusAndDate(
-            @Param("status") EventStatus status,
-            @Param("searchStart") LocalDateTime searchStart,
-            @Param("searchEnd") LocalDateTime searchEnd,
-            Pageable pageable);
-
-    // 상태 + 카테고리 + 기간 필터링 (풀 옵션)
+    /**
+     * [통합 검색]
+     * 키워드, 지역, 카테고리, 날짜 조건을 한 번에 처리합니다.
+     * 파라미터가 NULL이면 해당 조건은 무시(전체 조회)됩니다.
+     */
     @Query("SELECT DISTINCT e FROM Event e " +
-            "JOIN e.categories c " +
+            "LEFT JOIN e.categories c " + // 카테고리 조건을 위해 조인
             "WHERE e.status = :status " +
-            "AND c IN :categories " +
-            "AND e.startAt <= :searchEnd " +
-            "AND e.endAt >= :searchStart")
-    Page<Event> findByStatusAndCategoriesAndDate(
+            // 1. 날짜 범위 (교집합 검색: 행사가 검색 기간에 조금이라도 걸치면 조회)
+            "AND (:startAt IS NULL OR e.endAt >= :startAt) " +
+            "AND (:endAt IS NULL OR e.startAt <= :endAt) " +
+            // 2. 카테고리 (없으면 전체, 있으면 해당 카테고리 포함된 것만)
+            "AND (:categories IS NULL OR c IN :categories) " +
+            // 3. 지역 필터 (주소에 해당 지역명이 포함되는지)
+            "AND (:region IS NULL OR e.placeAddress LIKE %:region%) " +
+            // 4. 키워드 검색 (제목 또는 장소명에 키워드 포함)
+            "AND (:keyword IS NULL OR (e.title LIKE %:keyword% OR e.placeName LIKE %:keyword%))")
+    Page<Event> searchEvents(
             @Param("status") EventStatus status,
+            @Param("startAt") LocalDateTime startAt,
+            @Param("endAt") LocalDateTime endAt,
             @Param("categories") List<EventCategory> categories,
-            @Param("searchStart") LocalDateTime searchStart,
-            @Param("searchEnd") LocalDateTime searchEnd,
-            Pageable pageable);
+            @Param("region") String region,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    // (관리자용 전체 조회는 필요하다면 남겨둡니다)
+    Page<Event> findAll(Pageable pageable);
 }

--- a/backend/src/main/java/com/dailo/backend/service/EventService.java
+++ b/backend/src/main/java/com/dailo/backend/service/EventService.java
@@ -1,6 +1,5 @@
 package com.dailo.backend.service;
 
-// 패키지 경로가 변경되었으므로 import 수정
 import com.dailo.backend.dto.EventDetailResponse;
 import com.dailo.backend.dto.EventListRequest;
 import com.dailo.backend.dto.EventListResponse;
@@ -33,11 +32,12 @@ public class EventService {
 
     public EventDetailResponse getEventDetail(Long eventId) {
         return eventRepository.findById(eventId)
-                .map(EventDetailResponse::from) // Entity -> DTO 변환 위임
+                .map(EventDetailResponse::from)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이벤트입니다. id=" + eventId));
     }
 
-    // 지도 마커 조회 (Bounds)
+    // 지도 마커 조회
+
     public List<EventMapResponse> getEventsInMap(Double swLat, Double neLat, Double swLng, Double neLng) {
         return eventRepository.findEventsInBounds(swLat, neLat, swLng, neLng, EventStatus.ACTIVE)
                 .stream()
@@ -45,36 +45,29 @@ public class EventService {
                 .collect(Collectors.toList());
     }
 
-    // 리스트 조회
+    // 리스트 조회 (검색/필터 통합)
+
     public Page<EventListResponse> getEventList(EventListRequest request) {
+        // startAt 오름차순
         Pageable pageable = PageRequest.of(request.page() - 1, request.size(), Sort.by(Sort.Direction.ASC, "startAt"));
 
-        Page<Event> events;
+        LocalDateTime searchStart = (request.startAt() != null) ? request.startAt().atStartOfDay() : null;
+        LocalDateTime searchEnd = (request.endAt() != null) ? request.endAt().atTime(LocalTime.MAX) : null;
 
-        LocalDateTime searchStart = (request.startDateTime() != null) ? request.startDateTime().atStartOfDay() : LocalDateTime.MIN;
-        LocalDateTime searchEnd = (request.endDateTime() != null) ? request.endDateTime().atTime(LocalTime.MAX) : LocalDateTime.MAX;
-
-        if (request.hasDateFilter()) {
-            if (request.hasCategory()) {
-                events = eventRepository.findByStatusAndCategoriesAndDate(
-                        EventStatus.ACTIVE, request.categories(), searchStart, searchEnd, pageable);
-            } else {
-                events = eventRepository.findByStatusAndDate(
-                        EventStatus.ACTIVE, searchStart, searchEnd, pageable);
-            }
-        } else {
-            if (request.hasCategory()) {
-                events = eventRepository.findDistinctByStatusAndCategoriesIn(
-                        EventStatus.ACTIVE, request.categories(), pageable);
-            } else {
-                events = eventRepository.findAllByStatus(EventStatus.ACTIVE, pageable);
-            }
-        }
+        // 통합 검색 쿼리 실행
+        Page<Event> events = eventRepository.searchEvents(
+                EventStatus.ACTIVE,
+                searchStart,
+                searchEnd,
+                request.categories(),
+                request.region(),
+                request.keyword(),
+                pageable
+        );
 
         return events.map(this::convertToEventListResponse);
     }
 
-    // 리스트 변환용 메서드
     private EventListResponse convertToEventListResponse(Event event) {
         return new EventListResponse(
                 event.getId(),


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #72 


## 작업 내용

- [x] 리스트 조회용 DTO (EventListRequest, EventListResponse) 필드 추가 및 네이밍 통일 (startAt 등)
- [x] Repository 검색 쿼리 구현 (제목/장소 키워드 검색, 지역 필터, 날짜 범위, 카테고리 복합 조건)
- [x] Service 비즈니스 로직 고도화 (동적 쿼리 처리)
- [x] 리스트 조회 API (GET /api/events) Controller 연결 및 테스트
- [x] Swagger API 문서화 설정

## 체크리스트

- [x] keyword 입력 시 제목(title) 또는 장소명(placeName)에 포함된 행사가 검색되는가?
- [x] region 파라미터로 특정 지역(예: "서울", "강남") 필터링이 가능한가?
- [x] categories를 다중 선택했을 때 해당 카테고리 중 하나라도 포함된 행사가 조회되는가? (OR 조건)
- [x] startDateTime ~ endDateTime 날짜 범위 내에서 진행 중인 행사만 필터링되는가?
- [x] 페이징(page, size) 기능이 정상 동작하며, 최신순(기본) 정렬이 적용되는가?
- [x] 응답 DTO의 날짜 필드명이 startAt, endAt으로 상세 조회 API와 통일되었는가?
