### PR TITLE
[FEAT] 행사 검색 및 다중 필터링 API 구현

### DIFF
--- a/backend/src/main/java/com/dailo/backend/service/EventService.java
+++ b/backend/src/main/java/com/dailo/backend/service/EventService.java
@@ -46,16 +46,30 @@ public class EventService {
                 .collect(Collectors.toList());
     }
 
-    // 리스트 조회 (검색/필터 통합)
-
+    // 리스트 조회 (검색/필터/정렬 통합)
     public Page<EventListResponse> getEventList(EventListRequest request) {
-        // startAt 오름차순
-        Pageable pageable = PageRequest.of(request.page() - 1, request.size(), Sort.by(Sort.Direction.ASC, "startAt"));
 
+        // 동적 정렬 처리 (프론트에서 "startAt,desc" 처럼 보내면 그걸 적용)
+        Sort sort = Sort.by(Sort.Direction.ASC, "startAt"); // 기본값
+
+        if (request.sort() != null && !request.sort().isBlank()) {
+            String[] sortParams = request.sort().split(",");
+            String property = sortParams[0];
+            Sort.Direction direction = (sortParams.length > 1 && sortParams[1].equalsIgnoreCase("desc"))
+                    ? Sort.Direction.DESC
+                    : Sort.Direction.ASC;
+
+            sort = Sort.by(direction, property);
+        }
+
+        // Pageable 생성
+        Pageable pageable = PageRequest.of(request.page() - 1, request.size(), sort);
+
+        // 날짜 변환
         LocalDateTime searchStart = (request.startAt() != null) ? request.startAt().atStartOfDay() : null;
         LocalDateTime searchEnd = (request.endAt() != null) ? request.endAt().atTime(LocalTime.MAX) : null;
 
-        // 통합 검색 쿼리 실행
+        // 레포지토리 호출
         Page<Event> events = eventRepository.searchEvents(
                 EventStatus.ACTIVE,
                 searchStart,
@@ -68,7 +82,6 @@ public class EventService {
 
         return events.map(this::convertToEventListResponse);
     }
-
     private EventListResponse convertToEventListResponse(Event event) {
         return new EventListResponse(
                 event.getId(),


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #91 

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
- [ ] **검색:** 행사 제목, 설명, 장소명에 대한 키워드 검색 (LIKE 검색)
- [ ] **필터링:**
    - 날짜 범위 (Start ~ End)
    - 지역 (Location / 행정동)
    - 카테고리 (Category - 다중 선택 가능)
- [ ] **정렬:** 최신순, 시작일순 정렬 지원
- [ ] **페이징:** 대용량 데이터 조회 시 성능 고려 (Paging)

## 체크리스트
- [ ] 검색어 없이 필터만 걸어도 동작하는가? (동적 쿼리)
- [ ] 종료된 행사를 제외하는 옵션이 잘 작동하는가?
