### PR TITLE
fix: 빌드 오류 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,6 +50,16 @@ dependencies {
 
 	// Swagger (Spring Boot 3용)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	// Firebase Admin SDK (푸시 알림 발송용)
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+	// AWS SDK v2 for S3
+	implementation platform('software.amazon.awssdk:bom:2.20.0')
+	implementation 'software.amazon.awssdk:s3'
+
+	// 이메일 발송
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/dailo/backend/dto/NoticeResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/NoticeResponseDto.java
@@ -1,6 +1,7 @@
 package com.dailo.backend.dto;
 
 import com.dailo.backend.entity.Notice;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class NoticeResponseDto {
 

--- a/backend/src/main/java/com/dailo/backend/jwt/TokenProvider.java
+++ b/backend/src/main/java/com/dailo/backend/jwt/TokenProvider.java
@@ -66,6 +66,32 @@ public class TokenProvider {
                 .build();
     }
 
+    // 멤버 ID와 역할로 토큰 직접 생성 (이메일 인증 등에서 사용)
+    public TokenDto generateTokenDtoForMember(String memberId, String role) {
+        long now = (new Date()).getTime();
+        String authorities = "ROLE_" + role;
+
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(memberId)
+                .claim(AUTHORITIES_KEY, authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .refreshToken(refreshToken)
+                .build();
+    }
+
     // 토큰에서 인증 정보 꺼내기
     public Authentication getAuthentication(String accessToken) {
         // 토큰 복호화

--- a/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
@@ -84,5 +84,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     /** 제목이 정확히 일치하는 이벤트 목록 (이전 시드 삭제용) */
     List<Event> findByTitleIn(List<String> titles);
+
+    /** 특정 기간에 시작하는 행사 조회 (D-1 알림용) */
+    List<Event> findByStartAtBetween(LocalDateTime start, LocalDateTime end);
 }
 

--- a/backend/src/main/java/com/dailo/backend/repository/ScrapRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/ScrapRepository.java
@@ -1,5 +1,6 @@
 package com.dailo.backend.repository;
 
+import com.dailo.backend.entity.Member;
 import com.dailo.backend.entity.Scrap;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -24,4 +26,8 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     // 캘린더 조회 시 북마크 여부 확인용
     @Query("SELECT s.event.id FROM Scrap s WHERE s.member.id = :memberId")
     Set<Long> findScrappedEventIds(@Param("memberId") Long memberId);
+
+    // 특정 행사를 스크랩한 회원 목록 조회
+    @Query("SELECT s.member FROM Scrap s WHERE s.event.id = :eventId")
+    List<Member> findAllMemberByEventId(@Param("eventId") Long eventId);
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -29,3 +29,14 @@ jwt.refresh-token-validity-in-seconds=604800
 # 이메일 또는 회원 ID를 쉼표로 구분해 입력 (예: admin@example.com 또는 1,2,3)
 app.admin.emails=
 app.admin.user-ids=
+
+# AWS S3
+cloud.aws.s3.bucket=${AWS_S3_BUCKET:dailo-uploads}
+cloud.aws.region=${AWS_REGION:ap-northeast-2}
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY:}
+cloud.aws.credentials.secret-key=${AWS_SECRET_KEY:}
+cloud.aws.s3.presigned-url-expiration-minutes=60
+
+# Multipart
+spring.servlet.multipart.max-file-size=100MB
+spring.servlet.multipart.max-request-size=100MB


### PR DESCRIPTION
1. 작업 개요
게시판의 풍부한 컨텐츠 제공을 위해 AWS S3 기반 이미지 업로드 기능을 구현했습니다. 보안을 위해 S3 버킷은 비공개로 유지하며, 클라이언트는 서버가 발급한 Presigned URL을 통해 안전하게 이미지를 조회합니다.

2. 변경 사항 (파일 기준)
🆕 신규 생성
S3Config.java: S3Client 및 S3Presigner 빈(Bean) 설정

S3UploadService.java: S3 파일 업로드, 삭제 및 Presigned URL 생성 핵심 로직

FileUploadController.java: 파일 업로드 처리를 위한 공통 API 엔드포인트

🛠 수정 및 확장
build.gradle: AWS SDK v2 의존성 추가

application.properties: S3 버킷 정보 및 파일 업로드 용량 제한(최대 100MB) 설정

Post.java (Entity): DB에는 S3 경로인 imageKeys 목록을 저장하도록 필드 추가

PostRequestDto / PostResponseDto: 이미지 전송을 위한 필드(imageKeys, imageUrls) 추가

PostService.java: 게시글 조회 시 DB의 Key를 유효한 Presigned URL로 변환하는 서비스 로직 추가

3. 문제 상황 및 원인
개발 과정에서 주로 환경 변수 주입 미흡으로 인한 설정 오류가 발생했습니다.

Spring Boot 환경변수 로드 실패: .env 파일에 정의된 변수들이 시스템 환경변수로 인식되지 않아 애플리케이션 실행 시 설정을 읽지 못함.

MySQL 접근 거부: 로컬 DB 비밀번호와 .env 설정값이 일치하지 않아 Access denied 발생.

AWS 인증 오류: AWS Access key ID cannot be blank 에러 발생. 실제 서버 런타임에 AWS 자격 증명이 주입되지 않음.

4. 해결 방법
환경변수 일괄 주입: 서버 실행 전 export $(cat .env | grep -v '^#' | xargs) 명령어를 사용하여 .env의 내용을 쉘 환경변수로 강제 로드 후 실행하여 해결.

설정 동기화: .env.example 파일을 최신화하여 팀원들이 각자의 환경에 맞는 AWS/DB 계정 정보를 쉽게 설정할 수 있도록 가이드 마련.

보안 유지: .env 파일이 깃허브에 올라가지 않도록 .gitignore 설정을 재점검함.

5. API 사용 흐름
이미지 처리는 서버 부하 분산과 데이터 무결성을 위해 2-Step으로 진행됩니다.

이미지 선 업로드: POST /api/files/upload 호출 → S3 저장 후 반환된 S3 Key(예: posts/abc-123.jpg)를 클라이언트가 보관.

게시글 생성: POST /api/posts 요청 시, 위에서 받은 imageKeys 배열을 포함하여 전송.

이미지 포함 조회: GET /api/posts/{id} 호출 시, 서버는 저장된 Key를 1시간 동안 유효한 Presigned URL로 변환하여 imageUrls 필드로 반환.

6. 환경 변수 설정 방법
프로젝트 루트의 .env 파일에 아래 항목을 반드시 추가해야 정상 동작합니다. (상세 값은 팀 내부 채널 공유)

Bash
# Database
DB_PASSWORD=your_password

# AWS S3
AWS_ACCESS_KEY=your_access_key
AWS_SECRET_KEY=your_secret_key
AWS_S3_BUCKET=dailo-bucket-name
AWS_REGION=ap-northeast-2