### PR TITLE
[FEAT] 네이버 지도 길찾기 데이터 제공 및 URL 연동

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/EventController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/EventController.java
@@ -1,9 +1,9 @@
 package com.dailo.backend.controller;
 
-import com.dailo.backend.dto.EventDetailResponse;
-import com.dailo.backend.dto.EventListRequest;
-import com.dailo.backend.dto.EventListResponse;
-import com.dailo.backend.dto.EventMapResponse;
+import com.dailo.backend.dto.event.EventDetailResponse;
+import com.dailo.backend.dto.event.EventListRequest;
+import com.dailo.backend.dto.event.EventListResponse;
+import com.dailo.backend.dto.event.EventMapResponse;
 import com.dailo.backend.service.EventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/backend/src/main/java/com/dailo/backend/controller/ScrapController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/ScrapController.java
@@ -1,6 +1,6 @@
 package com.dailo.backend.controller;
 
-import com.dailo.backend.dto.EventListResponse;
+import com.dailo.backend.dto.event.EventListResponse;
 import com.dailo.backend.service.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/backend/src/main/java/com/dailo/backend/dto/event/EventDetailResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/event/EventDetailResponse.java
@@ -1,4 +1,4 @@
-package com.dailo.backend.dto;
+package com.dailo.backend.dto.event;
 
 import com.dailo.backend.entity.Event;
 import com.dailo.backend.domain.enums.EventCategory;
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,7 +31,38 @@ public class EventDetailResponse {
     private String hostContact;          // 주최측 연락처
     private String status;               // 행사 상태 (ACTIVE/DRAFT 등)
 
+    // 네이버 지도 길찾기 URL (웹용)
+    private String naverMapUrl;
+
     public static EventDetailResponse from(Event event) {
+
+        // 1. 장소명 or 제목 가져오기
+        String safePlaceName;
+        if (event.getPlaceName() != null && !event.getPlaceName().isEmpty()) {
+            safePlaceName = event.getPlaceName();
+        } else {
+            safePlaceName = event.getTitle();
+        }
+
+        // 2. URL 생성 (URL 인코딩 적용)
+        String generatedMapUrl = null;
+        if (event.getLatitude() != null && event.getLongitude() != null) {
+            try {
+
+                String encodedPlaceName = URLEncoder.encode(safePlaceName, StandardCharsets.UTF_8);
+
+                generatedMapUrl = String.format(
+                        "https://map.naver.com/index.nhn?elng=%f&elat=%f&etext=%s&menu=route",
+                        event.getLongitude(),
+                        event.getLatitude(),
+                        encodedPlaceName // 인코딩된 이름을 넣어야 함!
+                );
+            } catch (Exception e) {
+                // 인코딩 실패 시 URL 생성 안 함 (혹은 로그 남기기)
+                generatedMapUrl = null;
+            }
+        }
+
         return EventDetailResponse.builder()
                 .id(event.getId())
                 .title(event.getTitle())
@@ -44,6 +77,7 @@ public class EventDetailResponse {
                 .categories(event.getCategories())
                 .hostContact(event.getHostContact())
                 .status(event.getStatus().name())
+                .naverMapUrl(generatedMapUrl)
                 .build();
     }
 }

--- a/backend/src/main/java/com/dailo/backend/dto/event/EventListRequest.java
+++ b/backend/src/main/java/com/dailo/backend/dto/event/EventListRequest.java
@@ -1,4 +1,4 @@
-package com.dailo.backend.dto;
+package com.dailo.backend.dto.event;
 
 import com.dailo.backend.domain.enums.EventCategory;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/backend/src/main/java/com/dailo/backend/dto/event/EventListResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/event/EventListResponse.java
@@ -1,6 +1,5 @@
-package com.dailo.backend.dto;
+package com.dailo.backend.dto.event;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record EventListResponse(

--- a/backend/src/main/java/com/dailo/backend/dto/event/EventMapResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/event/EventMapResponse.java
@@ -1,4 +1,4 @@
-package com.dailo.backend.dto;
+package com.dailo.backend.dto.event;
 
 import com.dailo.backend.entity.Event;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/com/dailo/backend/service/EventService.java
+++ b/backend/src/main/java/com/dailo/backend/service/EventService.java
@@ -1,9 +1,9 @@
 package com.dailo.backend.service;
 
-import com.dailo.backend.dto.EventDetailResponse;
-import com.dailo.backend.dto.EventListRequest;
-import com.dailo.backend.dto.EventListResponse;
-import com.dailo.backend.dto.EventMapResponse;
+import com.dailo.backend.dto.event.EventDetailResponse;
+import com.dailo.backend.dto.event.EventListRequest;
+import com.dailo.backend.dto.event.EventListResponse;
+import com.dailo.backend.dto.event.EventMapResponse;
 
 import com.dailo.backend.entity.Event;
 import com.dailo.backend.domain.enums.EventStatus;

--- a/backend/src/main/java/com/dailo/backend/service/ScrapService.java
+++ b/backend/src/main/java/com/dailo/backend/service/ScrapService.java
@@ -1,6 +1,6 @@
 package com.dailo.backend.service;
 
-import com.dailo.backend.dto.EventListResponse;
+import com.dailo.backend.dto.event.EventListResponse;
 import com.dailo.backend.entity.Event;
 import com.dailo.backend.entity.Member;
 import com.dailo.backend.entity.Scrap;


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #78 

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용

- [x] DTO 수정: EventDetailResponse 클래스에 naverMapUrl 필드 추가
- [x] URL 생성 로직 구현: 위도(latitude), 경도(longitude), 장소명(placeName)을 조합하여 네이버 지도 웹 URL 포맷팅
- [x] API 응답 확인: 행사 상세 조회 API(GET /api/events/{id}) 호출 시 URL이 정상적으로 반환되는지 테스트

## 체크리스트

- [x] 응답 JSON에 naverMapUrl 필드가 포함되어 있는가?
- [x] 반환된 URL 클릭 시, 네이버 지도가 실행되며 도착지가 해당 행사 장소로 잡히는가?
- [x] 출발지는 공란(-/-)으로 처리되어 사용자의 입력을 유도하는가?