### PR TITLE
[FEAT] 관심 행사(Scrap) 저장/취소 및 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/ScrapController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/ScrapController.java
@@ -1,0 +1,55 @@
+package com.dailo.backend.controller;
+
+import com.dailo.backend.dto.EventListResponse;
+import com.dailo.backend.service.ScrapService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/scraps")
+@RequiredArgsConstructor
+@Tag(name = "Scrap API", description = "관심 행사(찜하기) 저장/취소 및 목록 조회")
+public class ScrapController {
+
+    private final ScrapService scrapService;
+
+    // [임시] 로그인 기능 구현 전까지 사용할 테스트 유저 ID
+    private static final Long TEST_USER_ID = 1L;
+
+    /**
+     * 1. 스크랩 토글 (저장/취소)
+     * [POST] /api/scraps/{eventId}
+     */
+    @Operation(summary = "스크랩 토글 (저장/취소)", description = "행사를 찜하거나 취소합니다. (이미 찜했으면 삭제, 없으면 저장)")
+    @PostMapping("/{eventId}")
+    public ResponseEntity<String> toggleScrap(
+            @Parameter(description = "행사 ID", required = true) @PathVariable Long eventId
+    ) {
+        boolean isScraped = scrapService.toggleScrap(TEST_USER_ID, eventId);
+
+        if (isScraped) {
+            return ResponseEntity.ok("스크랩 완료 (저장됨)");
+        } else {
+            return ResponseEntity.ok("스크랩 취소 (삭제됨)");
+        }
+    }
+
+    /**
+     * 2. 내 스크랩 목록 조회
+     * [GET] /api/scraps
+     */
+    @Operation(summary = "내 스크랩 목록 조회", description = "내가 찜한 행사 목록을 페이징하여 조회합니다.")
+    @GetMapping
+    public ResponseEntity<Page<EventListResponse>> getMyScraps(
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return ResponseEntity.ok(scrapService.getMyScraps(TEST_USER_ID, pageable));
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/entity/Scrap.java
+++ b/backend/src/main/java/com/dailo/backend/entity/Scrap.java
@@ -1,0 +1,49 @@
+package com.dailo.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "scrap",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_scrap_member_event", // 중복 스크랩 방지 (DB 레벨)
+                        columnNames = {"member_id", "event_id"}
+                )
+        }
+)
+public class Scrap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Scrap(Member member, Event event) {
+        this.member = member;
+        this.event = event;
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/repository/ScrapRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/ScrapRepository.java
@@ -1,0 +1,25 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.Scrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
+    // 1. 스크랩 여부 확인 (Toggle 구현용)
+    // "누가(memberId) 어떤 행사(eventId)를 찜했는지 찾기"
+    Optional<Scrap> findByMemberIdAndEventId(Long memberId, Long eventId);
+
+    // 2. 내 스크랩 목록 조회 (성능 최적화)
+    // 일반 조회를 하면 Event 정보를 가져올 때마다 쿼리가 추가로 나가는 문제(N+1)가 발생합니다.
+    // JOIN FETCH를 써서 스크랩과 행사 정보를 한 번의 쿼리로 가져옵니다.
+    @Query("SELECT s FROM Scrap s " +
+            "JOIN FETCH s.event " +
+            "WHERE s.member.id = :memberId")
+    Page<Scrap> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+}

--- a/backend/src/main/java/com/dailo/backend/service/ScrapService.java
+++ b/backend/src/main/java/com/dailo/backend/service/ScrapService.java
@@ -1,0 +1,77 @@
+package com.dailo.backend.service;
+
+import com.dailo.backend.dto.EventListResponse;
+import com.dailo.backend.entity.Event;
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.entity.Scrap;
+import com.dailo.backend.repository.EventRepository;
+import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.repository.ScrapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScrapService {
+
+    private final ScrapRepository scrapRepository;
+    private final MemberRepository memberRepository;
+    private final EventRepository eventRepository;
+
+    /**
+     * 스크랩 토글 (Toggle)
+     * - 이미 스크랩 했으면 -> 취소(삭제) & return false
+     * - 안 했으면 -> 저장 & return true
+     */
+    @Transactional
+    public boolean toggleScrap(Long memberId, Long eventId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 행사입니다."));
+
+        // 이미 스크랩 되어 있는지 확인
+        Optional<Scrap> scrapOptional = scrapRepository.findByMemberIdAndEventId(memberId, eventId);
+
+        if (scrapOptional.isPresent()) {
+            // 이미 존재하면 삭제
+            scrapRepository.delete(scrapOptional.get());
+            return false; // 결과: 취소됨
+        } else {
+            // 없으면 저장
+            Scrap scrap = Scrap.builder()
+                    .member(member)
+                    .event(event)
+                    .build();
+            scrapRepository.save(scrap);
+            return true;
+        }
+    }
+
+    /**
+     * 내 스크랩 목록 조회
+     * - Scrap 엔티티를 조회해서 Event 정보를 꺼낸 뒤 DTO로 변환
+     */
+    public Page<EventListResponse> getMyScraps(Long memberId, Pageable pageable) {
+        Page<Scrap> scraps = scrapRepository.findAllByMemberId(memberId, pageable);
+
+        return scraps.map(scrap -> {
+            Event event = scrap.getEvent();
+            return new EventListResponse(
+                    event.getId(),
+                    event.getTitle(),
+                    event.getThumbnailUrl(),
+                    event.getStartAt(),
+                    event.getEndAt(),
+                    event.getPlaceName()
+            );
+        });
+    }
+}


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #74 

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용

- [x] Scrap 도메인 설계 (User - Event 다대다 해소를 위한 중간 Entity)
- [x] ScrapRepository 구현 (특정 유저의 스크랩 여부 조회, 목록 조회)
- [x] ScrapService 비즈니스 로직 구현 (Toggle 방식: 이미 있으면 삭제, 없으면 저장)
- [x] 스크랩 API Controller 구현 (POST /api/scraps/{eventId}, GET /api/scraps)
- [x] Swagger API 문서화 설정

## 체크리스트

- [x] [저장/삭제] 동일한 이벤트를 다시 요청하면 스크랩이 취소(삭제)되는가? (Toggle)
- [x] [중복 방지] 이미 스크랩된 이벤트를 중복 저장하지 않도록 처리되었는가?
- [x] [목록 조회] 내가 스크랩한 행사만 페이징(Page) 처리되어 조회되는가?
- [x] [데이터 무결성] 삭제된 행사나 없는 행사를 스크랩하려고 하면 예외가 발생하는가?
- [x] [성능] 목록 조회 시 N+1 문제 없이 이벤트 정보를 잘 가져오는가? (Fetch Join 등 고려)
