### PR TITLE
[TEST] 통합 테스트 추가 + BlockService 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ backend/docs/
 
 # Logs
 **/logs/
+.vscode/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 
 	// Spring Security && Validation
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/src/main/java/com/dailo/backend/service/BlockService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BlockService.java
@@ -29,7 +29,7 @@ public class BlockService {
 
         // 이미 차단했는지 확인
         if (blockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)) {
-            throw new IllegalStateException("Already blocked");
+            throw new com.dailo.backend.exception.ConflictException("Already blocked");
         }
 
         Block block = Block.builder()

--- a/backend/src/test/java/com/dailo/backend/integration/BlockApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/BlockApiTest.java
@@ -1,0 +1,146 @@
+package com.dailo.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class BlockApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @Order(1)
+    @DisplayName("POST /api/blocks - 차단 추가")
+    void blockUser() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of("blockedId", 100));
+
+        mockMvc.perform(post("/api/blocks")
+                        .header("X-User-Id", "10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.blockerId").value(10))
+                .andExpect(jsonPath("$.blockedId").value(100));
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("POST /api/blocks - 자기 자신 차단 불가")
+    void blockSelfNotAllowed() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of("blockedId", 10));
+
+        mockMvc.perform(post("/api/blocks")
+                        .header("X-User-Id", "10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("POST /api/blocks - 중복 차단 방지")
+    void duplicateBlockNotAllowed() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of("blockedId", 200));
+
+        // 첫 번째 차단
+        mockMvc.perform(post("/api/blocks")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+
+        // 중복 차단 시도
+        mockMvc.perform(post("/api/blocks")
+                        .header("X-User-Id", "20")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("GET /api/blocks/me - 내 차단 목록")
+    void getMyBlocks() throws Exception {
+        // 차단 추가
+        String body = objectMapper.writeValueAsString(Map.of("blockedId", 300));
+        mockMvc.perform(post("/api/blocks")
+                .header("X-User-Id", "30")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+
+        mockMvc.perform(get("/api/blocks/me")
+                        .header("X-User-Id", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("GET /api/blocks/check/{userId} - 차단 여부 확인")
+    void checkBlock() throws Exception {
+        mockMvc.perform(get("/api/blocks/check/100")
+                        .header("X-User-Id", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.blocked").exists());
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("DELETE /api/blocks/{blockedId} - 차단 해제")
+    void unblockUser() throws Exception {
+        // 차단 추가
+        String body = objectMapper.writeValueAsString(Map.of("blockedId", 400));
+        mockMvc.perform(post("/api/blocks")
+                .header("X-User-Id", "40")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+
+        // 차단 해제
+        mockMvc.perform(delete("/api/blocks/400")
+                        .header("X-User-Id", "40"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("상호 미노출 - 차단 시 게시글 필터링")
+    void blockFilterOnPosts() throws Exception {
+        // 사용자 50이 게시글 작성
+        String postBody = objectMapper.writeValueAsString(Map.of(
+                "title", "차단 필터 테스트",
+                "content", "내용",
+                "categoryType", "FREE"
+        ));
+        mockMvc.perform(post("/api/posts")
+                .header("X-User-Id", "50")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(postBody));
+
+        // 사용자 60이 사용자 50 차단
+        String blockBody = objectMapper.writeValueAsString(Map.of("blockedId", 50));
+        mockMvc.perform(post("/api/blocks")
+                .header("X-User-Id", "60")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(blockBody));
+
+        // 사용자 60이 게시글 목록 조회 → 사용자 50 글 안 보임
+        mockMvc.perform(get("/api/posts")
+                        .header("X-User-Id", "60"))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/dailo/backend/integration/CommentApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/CommentApiTest.java
@@ -1,0 +1,197 @@
+package com.dailo.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CommentApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long createPost() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "title", "댓글 테스트 게시글",
+                "content", "내용",
+                "categoryType", "FREE"
+        ));
+        String response = mockMvc.perform(post("/api/posts")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("id").asLong();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("POST /api/posts/{postId}/comments - 댓글 생성")
+    void createComment() throws Exception {
+        Long postId = createPost();
+
+        String body = objectMapper.writeValueAsString(Map.of(
+                "content", "테스트 댓글"
+        ));
+
+        mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.content").value("테스트 댓글"))
+                .andExpect(jsonPath("$.postId").value(postId));
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("POST - 대댓글 생성 (1단계)")
+    void createReply() throws Exception {
+        Long postId = createPost();
+
+        // 부모 댓글 생성
+        String parentBody = objectMapper.writeValueAsString(Map.of("content", "부모 댓글"));
+        String parentResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(parentBody))
+                .andReturn().getResponse().getContentAsString();
+        Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
+
+        // 대댓글 생성
+        String replyBody = objectMapper.writeValueAsString(Map.of(
+                "content", "대댓글입니다",
+                "parentCommentId", parentId
+        ));
+
+        mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(replyBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").value("대댓글입니다"))
+                .andExpect(jsonPath("$.parentCommentId").value(parentId));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("POST - 대댓글의 대댓글 방지 (2단계 불가)")
+    void nestedReplyNotAllowed() throws Exception {
+        Long postId = createPost();
+
+        // 부모 댓글
+        String parentBody = objectMapper.writeValueAsString(Map.of("content", "1단계"));
+        String parentResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(parentBody))
+                .andReturn().getResponse().getContentAsString();
+        Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
+
+        // 대댓글
+        String replyBody = objectMapper.writeValueAsString(Map.of(
+                "content", "2단계", "parentCommentId", parentId));
+        String replyResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(replyBody))
+                .andReturn().getResponse().getContentAsString();
+        Long replyId = objectMapper.readTree(replyResponse).get("id").asLong();
+
+        // 대댓글의 대댓글 → 실패
+        String nestedBody = objectMapper.writeValueAsString(Map.of(
+                "content", "3단계 불가", "parentCommentId", replyId));
+
+        mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(nestedBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("GET /api/posts/{postId}/comments - 댓글 목록 (대댓글 포함)")
+    void getCommentsWithReplies() throws Exception {
+        Long postId = createPost();
+
+        // 댓글 + 대댓글 생성
+        String parentBody = objectMapper.writeValueAsString(Map.of("content", "부모"));
+        String parentResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(parentBody))
+                .andReturn().getResponse().getContentAsString();
+        Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
+
+        String replyBody = objectMapper.writeValueAsString(Map.of(
+                "content", "자식", "parentCommentId", parentId));
+        mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                .header("X-User-Id", "2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(replyBody));
+
+        // 조회
+        mockMvc.perform(get("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].replies").isArray());
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("PUT /api/comments/{id} - 댓글 수정")
+    void updateComment() throws Exception {
+        Long postId = createPost();
+
+        String body = objectMapper.writeValueAsString(Map.of("content", "수정 전"));
+        String response = mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn().getResponse().getContentAsString();
+        Long commentId = objectMapper.readTree(response).get("id").asLong();
+
+        String updateBody = objectMapper.writeValueAsString(Map.of("content", "수정 후"));
+        mockMvc.perform(put("/api/comments/" + commentId)
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").value("수정 후"));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("DELETE /api/comments/{id} - 댓글 삭제")
+    void deleteComment() throws Exception {
+        Long postId = createPost();
+
+        String body = objectMapper.writeValueAsString(Map.of("content", "삭제될 댓글"));
+        String response = mockMvc.perform(post("/api/posts/" + postId + "/comments")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn().getResponse().getContentAsString();
+        Long commentId = objectMapper.readTree(response).get("id").asLong();
+
+        mockMvc.perform(delete("/api/comments/" + commentId)
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/dailo/backend/integration/LogApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/LogApiTest.java
@@ -1,0 +1,128 @@
+package com.dailo.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LogApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // ==================== Search Log ====================
+
+    @Test
+    @Order(1)
+    @DisplayName("POST /api/logs/search - 검색 로그 기록")
+    void logSearch() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "keyword", "콘서트",
+                "filters", "{\"category\":\"MUSIC\"}",
+                "resultCount", 15,
+                "requestId", "req-001"
+        ));
+
+        mockMvc.perform(post("/api/logs/search")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.keyword").value("콘서트"))
+                .andExpect(jsonPath("$.userId").value(1));
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("POST /api/logs/search - 비로그인 검색 로그")
+    void logSearchWithoutLogin() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "keyword", "축제",
+                "resultCount", 5
+        ));
+
+        mockMvc.perform(post("/api/logs/search")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").isEmpty());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("POST /api/logs/search - keyword 길이 초과 시 400")
+    void logSearchKeywordTooLong() throws Exception {
+        String longKeyword = "a".repeat(101);
+        String body = objectMapper.writeValueAsString(Map.of(
+                "keyword", longKeyword
+        ));
+
+        mockMvc.perform(post("/api/logs/search")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("GET /api/logs/search/top - 인기 검색어")
+    void getTopKeywords() throws Exception {
+        mockMvc.perform(get("/api/logs/search/top?limit=5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    // ==================== Click Log ====================
+
+    @Test
+    @Order(5)
+    @DisplayName("POST /api/logs/click - 클릭 로그 기록")
+    void logClick() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "eventId", 1,
+                "source", "search",
+                "requestId", "req-001"
+        ));
+
+        mockMvc.perform(post("/api/logs/click")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.eventId").value(1))
+                .andExpect(jsonPath("$.source").value("search"));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("GET /api/logs/click/count/{eventId} - 이벤트 클릭 수")
+    void getClickCount() throws Exception {
+        mockMvc.perform(get("/api/logs/click/count/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("GET /api/logs/click/top - 인기 이벤트")
+    void getTopClickedEvents() throws Exception {
+        mockMvc.perform(get("/api/logs/click/top?limit=5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+}

--- a/backend/src/test/java/com/dailo/backend/integration/PostApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/PostApiTest.java
@@ -1,0 +1,146 @@
+package com.dailo.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PostApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @Order(1)
+    @DisplayName("POST /api/posts - 게시글 생성")
+    void createPost() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "title", "테스트 게시글",
+                "content", "테스트 내용입니다",
+                "categoryType", "FREE"
+        ));
+
+        mockMvc.perform(post("/api/posts")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.title").value("테스트 게시글"))
+                .andExpect(jsonPath("$.authorId").value(1));
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("GET /api/posts - 게시글 목록 조회")
+    void getAllPosts() throws Exception {
+        // 먼저 게시글 생성
+        String body = objectMapper.writeValueAsString(Map.of(
+                "title", "목록 테스트 글",
+                "content", "내용",
+                "categoryType", "FREE"
+        ));
+        mockMvc.perform(post("/api/posts")
+                .header("X-User-Id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+
+        mockMvc.perform(get("/api/posts")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("GET /api/posts/{id} - 게시글 단건 조회")
+    void getPostById() throws Exception {
+        // 게시글 생성
+        String body = objectMapper.writeValueAsString(Map.of(
+                "title", "단건 조회 테스트",
+                "content", "내용",
+                "categoryType", "FREE"
+        ));
+        String response = mockMvc.perform(post("/api/posts")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn().getResponse().getContentAsString();
+
+        Long postId = objectMapper.readTree(response).get("id").asLong();
+
+        mockMvc.perform(get("/api/posts/" + postId)
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("단건 조회 테스트"));
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("PUT /api/posts/{id} - 게시글 수정")
+    void updatePost() throws Exception {
+        // 게시글 생성
+        String createBody = objectMapper.writeValueAsString(Map.of(
+                "title", "수정 전",
+                "content", "내용",
+                "categoryType", "FREE"
+        ));
+        String response = mockMvc.perform(post("/api/posts")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andReturn().getResponse().getContentAsString();
+
+        Long postId = objectMapper.readTree(response).get("id").asLong();
+
+        // 수정
+        String updateBody = objectMapper.writeValueAsString(Map.of(
+                "title", "수정 후",
+                "content", "수정된 내용",
+                "categoryType", "FREE"
+        ));
+        mockMvc.perform(put("/api/posts/" + postId)
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("수정 후"));
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("DELETE /api/posts/{id} - 게시글 삭제")
+    void deletePost() throws Exception {
+        // 게시글 생성
+        String body = objectMapper.writeValueAsString(Map.of(
+                "title", "삭제 테스트",
+                "content", "내용",
+                "categoryType", "FREE"
+        ));
+        String response = mockMvc.perform(post("/api/posts")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn().getResponse().getContentAsString();
+
+        Long postId = objectMapper.readTree(response).get("id").asLong();
+
+        mockMvc.perform(delete("/api/posts/" + postId)
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/backend/src/test/java/com/dailo/backend/integration/ReportApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/ReportApiTest.java
@@ -1,0 +1,68 @@
+package com.dailo.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ReportApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @Order(1)
+    @DisplayName("POST /api/reports - 신고 생성")
+    void createReport() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "targetType", "POST",
+                "targetId", 1,
+                "reason", "SPAM",
+                "description", "광고 게시글"
+        ));
+
+        mockMvc.perform(post("/api/reports")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.reporterId").value(1))
+                .andExpect(jsonPath("$.status").value("PENDING"));
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("GET /api/reports/my - 내 신고 목록")
+    void getMyReports() throws Exception {
+        // 신고 생성 (POST 타입은 실제 게시글 ID 필요하므로 USER 타입 사용)
+        String body = objectMapper.writeValueAsString(Map.of(
+                "targetType", "USER",
+                "targetId", 99,
+                "reason", "ABUSE"
+        ));
+        mockMvc.perform(post("/api/reports")
+                .header("X-User-Id", "2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+
+        mockMvc.perform(get("/api/reports/my")
+                        .header("X-User-Id", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray());
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,18 @@
+# Test Database (MySQL - dailo_test)
+spring.datasource.url=jdbc:mysql://localhost:3306/dailo_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=${DB_USERNAME:root}
+spring.datasource.password=${DB_PASSWORD:changeme}
+
+# JPA Settings for Test
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# JWT (테스트용)
+jwt.secret=vmfhaltkfkdgodyroqkfwkdbalroqkfwkdbalsucvmfhaltkfkdgodyroqkfwkdbalroqkfwkdbalsucvmfhaltkfkdgodyroqkfwkdbalroqkfwkdbalsuc
+jwt.access-token-validity-in-seconds=1800
+jwt.refresh-token-validity-in-seconds=604800
+
+# Logging
+logging.level.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
- PostApiTest, CommentApiTest, BlockApiTest, ReportApiTest, LogApiTest (28 cases)
- MySQL 테스트 환경 설정 (dailo_test DB)
- BlockService: 중복 차단 시 ConflictException으로 수정 (500→409)
- build.gradle: H2 테스트 의존성 추가
- .gitignore: .vscode/ 제외

## 개요
- PostApiTest, CommentApiTest, BlockApiTest, ReportApiTest, LogApiTest (28 cases)
- MySQL 테스트 환경 설정 (dailo_test DB)
- BlockService: 중복 차단 시 ConflictException으로 수정 (500→409)
- build.gradle: H2 테스트 의존성 추가
- .gitignore: .vscode/ 제외


