### PR TITLE
[FEAT] EventSource + SyncLog Entity 구현

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/AdminSyncLogController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/AdminSyncLogController.java
@@ -1,0 +1,62 @@
+package com.dailo.backend.controller;
+
+import com.dailo.backend.domain.enums.SyncStatus;
+import com.dailo.backend.dto.SyncLogCompleteRequestDto;
+import com.dailo.backend.dto.SyncLogResponseDto;
+import com.dailo.backend.dto.SyncLogStartRequestDto;
+import com.dailo.backend.service.SyncLogService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/sync-logs")
+@RequiredArgsConstructor
+public class AdminSyncLogController {
+
+    private final SyncLogService syncLogService;
+
+    // 동기화 로그 목록 조회
+    @GetMapping
+    public ResponseEntity<Page<SyncLogResponseDto>> getLogs(
+            @RequestHeader("X-User-Id") Long adminId,
+            @RequestParam(required = false) String sourceType,
+            @RequestParam(required = false) SyncStatus status,
+            @PageableDefault(size = 20, sort = "startedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(syncLogService.getLogs(adminId, sourceType, status, pageable));
+    }
+
+    // 동기화 로그 상세 조회
+    @GetMapping("/{logId}")
+    public ResponseEntity<SyncLogResponseDto> getLog(
+            @RequestHeader("X-User-Id") Long adminId,
+            @PathVariable Long logId) {
+
+        return ResponseEntity.ok(syncLogService.getLog(adminId, logId));
+    }
+
+    // 동기화 시작 기록
+    @PostMapping("/start")
+    public ResponseEntity<SyncLogResponseDto> startSync(
+            @RequestHeader("X-User-Id") Long adminId,
+            @Valid @RequestBody SyncLogStartRequestDto requestDto) {
+
+        return ResponseEntity.ok(syncLogService.startSync(adminId, requestDto));
+    }
+
+    // 동기화 완료 기록
+    @PutMapping("/{logId}/complete")
+    public ResponseEntity<SyncLogResponseDto> completeSync(
+            @RequestHeader("X-User-Id") Long adminId,
+            @PathVariable Long logId,
+            @Valid @RequestBody SyncLogCompleteRequestDto requestDto) {
+
+        return ResponseEntity.ok(syncLogService.completeSync(adminId, logId, requestDto));
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/domain/enums/SyncStatus.java
+++ b/backend/src/main/java/com/dailo/backend/domain/enums/SyncStatus.java
@@ -1,0 +1,7 @@
+package com.dailo.backend.domain.enums;
+
+public enum SyncStatus {
+    STARTED,    // 동기화 시작
+    SUCCESS,    // 동기화 성공
+    FAILED      // 동기화 실패
+}

--- a/backend/src/main/java/com/dailo/backend/dto/SyncLogCompleteRequestDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/SyncLogCompleteRequestDto.java
@@ -1,0 +1,15 @@
+package com.dailo.backend.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SyncLogCompleteRequestDto {
+
+    private boolean success;
+    private Integer totalCount;
+    private Integer successCount;
+    private Integer failCount;
+    private String errorMessage;
+}

--- a/backend/src/main/java/com/dailo/backend/dto/SyncLogResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/SyncLogResponseDto.java
@@ -1,0 +1,37 @@
+package com.dailo.backend.dto;
+
+import com.dailo.backend.domain.enums.SyncStatus;
+import com.dailo.backend.entity.SyncLog;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SyncLogResponseDto {
+
+    private Long id;
+    private String sourceType;
+    private SyncStatus status;
+    private Integer totalCount;
+    private Integer successCount;
+    private Integer failCount;
+    private String errorMessage;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+
+    public static SyncLogResponseDto from(SyncLog syncLog) {
+        return SyncLogResponseDto.builder()
+                .id(syncLog.getId())
+                .sourceType(syncLog.getSourceType())
+                .status(syncLog.getStatus())
+                .totalCount(syncLog.getTotalCount())
+                .successCount(syncLog.getSuccessCount())
+                .failCount(syncLog.getFailCount())
+                .errorMessage(syncLog.getErrorMessage())
+                .startedAt(syncLog.getStartedAt())
+                .completedAt(syncLog.getCompletedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/dto/SyncLogStartRequestDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/SyncLogStartRequestDto.java
@@ -1,0 +1,13 @@
+package com.dailo.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SyncLogStartRequestDto {
+
+    @NotBlank(message = "sourceType is required")
+    private String sourceType;
+}

--- a/backend/src/main/java/com/dailo/backend/entity/EventSource.java
+++ b/backend/src/main/java/com/dailo/backend/entity/EventSource.java
@@ -1,0 +1,42 @@
+package com.dailo.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "event_sources", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_event_source_type_external", columnNames = {"source_type", "external_id"})
+})
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EventSource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "source_type", nullable = false)
+    private String sourceType;
+
+    @Column(name = "external_id", nullable = false)
+    private String externalId;
+
+    @Column(name = "raw_data", columnDefinition = "TEXT")
+    private String rawData;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/entity/SyncLog.java
+++ b/backend/src/main/java/com/dailo/backend/entity/SyncLog.java
@@ -1,0 +1,80 @@
+package com.dailo.backend.entity;
+
+import com.dailo.backend.domain.enums.SyncStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "sync_logs")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SyncLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "source_type", nullable = false)
+    private String sourceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private SyncStatus status = SyncStatus.STARTED;
+
+    @Column(name = "total_count")
+    @Builder.Default
+    private Integer totalCount = 0;
+
+    @Column(name = "success_count")
+    @Builder.Default
+    private Integer successCount = 0;
+
+    @Column(name = "fail_count")
+    @Builder.Default
+    private Integer failCount = 0;
+
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(name = "started_at", nullable = false, updatable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.startedAt = LocalDateTime.now();
+    }
+
+    // 동기화 성공 완료 (상태 검증은 Service에서 수행)
+    public void completeAsSuccess(int totalCount, int successCount, int failCount) {
+        this.status = SyncStatus.SUCCESS;
+        this.totalCount = totalCount;
+        this.successCount = successCount;
+        this.failCount = failCount;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    // 동기화 실패 완료 (상태 검증은 Service에서 수행)
+    public void completeAsFailed(String errorMessage) {
+        this.status = SyncStatus.FAILED;
+        this.errorMessage = errorMessage;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    // 부분 성공 (상태 검증은 Service에서 수행)
+    public void completeWithPartialSuccess(int totalCount, int successCount, int failCount, String errorMessage) {
+        this.status = failCount > 0 ? SyncStatus.FAILED : SyncStatus.SUCCESS;
+        this.totalCount = totalCount;
+        this.successCount = successCount;
+        this.failCount = failCount;
+        this.errorMessage = errorMessage;
+        this.completedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/repository/EventSourceRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/EventSourceRepository.java
@@ -1,0 +1,22 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.Event;
+import com.dailo.backend.entity.EventSource;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EventSourceRepository extends JpaRepository<EventSource, Long> {
+
+    // 이벤트의 소스 목록
+    List<EventSource> findByEvent(Event event);
+
+    // 소스 타입 + 외부 ID로 조회 (중복 체크용)
+    Optional<EventSource> findBySourceTypeAndExternalId(String sourceType, String externalId);
+
+    // 외부 ID 존재 여부 체크
+    boolean existsBySourceTypeAndExternalId(String sourceType, String externalId);
+}

--- a/backend/src/main/java/com/dailo/backend/repository/SyncLogRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/SyncLogRepository.java
@@ -1,0 +1,26 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.domain.enums.SyncStatus;
+import com.dailo.backend.entity.SyncLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SyncLogRepository extends JpaRepository<SyncLog, Long> {
+
+    // 소스 타입별 로그 조회
+    Page<SyncLog> findBySourceType(String sourceType, Pageable pageable);
+
+    // 상태별 로그 조회
+    Page<SyncLog> findByStatus(SyncStatus status, Pageable pageable);
+
+    // 소스 + 상태별 로그 조회
+    Page<SyncLog> findBySourceTypeAndStatus(String sourceType, SyncStatus status, Pageable pageable);
+
+    // 최근 동기화 로그 (소스 타입별)
+    List<SyncLog> findTop5BySourceTypeOrderByStartedAtDesc(String sourceType);
+}

--- a/backend/src/main/java/com/dailo/backend/service/SyncLogService.java
+++ b/backend/src/main/java/com/dailo/backend/service/SyncLogService.java
@@ -1,0 +1,113 @@
+package com.dailo.backend.service;
+
+import com.dailo.backend.domain.enums.SyncStatus;
+import com.dailo.backend.dto.SyncLogCompleteRequestDto;
+import com.dailo.backend.dto.SyncLogResponseDto;
+import com.dailo.backend.dto.SyncLogStartRequestDto;
+import com.dailo.backend.entity.SyncLog;
+import com.dailo.backend.exception.ConflictException;
+import com.dailo.backend.exception.ForbiddenException;
+import com.dailo.backend.exception.NotFoundException;
+import com.dailo.backend.repository.SyncLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SyncLogService {
+
+    private final SyncLogRepository syncLogRepository;
+
+    // TODO: User Entity 구현 후 DB 조회로 변경
+    private static final Set<Long> ADMIN_IDS = Set.of(1L, 2L);
+
+    private void validateAdminRole(Long userId) {
+        if (!ADMIN_IDS.contains(userId)) {
+            throw new ForbiddenException("Admin access required");
+        }
+    }
+
+    // 동기화 로그 목록 조회 (필터링)
+    public Page<SyncLogResponseDto> getLogs(Long adminId, String sourceType, SyncStatus status, Pageable pageable) {
+        validateAdminRole(adminId);
+
+        Page<SyncLog> logs;
+
+        if (sourceType != null && status != null) {
+            logs = syncLogRepository.findBySourceTypeAndStatus(sourceType, status, pageable);
+        } else if (sourceType != null) {
+            logs = syncLogRepository.findBySourceType(sourceType, pageable);
+        } else if (status != null) {
+            logs = syncLogRepository.findByStatus(status, pageable);
+        } else {
+            logs = syncLogRepository.findAll(pageable);
+        }
+
+        return logs.map(SyncLogResponseDto::from);
+    }
+
+    // 동기화 로그 상세 조회
+    public SyncLogResponseDto getLog(Long adminId, Long logId) {
+        validateAdminRole(adminId);
+
+        SyncLog log = syncLogRepository.findById(logId)
+                .orElseThrow(() -> new NotFoundException("SyncLog not found: " + logId));
+
+        return SyncLogResponseDto.from(log);
+    }
+
+    // 동기화 시작 기록
+    @Transactional
+    public SyncLogResponseDto startSync(Long adminId, SyncLogStartRequestDto requestDto) {
+        validateAdminRole(adminId);
+
+        SyncLog log = SyncLog.builder()
+                .sourceType(requestDto.getSourceType())
+                .build();
+
+        SyncLog savedLog = syncLogRepository.save(log);
+
+        return SyncLogResponseDto.from(savedLog);
+    }
+
+    // 동기화 완료 기록
+    @Transactional
+    public SyncLogResponseDto completeSync(Long adminId, Long logId, SyncLogCompleteRequestDto requestDto) {
+        validateAdminRole(adminId);
+
+        SyncLog log = syncLogRepository.findById(logId)
+                .orElseThrow(() -> new NotFoundException("SyncLog not found: " + logId));
+
+        // 이미 완료된 로그인지 확인
+        if (log.getStatus() != SyncStatus.STARTED) {
+            throw new ConflictException("SyncLog already completed");
+        }
+
+        if (requestDto.isSuccess()) {
+            log.completeAsSuccess(
+                    requestDto.getTotalCount() != null ? requestDto.getTotalCount() : 0,
+                    requestDto.getSuccessCount() != null ? requestDto.getSuccessCount() : 0,
+                    requestDto.getFailCount() != null ? requestDto.getFailCount() : 0
+            );
+        } else {
+            if (requestDto.getTotalCount() != null && requestDto.getTotalCount() > 0) {
+                log.completeWithPartialSuccess(
+                        requestDto.getTotalCount(),
+                        requestDto.getSuccessCount() != null ? requestDto.getSuccessCount() : 0,
+                        requestDto.getFailCount() != null ? requestDto.getFailCount() : 0,
+                        requestDto.getErrorMessage()
+                );
+            } else {
+                log.completeAsFailed(requestDto.getErrorMessage());
+            }
+        }
+
+        return SyncLogResponseDto.from(log);
+    }
+}


### PR DESCRIPTION
## 작업 내용
이벤트 소스 추적 및 동기화 로그를 위한 Entity를 구현합니다.

### 생성할 파일
- [x] entity/EventSource.java
- [x] entity/SyncLog.java
- [x] repository/EventSourceRepository.java
- [x] repository/SyncLogRepository.java
- [x] domain/enums/SourceType.java (PUBLIC_API, AI_CRAWL)

### EventSource 필드
- id, eventId, sourceType, externalId, rawData, createdAt
- UNIQUE(sourceType, externalId)

### SyncLog 필드
- id, sourceType, status, totalCount, successCount, failCount, errorMessage, startedAt, completedAt

### 테스트
- [x] MySQL 테이블 생성 확인
- [x] UNIQUE 제약 확인
 
close #67 