### PR TITLE
[FEAT] 회원 관리 기능 고도화 및 프로필 이미지 S3 연동

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -34,6 +34,11 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/dailo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+      AWS_S3_BUCKET: ${AWS_S3_BUCKET}
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
+      APP_UPLOAD_USE_S3: "true"
     ports:
       - "8080:8080"
     depends_on:

--- a/backend/src/main/java/com/dailo/backend/config/S3Config.java
+++ b/backend/src/main/java/com/dailo/backend/config/S3Config.java
@@ -12,22 +12,31 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 @Configuration
 public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
     @Value("${cloud.aws.region}")
     private String region;
 
+
     @Bean
     public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.create()) 
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();
     }
 
     @Bean
     public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Presigner.builder()
                 .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.create()) 
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();
     }
 }

--- a/backend/src/main/java/com/dailo/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/MemberController.java
@@ -3,11 +3,15 @@ package com.dailo.backend.controller;
 import com.dailo.backend.dto.auth.MemberResponseDto;
 import com.dailo.backend.dto.auth.MemberUpdateRequestDto;
 import com.dailo.backend.service.MemberService;
+import com.dailo.backend.service.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/members")
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final S3UploadService s3UploadService;
 
     // 내 정보 조회
     @GetMapping("/me")
@@ -23,6 +28,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.getMyProfile(memberId));
     }
 
+    // 프로필 수정
     @PatchMapping("/me")
     public ResponseEntity<MemberResponseDto> updateProfile(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -31,10 +37,34 @@ public class MemberController {
         return ResponseEntity.ok(memberService.updateProfile(memberId, request));
     }
 
+    // 회원 탈퇴
     @DeleteMapping("/me")
     public ResponseEntity<String> withdraw(@AuthenticationPrincipal UserDetails userDetails) {
         Long memberId = Long.parseLong(userDetails.getUsername());
         memberService.withdraw(memberId);
         return ResponseEntity.ok("회원 탈퇴 완료");
+    }
+
+    // 닉네임 중복 체크
+    @GetMapping("/check-nickname")
+    public ResponseEntity<Boolean> checkNickname(@RequestParam String nickname) {
+        return ResponseEntity.ok(memberService.checkNicknameDuplicate(nickname));
+    }
+
+    // 프로필 이미지 업로드 API
+    @PostMapping(value = "/me/image", consumes = "multipart/form-data")
+    public ResponseEntity<MemberResponseDto> uploadProfileImage(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestPart("file") MultipartFile file) throws IOException {
+
+        Long memberId = Long.parseLong(userDetails.getUsername());
+
+        // 1. 팀장님이 만든 S3 서비스로 파일 업로드 (디렉토리명은 "profile"로 지정)
+        String imageKey = s3UploadService.upload(file, "profile");
+
+        // 2. DB에 업로드된 Key 저장 (MemberService에 updateProfileImage 메서드 추가 필요)
+        MemberResponseDto updatedMember = memberService.updateProfileImage(memberId, imageKey);
+
+        return ResponseEntity.ok(updatedMember);
     }
 }

--- a/backend/src/main/java/com/dailo/backend/dto/auth/MemberResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/auth/MemberResponseDto.java
@@ -16,12 +16,12 @@ public class MemberResponseDto {
     private String nickname;
     private String profileImageUrl;
 
-    public static MemberResponseDto of(Member member) {
+    public static MemberResponseDto of(Member member, String presignedUrl) {
         return MemberResponseDto.builder()
                 .id(member.getId())
                 .email(member.getEmail())
                 .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
+                .profileImageUrl(presignedUrl)
                 .build();
     }
 }

--- a/backend/src/main/java/com/dailo/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/dailo/backend/exception/GlobalExceptionHandler.java
@@ -74,6 +74,18 @@ public class GlobalExceptionHandler {
         return buildResponse(HttpStatus.UNAUTHORIZED, e.getMessage());
     }
 
+    // 413 Payload Too Large - 파일 용량 초과 (최대 100MB 설정 시)
+    @ExceptionHandler(org.springframework.web.multipart.MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, Object>> handleMaxUploadSizeExceededException(org.springframework.web.multipart.MaxUploadSizeExceededException e) {
+        return buildResponse(HttpStatus.PAYLOAD_TOO_LARGE, "파일 용량이 너무 큽니다. 최대 100MB까지 가능합니다.");
+    }
+
+    // 500 Internal Server Error - S3 관련 클라이언트 에러 (키 미설정 등)
+    @ExceptionHandler(software.amazon.awssdk.core.exception.SdkClientException.class)
+    public ResponseEntity<Map<String, Object>> handleSdkClientException(software.amazon.awssdk.core.exception.SdkClientException e) {
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "서버 파일 스토리지 설정에 문제가 발생했습니다.");
+    }
+
     private ResponseEntity<Map<String, Object>> buildResponse(HttpStatus status, String message) {
         Map<String, Object> body = new HashMap<>();
         body.put("timestamp", LocalDateTime.now());

--- a/backend/src/main/java/com/dailo/backend/repository/MemberRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/MemberRepository.java
@@ -14,4 +14,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     /** 개인정보처리방침 준수: 탈퇴자(DELETED)는 목록에 노출하지 않음 */
     Page<Member> findByStatusNot(MemberStatus status, Pageable pageable);
+
+    // 닉네임 중복 확인을 위한 쿼리
+    boolean existsByNickname(String nickname);
+
 }

--- a/backend/src/main/java/com/dailo/backend/service/AuthService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AuthService.java
@@ -37,7 +37,9 @@ public class AuthService {
         }
 
         Member member = requestDto.toMember(passwordEncoder);
-        return MemberResponseDto.of(memberRepository.save(member));
+        Member savedMember = memberRepository.save(member);
+
+        return MemberResponseDto.of(savedMember, null);
     }
 
     /**

--- a/backend/src/main/java/com/dailo/backend/service/MemberService.java
+++ b/backend/src/main/java/com/dailo/backend/service/MemberService.java
@@ -14,12 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final S3UploadService s3UploadService;
 
     // 내 정보 조회
     public MemberResponseDto getMyProfile(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("회원 정보가 없습니다."));
-        return MemberResponseDto.of(member);
+
+        return createDtoWithPresignedUrl(member);
     }
 
     // 프로필 수정
@@ -28,10 +30,29 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("회원 정보가 없습니다."));
 
-        // 닉네임 중복 체크 로직 (필요시 추가)
+        // 닉네임 중복 방어
+        String newNickname = request.getNickname();
+        if (newNickname != null && !newNickname.equals(member.getNickname())) {
+            if (memberRepository.existsByNickname(newNickname)) {
+                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            }
+        }
 
-        member.updateProfile(request.getNickname(), request.getProfileImageUrl());
-        return MemberResponseDto.of(member);
+        // 💡 엔티티 값 변경
+        member.updateProfile(newNickname, request.getProfileImageUrl());
+
+        return createDtoWithPresignedUrl(member);
+    }
+
+    // 💡 이미지 전용 업데이트
+    @Transactional
+    public MemberResponseDto updateProfileImage(Long memberId, String imageKey) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원 정보가 없습니다."));
+
+        member.updateProfile(member.getNickname(), imageKey);
+
+        return createDtoWithPresignedUrl(member);
     }
 
     // 회원 탈퇴
@@ -42,14 +63,32 @@ public class MemberService {
         member.withdraw();
     }
 
-    /** id=1 회원 닉네임이 비어 있으면 "회원1"로 설정 (댓글 등 기존 데이터 표시용) */
+    // 닉네임 중복 체크
+    public boolean checkNicknameDuplicate(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
+
+    /** id=1 회원 닉네임이 비어 있으면 "회원1"로 설정 */
     @Transactional
     public void ensureMember1Nickname() {
         memberRepository.findById(1L).ifPresent(m -> {
             if (m.getNickname() == null || m.getNickname().isBlank()) {
                 m.updateProfile("회원1", null);
-                memberRepository.save(m);
             }
         });
+    }
+
+    /**
+     * 💡 [공통 로직] 엔티티의 S3 Key를 Presigned URL로 변환하여 DTO 생성
+     */
+    private MemberResponseDto createDtoWithPresignedUrl(Member member) {
+        String key = member.getProfileImageUrl(); // DB에는 "profile/uuid.jpg" 형태로 저장됨
+        String presignedUrl = null;
+
+        if (key != null && !key.isBlank()) {
+            presignedUrl = s3UploadService.getPresignedUrl(key);
+        }
+
+        return MemberResponseDto.of(member, presignedUrl);
     }
 }

--- a/backend/src/main/java/com/dailo/backend/service/S3UploadService.java
+++ b/backend/src/main/java/com/dailo/backend/service/S3UploadService.java
@@ -16,6 +16,8 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -38,6 +40,12 @@ public class S3UploadService {
     public String upload(MultipartFile file, String directory) throws IOException {
         String originalFilename = file.getOriginalFilename();
         String extension = getExtension(originalFilename);
+
+        // 확장자 검증 로직 추가
+        if (extension == null || !isAllowedExtension(extension)) {
+            throw new IllegalArgumentException("허용되지 않는 파일 형식입니다. (jpg, jpeg, png, gif, webp만 가능)");
+        }
+
         String key = directory + "/" + UUID.randomUUID() + (extension != null ? "." + extension : "");
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -57,6 +65,9 @@ public class S3UploadService {
      * S3 key로 Presigned URL 생성
      */
     public String getPresignedUrl(String key) {
+
+        if (key == null || key.isEmpty()) return null;
+
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
@@ -75,6 +86,8 @@ public class S3UploadService {
      * S3 객체 삭제
      */
     public void delete(String key) {
+        if (key == null || key.isEmpty()) return;
+
         DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
@@ -89,5 +102,10 @@ public class S3UploadService {
         int i = filename.lastIndexOf('.');
         if (i <= 0 || i >= filename.length() - 1) return null;
         return filename.substring(i + 1).toLowerCase();
+    }
+
+    private boolean isAllowedExtension(String extension) {
+        List<String> allowed = Arrays.asList("jpg", "jpeg", "png", "gif", "webp");
+        return allowed.contains(extension.toLowerCase());
     }
 }


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #103 

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->

- [x] AWS S3 SDK 연동 및 이미지 업로드 공통 서비스 구현
- [x] 내 프로필 정보 조회 API 구현 (GET /api/members/me)
- [x] 닉네임 및 프로필 이미지 수정 API 구현 (PATCH /api/members/me)
- [x] 닉네임 중복 체크 API 구현 (GET /api/members/check-nickname)

## 체크리스트

- [x]  GET /api/members/me 호출 시 알림 설정값(NotificationSetting)이 함께 반환되는가?
- [x] 이미지 업로드 시 S3에 파일이 저장되고 유효한 URL이 반환되는가?
- [x] 중복된 닉네임으로 수정 시도 시 적절한 에러 응답이 반환되는가?
