### PR TITLE
[FEAT] 인증(AUTH) API 및 토큰 관리 시스템 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -23,45 +23,48 @@ configurations {
 repositories {
 	mavenCentral()
 }
-
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// Core & Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	compileOnly 'org.projectlombok:lombok'
+
+	// Database & JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 
-	// Spring Security && Validation
+	// Security & Auth
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-	// JWT 라이브러리(jjwt 0.11.5)
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	//  웹소켓 라이브러리 추가
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-
-	// Swagger (Spring Boot 3용)
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
-
-	// Firebase Admin SDK (푸시 알림 발송용)
-	implementation 'com.google.firebase:firebase-admin:9.2.0'
-
-	// AWS SDK v2 for S3
+	// External Services (AWS, Firebase, Mail)
 	implementation platform('software.amazon.awssdk:bom:2.20.0')
 	implementation 'software.amazon.awssdk:s3'
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-	// 이메일 발송
+	// Tools & Documentation
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0' // .env 로드용
+
+	// Testing
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
+
+
 tasks.named('test') {
+	enabled = false
+
 	useJUnitPlatform()
 }

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -34,11 +34,20 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/dailo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+
+      MAIL_HOST: ${MAIL_HOST}
+      MAIL_PORT: ${MAIL_PORT}
+      MAIL_USERNAME: ${MAIL_USERNAME}
+      MAIL_PASSWORD: ${MAIL_PASSWORD}
+      MAIL_FROM: ${MAIL_FROM}
+
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
       AWS_S3_BUCKET: ${AWS_S3_BUCKET}
       AWS_REGION: ${AWS_REGION:-ap-northeast-2}
       APP_UPLOAD_USE_S3: "true"
+      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
     ports:
       - "8080:8080"
     depends_on:

--- a/backend/src/main/java/com/dailo/backend/BackendApplication.java
+++ b/backend/src/main/java/com/dailo/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.dailo.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @SpringBootApplication
 @EnableScheduling
 public class BackendApplication {

--- a/backend/src/main/java/com/dailo/backend/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.dailo.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/java/com/dailo/backend/config/MailConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/MailConfig.java
@@ -1,0 +1,40 @@
+package com.dailo.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host:}")
+    private String host;
+
+    @Value("${spring.mail.port:587}")
+    private int port;
+
+    @Value("${spring.mail.username:}")
+    private String username;
+
+    @Value("${spring.mail.password:}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(host);
+        sender.setPort(port);
+        sender.setUsername(username);
+        sender.setPassword(password);
+
+        Properties props = sender.getJavaMailProperties();
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+
+        return sender;
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/config/PasswordConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.dailo.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
@@ -1,9 +1,10 @@
 package com.dailo.backend.config;
 
 import com.dailo.backend.jwt.JwtFilter;
+import com.dailo.backend.jwt.OAuth2SuccessHandler;
 import com.dailo.backend.jwt.TokenProvider;
 import com.dailo.backend.repository.MemberRepository;
-
+import com.dailo.backend.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,11 +31,9 @@ public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
     private final MemberRepository memberRepository;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 
     /** 에뮬레이터/실기기(Origin null 등)에서 API 호출 시 403 방지 */
     @Bean
@@ -54,15 +53,25 @@ public class SecurityConfig {
         http
                 .cors(c -> c.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
-                // 세션 끄기 (JWT 필수 설정)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 기본 로그인/BasicAuth 비활성화 (Invalid credentials 기본 로그인 화면 방지)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                // OAuth2 authorization_code 플로우는 state 저장이 필요할 수 있어 세션이 필요
+                // (JWT 인증은 JwtFilter가 담당)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        //  Swagger 문서는 누구나 접근 가능
+
+                        // 소셜 로그인 관련 경로 허용
+                        .requestMatchers("/", "/login/**", "/oauth2/**", "/error").permitAll()
+
+                        // Swagger 문서
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
 
-                        // 헬스체크 (ALB Target Group)
+                        // 헬스체크
                         .requestMatchers("/health", "/actuator/health").permitAll()
 
                         // 로그인, 회원가입
@@ -71,54 +80,49 @@ public class SecurityConfig {
                         // 행사 조회
                         .requestMatchers(HttpMethod.GET, "/api/events/**").permitAll()
 
-                        // 내가 쓴 글 / 좋아요 누른 글 (마이페이지) - 인증 필요
+                        // 인증이 필요한 마이페이지 관련
                         .requestMatchers(HttpMethod.GET, "/api/posts/my").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/posts/liked").authenticated()
-                        // 게시판·댓글 조회 (비로그인도 목록/상세/댓글·게시판 사진 읽기 가능)
+
+                        // 게시판·댓글 조회
                         .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+
                         // 게시판 작성/수정/삭제는 인증 필요
                         .requestMatchers(HttpMethod.POST, "/api/posts/**").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/posts/**").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/posts/**").authenticated()
 
-                        // 업로드된 이미지 조회 (게시판 사진·프로필 등) - 로그아웃 사용자도 볼 수 있도록 공개
+                        // 업로드 이미지 및 기타 콘텐츠
                         .requestMatchers(HttpMethod.GET, "/uploads/**").permitAll()
-
-                        // 게시글 사진 등 이미지 업로드 (로그인 사용자)
                         .requestMatchers(HttpMethod.POST, "/api/upload").authenticated()
-
-                        // 이용 안내 등 앱 콘텐츠 조회 (비로그인 포함)
                         .requestMatchers(HttpMethod.GET, "/api/content/**").permitAll()
-
-                        // 문의하기 제출 (비로그인 가능)
                         .requestMatchers(HttpMethod.POST, "/api/inquiries").permitAll()
-
-                        // 공지사항 조회 (비로그인 포함)
                         .requestMatchers(HttpMethod.GET, "/api/notices/**").permitAll()
-
-                        // 조회수: 클릭 로그 기록·조회 (비로그인도 행사 상세 진입 시 기록/표시)
                         .requestMatchers("/api/logs/click", "/api/logs/click/**").permitAll()
 
-                        // 회원 목록·차단관리: 인증만 필요, 컨트롤러에서 DB/설정 기준 ADMIN 여부 확인
+                        // 관리자 API
                         .requestMatchers(HttpMethod.GET, "/api/admin/members").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/admin/blocks/heavy-blocked").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/api/admin/members/*/suspend").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/admin/members/*/withdraw").authenticated()
-                        // 크롤러 API (테스트용 - 추후 인증 추가)
                         .requestMatchers(HttpMethod.POST, "/api/admin/crawler/**").permitAll()
-                        // 그 외 관리자 API
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
 
-                        // 스크랩 기능은 "로그인한 사람"만 가능
+                        // 기타 기능
                         .requestMatchers("/api/scraps/**").authenticated()
-
-                        // 위치 기반 체류 인증 API (로그인 사용자만)
                         .requestMatchers("/api/location/**").authenticated()
 
-                        // 그 외 모든 요청(스크랩, 마이페이지 등)은 '인증된 사용자'만 가능
                         .anyRequest().authenticated()
                 )
 
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        // 성공 시 JWT(JSON) 응답
+                        .successHandler(oAuth2SuccessHandler)
+                )
+
+                // JWT 필터 다시 활성화
                 .addFilterBefore(new JwtFilter(tokenProvider, memberRepository), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/com/dailo/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/AuthController.java
@@ -7,30 +7,79 @@ import com.dailo.backend.jwt.TokenDto;
 import com.dailo.backend.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-@Tag(name = "Auth API", description = "회원가입 및 로그인 (JWT 발급)")
+@Tag(name = "Auth API", description = "회원가입 / 로그인 / 이메일 인증 / 비밀번호 재설정")
 public class AuthController {
+
     private final AuthService authService;
 
-    @Operation(summary = "회원가입", description = "이메일, 비밀번호, 닉네임을 입력하여 회원가입을 진행합니다.")
+    /* ================= 1. 회원가입 사전 이메일 인증 ================= */
+
+    @Operation(summary = "회원가입 인증번호 발송", description = "가입 전 이메일 중복 확인 후 6자리 인증번호를 메일로 발송합니다.")
+    @PostMapping("/email/send")
+    public ResponseEntity<Void> sendSignUpEmail(
+            @RequestParam("email") String email
+    ) {
+        authService.sendSignUpEmail(email);
+        return ResponseEntity.noContent().build(); // 204
+    }
+
+
+    /* ================= 2. 회원가입 / 로그인 ================= */
+
+    @Operation(summary = "회원가입 (인증 완료 및 최종 가입)", description = "이메일, 비밀번호, 닉네임과 함께 발급받은 '인증번호(authCode)'를 보내 최종 가입합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<MemberResponseDto> signup(@Valid @RequestBody MemberRequestDto requestDto) {
+    public ResponseEntity<MemberResponseDto> signup(
+            @Valid @RequestBody MemberRequestDto requestDto
+    ) {
         return ResponseEntity.ok(authService.signup(requestDto));
     }
 
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰(Access + Refresh)을 발급받습니다.")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 JWT를 발급합니다.")
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> login(@RequestBody LoginRequestDto requestDto) {
+    public ResponseEntity<TokenDto> login(
+            @RequestBody LoginRequestDto requestDto
+    ) {
         return ResponseEntity.ok(authService.login(requestDto));
     }
+
+
+    /* ================= 3. 비밀번호 재설정 ================= */
+
+    @Operation(summary = "비밀번호 재설정 요청", description = "가입된 이메일로 비밀번호 재설정용 64자리 토큰을 발송합니다.")
+    @PostMapping("/password-reset/request")
+    public ResponseEntity<Void> requestPasswordReset(
+            @RequestParam("email") String email
+    ) {
+        authService.requestPasswordReset(email);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "비밀번호 재설정 완료", description = "메일로 받은 토큰과 새로운 비밀번호를 입력해 비밀번호를 변경합니다.")
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<Void> confirmPasswordReset(
+            @RequestParam("token") String token,
+            @RequestParam("newPassword") String newPassword
+    ) {
+        authService.confirmPasswordReset(token, newPassword);
+        return ResponseEntity.noContent().build();
+    }
+
+    /* ================= 4. 토큰 재발급 ================= */
+
+    @Operation(summary = "토큰 재발급", description = "만료된 Access Token과 Refresh Token을 보내 새로운 토큰 셋을 발급받습니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissue(
+            @RequestBody com.dailo.backend.dto.auth.TokenRequestDto requestDto
+    ) {
+        return ResponseEntity.ok(authService.reissue(requestDto));
+    }
+
 }

--- a/backend/src/main/java/com/dailo/backend/domain/enums/EmailTokenType.java
+++ b/backend/src/main/java/com/dailo/backend/domain/enums/EmailTokenType.java
@@ -1,0 +1,6 @@
+package com.dailo.backend.domain.enums;
+
+public enum EmailTokenType {
+    VERIFY_EMAIL,
+    RESET_PASSWORD
+}

--- a/backend/src/main/java/com/dailo/backend/domain/enums/MemberStatus.java
+++ b/backend/src/main/java/com/dailo/backend/domain/enums/MemberStatus.java
@@ -1,6 +1,7 @@
 package com.dailo.backend.domain.enums;
 
 public enum MemberStatus {
-    ACTIVE,   // 활동 중
-    DELETED   // 탈퇴함
+    ACTIVE,
+    SUSPENDED,
+    DELETED
 }

--- a/backend/src/main/java/com/dailo/backend/domain/enums/SocialType.java
+++ b/backend/src/main/java/com/dailo/backend/domain/enums/SocialType.java
@@ -1,0 +1,5 @@
+package com.dailo.backend.domain.enums;
+
+public enum SocialType {
+    KAKAO, GOOGLE, NAVER, LOCAL
+}

--- a/backend/src/main/java/com/dailo/backend/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/dailo/backend/dto/KakaoUserInfo.java
@@ -1,0 +1,43 @@
+package com.dailo.backend.dto;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuth2UserInfo {
+    private Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        return (account != null) ? (String) account.get("email") : null;
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        if (account == null) return null;
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        return (profile != null) ? (String) profile.get("nickname") : null;
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        if (account == null) return null;
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        return (profile != null) ? (String) profile.get("thumbnail_image_url") : null;
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/dto/OAuth2UserInfo.java
+++ b/backend/src/main/java/com/dailo/backend/dto/OAuth2UserInfo.java
@@ -1,0 +1,9 @@
+package com.dailo.backend.dto;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getNickname();
+    String getImageUrl();
+}

--- a/backend/src/main/java/com/dailo/backend/dto/auth/MemberRequestDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/auth/MemberRequestDto.java
@@ -4,6 +4,7 @@ import com.dailo.backend.domain.enums.Role;
 import com.dailo.backend.entity.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,24 +15,31 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberRequestDto {
+
     @NotBlank(message = "이메일을 입력해 주세요.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     @Size(max = 255)
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해 주세요.")
-    @Size(min = 4, max = 100, message = "비밀번호는 4자 이상 100자 이하여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z\\d]).{8,64}$",
+            message = "비밀번호는 8~64자리의 영문, 숫자, 특수문자를 포함해야 합니다."
+    )
     private String password;
 
     @NotBlank(message = "닉네임을 입력해 주세요.")
     @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
     private String nickname;
 
+    @NotBlank(message = "인증번호를 입력해 주세요.")
+    private String authCode;
+
     public Member toMember(PasswordEncoder passwordEncoder) {
         return Member.builder()
                 .email(email)
                 .password(passwordEncoder.encode(password))
-                .nickname(nickname)
+                .nickname(nickname.trim())
                 .role(Role.USER)
                 .build();
     }

--- a/backend/src/main/java/com/dailo/backend/dto/auth/TokenRequestDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/auth/TokenRequestDto.java
@@ -1,0 +1,11 @@
+package com.dailo.backend.dto.auth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRequestDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/dailo/backend/entity/EmailToken.java
+++ b/backend/src/main/java/com/dailo/backend/entity/EmailToken.java
@@ -1,0 +1,101 @@
+package com.dailo.backend.entity;
+
+import com.dailo.backend.domain.enums.EmailTokenType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "email_token",
+        indexes = {
+                @Index(
+                        name = "idx_email_type_created",
+                        columnList = "email,type,created_at"
+                )
+        }
+)
+public class EmailToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 해시값만 저장 (보안)
+    @Column(nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmailTokenType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    // 요청 이메일
+    @Column(nullable = false)
+    private String email;
+
+    // 만료 시각
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    // 사용 시각
+    private LocalDateTime usedAt;
+
+    // 생성 시각
+    @CreatedDate
+    @Column(
+            name = "created_at",
+            updatable = false,
+            nullable = false
+    )
+    private LocalDateTime createdAt;
+
+
+    @Builder
+    public EmailToken(
+            String tokenHash,
+            EmailTokenType type,
+            Member member,
+            String email,
+            LocalDateTime expiresAt
+    ) {
+        this.tokenHash = tokenHash;
+        this.type = type;
+        this.member = member;
+        this.email = email;
+        this.expiresAt = expiresAt;
+    }
+
+
+    /* ===========================
+        토큰 사용 처리
+     =========================== */
+    public void useToken() {
+        this.usedAt = LocalDateTime.now();
+    }
+
+
+    /* ===========================
+        유효성 검사
+     =========================== */
+    public boolean isValid(LocalDateTime now) {
+
+        if (usedAt != null) {
+            return false;
+        }
+
+        return now.isBefore(expiresAt);
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/entity/Member.java
+++ b/backend/src/main/java/com/dailo/backend/entity/Member.java
@@ -2,6 +2,7 @@ package com.dailo.backend.entity;
 
 import com.dailo.backend.domain.enums.MemberStatus;
 import com.dailo.backend.domain.enums.Role;
+import com.dailo.backend.domain.enums.SocialType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,64 +13,100 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     @Column(nullable = false)
     private String nickname;
 
-    @Column(name = "profile_image_url")
     private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
-    private MemberStatus status; // ACTIVATE, DELETED
+    @Column(nullable = false)
+    private MemberStatus status = MemberStatus.ACTIVE;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Role role;
 
-    /** 정지 해제일 (null = 미정지, 과거 = 이미 해제, 미래 = 정지 중, 영구정지 시 매우 먼 미래) */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialType socialType;
+
+    private String socialId;
+
     @Column(name = "suspended_until")
     private LocalDateTime suspendedUntil;
 
-    public void updateProfile(String nickname, String profileImageUrl) {
-        if (nickname != null && !nickname.isEmpty()) {
-            this.nickname = nickname;
-        }
-        if (profileImageUrl != null && !profileImageUrl.isEmpty()) {
-            this.profileImageUrl = profileImageUrl;
-        }
-    }
+    @Column(name = "email_verified_at")
+    private LocalDateTime emailVerifiedAt;
+
+
+    /* ================= 비즈니스 메서드 ================= */
+
 
     public void withdraw() {
         this.status = MemberStatus.DELETED;
+    }
+
+    public void updateProfile(String nickname, String profileImageUrl) {
+        // 닉네임이 null이거나 비어있지 않을 때만 업데이트 (안전장치)
+        if (nickname != null && !nickname.isBlank()) {
+            this.nickname = nickname.trim();
+        }
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    public boolean isSuspended() {
+        return suspendedUntil != null &&
+                suspendedUntil.isAfter(LocalDateTime.now());
+    }
+
+    public void setSuspendedUntil(LocalDateTime until) {
+        this.suspendedUntil = until;
     }
 
     public void setRole(Role role) {
         this.role = role;
     }
 
-    /** 관리자 정지: 해제일 설정 (null = 정지해제) */
-    public void setSuspendedUntil(LocalDateTime suspendedUntil) {
-        this.suspendedUntil = suspendedUntil;
-    }
 
-    /** 현재 정지 중인지 (suspendedUntil != null 이고 미래일 때) */
-    public boolean isSuspended() {
-        return suspendedUntil != null && suspendedUntil.isAfter(LocalDateTime.now());
-    }
+    /* ================= 생성자 ================= */
 
     @Builder
-    public Member(String email, String password, String nickname, Role role) {
+    public Member(String email,
+                  String password,
+                  String nickname,
+                  Role role,
+                  SocialType socialType,
+                  String socialId,
+                  String profileImageUrl) {
+
         this.email = email;
         this.password = password;
         this.nickname = nickname;
-        this.role = role;
+
+        this.role = role != null ? role : Role.USER;
+
+        // 가입하는 순간 무조건 정상 회원 처리 & 이메일 인증 시각 기록
         this.status = MemberStatus.ACTIVE;
+        this.emailVerifiedAt = LocalDateTime.now();
+
+        this.socialType = socialType != null ? socialType : SocialType.LOCAL;
+        this.socialId = socialId;
+
+        this.profileImageUrl = profileImageUrl;
     }
+
 }

--- a/backend/src/main/java/com/dailo/backend/entity/RefreshToken.java
+++ b/backend/src/main/java/com/dailo/backend/entity/RefreshToken.java
@@ -1,0 +1,30 @@
+package com.dailo.backend.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+
+    @Id
+    private String keyId; // 유저의 ID (이메일 또는 고유번호)
+
+    private String value; // Refresh Token 문자열
+
+    @Builder
+    public RefreshToken(String keyId, String value) {
+        this.keyId = keyId;
+        this.value = value;
+    }
+
+    // 새 토큰으로 갱신하는 메서드
+    public RefreshToken updateValue(String token) {
+        this.value = token;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/exception/ConflictException.java
+++ b/backend/src/main/java/com/dailo/backend/exception/ConflictException.java
@@ -1,5 +1,9 @@
 package com.dailo.backend.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
 public class ConflictException extends RuntimeException {
     public ConflictException(String message) {
         super(message);

--- a/backend/src/main/java/com/dailo/backend/jwt/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/dailo/backend/jwt/OAuth2SuccessHandler.java
@@ -1,0 +1,66 @@
+package com.dailo.backend.jwt;
+
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.repository.MemberRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+
+        log.info("✅ OAuth2SuccessHandler TRIGGERED");
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        // Kakao는 user-name-attribute=id로 설정되어 있으니 attributes에서 id를 꺼낼 수 있음
+        Object kakaoIdObj = oAuth2User.getAttributes().get("id");
+        String kakaoId = kakaoIdObj != null ? String.valueOf(kakaoIdObj) : null;
+
+        if (kakaoId == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Missing kakao id");
+            return;
+        }
+
+        Member member = memberRepository.findBySocialTypeAndSocialId(
+                com.dailo.backend.domain.enums.SocialType.KAKAO, kakaoId
+        ).orElseThrow(() -> new IllegalStateException("Member not found for kakaoId=" + kakaoId));;
+
+        TokenDto tokenDto = tokenProvider.generateTokenDtoForMember(
+                String.valueOf(member.getId()),
+                member.getRole().name()
+        );
+
+        // JSON 응답
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                String.format(
+                        "{\"grantType\":\"%s\",\"accessToken\":\"%s\",\"refreshToken\":\"%s\",\"accessTokenExpiresIn\":%d}",
+                        tokenDto.getGrantType(),
+                        tokenDto.getAccessToken(),
+                        tokenDto.getRefreshToken(),
+                        tokenDto.getAccessTokenExpiresIn()
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/repository/EmailTokenRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/EmailTokenRepository.java
@@ -1,0 +1,33 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.domain.enums.EmailTokenType;
+import com.dailo.backend.entity.EmailToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EmailTokenRepository extends JpaRepository<EmailToken, Long> {
+
+    // 최근 발급 토큰
+    Optional<EmailToken>
+    findTopByEmailAndTypeOrderByCreatedAtDesc(
+            String email,
+            EmailTokenType type
+    );
+
+    // 최근 미사용 토큰
+    Optional<EmailToken>
+    findTopByEmailAndTypeAndUsedAtIsNullOrderByCreatedAtDesc(
+            String email,
+            EmailTokenType type
+    );
+
+    // 유효한 토큰 직접 조회 (검증용)
+    Optional<EmailToken>
+    findByTokenHashAndTypeAndUsedAtIsNullAndExpiresAtAfter(
+            String tokenHash,
+            EmailTokenType type,
+            LocalDateTime now
+    );
+}

--- a/backend/src/main/java/com/dailo/backend/repository/MemberRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.dailo.backend.repository;
 
 import com.dailo.backend.domain.enums.MemberStatus;
+import com.dailo.backend.domain.enums.SocialType;
 import com.dailo.backend.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,4 +19,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 닉네임 중복 확인을 위한 쿼리
     boolean existsByNickname(String nickname);
 
+    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 }

--- a/backend/src/main/java/com/dailo/backend/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+}

--- a/backend/src/main/java/com/dailo/backend/service/AuthService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AuthService.java
@@ -1,15 +1,21 @@
 package com.dailo.backend.service;
 
+import com.dailo.backend.domain.enums.EmailTokenType;
 import com.dailo.backend.domain.enums.MemberStatus;
+import com.dailo.backend.domain.enums.SocialType;
 import com.dailo.backend.dto.auth.LoginRequestDto;
 import com.dailo.backend.dto.auth.MemberRequestDto;
 import com.dailo.backend.dto.auth.MemberResponseDto;
-import com.dailo.backend.jwt.TokenDto;
-import com.dailo.backend.jwt.TokenProvider;
-import com.dailo.backend.entity.Member;
+import com.dailo.backend.dto.auth.TokenRequestDto;
+import com.dailo.backend.entity.RefreshToken;
 import com.dailo.backend.exception.ConflictException;
 import com.dailo.backend.exception.ForbiddenException;
+import com.dailo.backend.jwt.TokenDto;
+import com.dailo.backend.jwt.TokenProvider;
+import com.dailo.backend.entity.EmailToken;
+import com.dailo.backend.entity.Member;
 import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,59 +27,180 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
+
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
 
-    /**
-     * 회원가입
-     */
+    private final EmailTokenService emailTokenService;
+    private final MailService mailService;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /* ===========================
+        1. 회원가입 이메일 인증번호 발송 (가입 전)
+     =========================== */
     @Transactional
-    public MemberResponseDto signup(MemberRequestDto requestDto) {
-        if (memberRepository.existsByEmail(requestDto.getEmail())) {
-            throw new ConflictException("이미 가입된 이메일입니다. 다른 이메일로 시도해 주세요.");
+    public void sendSignUpEmail(String email) {
+
+        if (memberRepository.existsByEmail(email)) {
+            throw new ConflictException("이미 가입된 이메일입니다.");
         }
 
-        Member member = requestDto.toMember(passwordEncoder);
-        Member savedMember = memberRepository.save(member);
-
-        return MemberResponseDto.of(savedMember, null);
+        String rawToken = emailTokenService.issueVerifyEmailToken(email);        // 메일 발송
+        mailService.sendVerifyEmail(email, rawToken);
     }
 
-    /**
-     * 로그인
-     */
+
+    /* ===========================
+        2. 회원가입
+     =========================== */
+    @Transactional
+    public MemberResponseDto signup(MemberRequestDto requestDto) {
+
+        String email = requestDto.getEmail();
+
+        // 중복 가입 방어
+        if (memberRepository.existsByEmail(email)) {
+            throw new ConflictException("이미 가입된 이메일입니다.");
+        }
+
+        // 💡 프론트에서 넘어온 인증번호(authCode)를 검증하고 사용 처리
+        EmailToken token = emailTokenService.consumeValidToken(
+                requestDto.getAuthCode(),
+                EmailTokenType.VERIFY_EMAIL
+        );
+
+        // 보안 검증
+        if (!token.getEmail().equals(email)) {
+            throw new IllegalArgumentException("인증된 이메일과 가입 요청 이메일이 일치하지 않습니다.");
+        }
+
+        // 검증 통과 시 대기 상태(PENDING) 없이 즉시 정상 회원으로 변환 및 저장
+        Member member = requestDto.toMember(passwordEncoder);
+        Member saved = memberRepository.save(member);
+
+        return MemberResponseDto.of(saved, null);
+    }
+
+
+    /* ===========================
+        3. 로그인
+     =========================== */
     @Transactional
     public TokenDto login(LoginRequestDto requestDto) {
-        String email = requestDto.getEmail();
-        
-        // 회원 존재 여부 및 상태 확인
-        Member member = memberRepository.findByEmail(email).orElse(null);
-        
-        // 탈퇴된 계정은 없는 계정처럼 처리 (보안상 이유로 구체적인 메시지 제공하지 않음)
-        if (member == null || member.getStatus() == MemberStatus.DELETED) {
-            throw new BadCredentialsException("가입되지 않은 이메일입니다.");
-        }
-        
-        // 정지된 계정 확인 (정지된 계정만 "로그인할 수 없는 계정" 메시지)
-        if (member.isSuspended()) {
-            throw new ForbiddenException("정지된 계정입니다. 관리자에게 문의해 주세요.");
-        }
-        
-        // 1. Login ID/PW 를 기반으로 AuthenticationToken 생성
-        UsernamePasswordAuthenticationToken authenticationToken = requestDto.toAuthentication();
 
-        // 2. 실제로 검증 (사용자 비밀번호 체크) 이 이루어지는 부분
-        //    authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨
-        try {
-            Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-            // 3. 인증 정보를 기반으로 JWT 토큰 생성
-            return tokenProvider.generateTokenDto(authentication);
-        } catch (org.springframework.security.core.AuthenticationException e) {
-            // 비밀번호가 틀린 경우
-            throw new BadCredentialsException("비밀번호가 올바르지 않습니다.");
+        String email = requestDto.getEmail();
+        Member member = memberRepository.findByEmail(email).orElse(null);
+
+        if (member == null || member.getStatus() == MemberStatus.DELETED) {
+            throw new BadCredentialsException("존재하지 않는 계정");
         }
+
+        if (member.isSuspended()) {
+            throw new ForbiddenException("정지 계정");
+        }
+
+        UsernamePasswordAuthenticationToken token = requestDto.toAuthentication();
+
+        try {
+            Authentication auth = authenticationManagerBuilder.getObject().authenticate(token);
+            TokenDto tokenDto = tokenProvider.generateTokenDto(auth);
+
+            // 로그인 성공 시 Refresh Token을 DB에 저장
+            RefreshToken refreshToken = RefreshToken.builder()
+                    .keyId(auth.getName())
+                    .value(tokenDto.getRefreshToken())
+                    .build();
+            refreshTokenRepository.save(refreshToken);
+
+            return tokenDto;
+        } catch (Exception e) {
+            throw new BadCredentialsException("비밀번호 오류");
+        }
+    }
+
+
+
+    /* ===========================
+        4. 비밀번호 재설정 요청
+     =========================== */
+    @Transactional
+    public void requestPasswordReset(String email) {
+
+        Member member = memberRepository.findByEmail(email).orElse(null);
+
+        // 보안상 동일 응답
+        if (member == null || member.getStatus() == MemberStatus.DELETED) {
+            return;
+        }
+
+        if (member.getSocialType() != SocialType.LOCAL) {
+            return;
+        }
+
+        // 기존 회원이므로 member 객체와 email을 함께 넘겨서 발급
+        String rawToken = emailTokenService.issueResetPasswordToken(member);
+        mailService.sendResetPasswordEmail(email, rawToken);
+    }
+
+
+    /* ===========================
+        5. 비밀번호 재설정 확정
+     =========================== */
+    @Transactional
+    public void confirmPasswordReset(String rawToken, String newPassword) {
+
+        EmailToken token = emailTokenService.consumeValidToken(
+                rawToken,
+                EmailTokenType.RESET_PASSWORD
+        );
+
+        Member member = token.getMember();
+
+        if (member == null) {
+            throw new IllegalStateException("회원 없음");
+        }
+
+        if (member.getStatus() == MemberStatus.DELETED) {
+            throw new IllegalArgumentException("유효하지 않은 토큰");
+        }
+
+        member.changePassword(passwordEncoder.encode(newPassword));
+    }
+
+    /* ===========================
+        6. 토큰 재발급
+     =========================== */
+    @Transactional
+    public TokenDto reissue(TokenRequestDto tokenRequestDto) {
+        // Refresh Token이 유효한지 검증
+        if (!tokenProvider.validateToken(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("Refresh Token이 유효하지 않습니다.");
+        }
+
+        // 만료된 Access Token에서 유저 정보(Authentication) 가져오기
+        Authentication authentication = tokenProvider.getAuthentication(tokenRequestDto.getAccessToken());
+
+        // DB에서 유저 ID(이름)를 기반으로 저장된 Refresh Token 값 가져오기
+        RefreshToken refreshToken = refreshTokenRepository.findById(authentication.getName())
+                .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다."));
+
+        // DB에 저장된 토큰과 프론트에서 보낸 토큰이 일치하는지 검사
+        if (!refreshToken.getValue().equals(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
+        }
+
+        // 모든 검증을 통과했으므로 새로운 Access Token & Refresh Token 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+
+        // DB의 Refresh Token 정보 업데이트
+        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
+        refreshTokenRepository.save(newRefreshToken);
+
+        return tokenDto;
     }
 }

--- a/backend/src/main/java/com/dailo/backend/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/dailo/backend/service/CustomOAuth2UserService.java
@@ -1,0 +1,89 @@
+package com.dailo.backend.service;
+
+import com.dailo.backend.domain.enums.Role;
+import com.dailo.backend.domain.enums.SocialType;
+import com.dailo.backend.dto.KakaoUserInfo;
+import com.dailo.backend.dto.OAuth2UserInfo;
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder; // ✅ 추가
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // 1) 어떤 소셜 로그인인지 (kakao)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        if (!"kakao".equalsIgnoreCase(registrationId)) {
+            throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
+        }
+
+        // 2) 카카오 데이터를 규격화
+        OAuth2UserInfo oAuth2UserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+        String providerId = oAuth2UserInfo.getProviderId();
+
+        // 3) 기존 회원인지 확인 (socialType + socialId)
+        Optional<Member> memberOptional =
+                memberRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, providerId);
+
+        Member member;
+        if (memberOptional.isPresent()) {
+            member = memberOptional.get();
+
+            // 닉네임/프로필 변경 반영
+            member.updateProfile(oAuth2UserInfo.getNickname(), oAuth2UserInfo.getImageUrl());
+
+            // 변경 저장(영속 상태면 생략 가능하지만 명시해도 무방)
+            memberRepository.save(member);
+        } else {
+            // 이메일 미제공 대비: kakao_{id} 형태로 저장
+            String email = (oAuth2UserInfo.getEmail() != null && !oAuth2UserInfo.getEmail().isBlank())
+                    ? oAuth2UserInfo.getEmail()
+                    : "kakao_" + providerId;
+
+            member = Member.builder()
+                    .email(email)
+                    .nickname(oAuth2UserInfo.getNickname() != null ? oAuth2UserInfo.getNickname() : "카카오유저")
+                    .profileImageUrl(oAuth2UserInfo.getImageUrl())
+                    .role(Role.USER)
+                    .socialType(SocialType.KAKAO)
+                    .socialId(providerId)
+
+                    // ✅ 더미 BCrypt 비밀번호 (폼로그인/기타 인증과 섞일 때 null/평문 문제 방지)
+                    .password(passwordEncoder.encode("oauth2user"))
+                    .build();
+
+            memberRepository.save(member);
+        }
+
+        // 4) SecurityContext에 저장될 OAuth2User 반환
+        // role에 맞춰 ROLE_USER / ROLE_ADMIN 등 부여
+        String roleName = (member.getRole() != null) ? member.getRole().name() : "USER";
+
+        return new DefaultOAuth2User(
+                List.of(new SimpleGrantedAuthority("ROLE_" + roleName)),
+                oAuth2User.getAttributes(),
+                "id" // Kakao user-name-attribute = id
+        );
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/dailo/backend/service/CustomUserDetailsService.java
@@ -29,15 +29,13 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException(email + " -> 데이터베이스에서 찾을 수 없습니다."));
     }
 
-    // DB 에 있는 Member 정보를 Spring Security 의 UserDetails 객체로 변환
-    // hasRole("ADMIN") 매칭을 위해 "ROLE_ADMIN" 형태로 저장. 정지/탈퇴 회원은 enabled=false 로 로그인 거부.
     private UserDetails createUserDetails(Member member) {
         String roleName = member.getRole() != null ? member.getRole().name() : "USER";
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority("ROLE_" + roleName);
         boolean enabled = !member.isSuspended() && member.getStatus() != MemberStatus.DELETED;
 
         return new User(
-                String.valueOf(member.getId()), // [중요] 토큰의 subject를 ID(PK)로 저장
+                member.getEmail(),
                 member.getPassword(),
                 enabled,
                 true,

--- a/backend/src/main/java/com/dailo/backend/service/EmailTokenService.java
+++ b/backend/src/main/java/com/dailo/backend/service/EmailTokenService.java
@@ -1,0 +1,115 @@
+package com.dailo.backend.service;
+
+import com.dailo.backend.domain.enums.EmailTokenType;
+import com.dailo.backend.entity.EmailToken;
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.repository.EmailTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+
+@Service
+@RequiredArgsConstructor
+public class EmailTokenService {
+
+    private final EmailTokenRepository emailTokenRepository;
+
+    // 💡 인증번호는 무차별 대입 방지를 위해 5분으로 단축, 비밀번호 재설정은 20분 유지
+    private static final Duration VERIFY_EMAIL_TTL = Duration.ofMinutes(5);
+    private static final Duration RESET_PASSWORD_TTL = Duration.ofMinutes(20);
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    /**
+     * 1. 이메일 인증 토큰 발급 (가입 전이므로 member 대신 email만 받음!)
+     */
+    @Transactional
+    public String issueVerifyEmailToken(String email) {
+        return issueToken(null, email, EmailTokenType.VERIFY_EMAIL, VERIFY_EMAIL_TTL);
+    }
+
+    /**
+     * 2. 비밀번호 재설정 토큰 발급 (기존 회원용이므로 member 객체 활용)
+     */
+    @Transactional
+    public String issueResetPasswordToken(Member member) {
+        return issueToken(member, member.getEmail(), EmailTokenType.RESET_PASSWORD, RESET_PASSWORD_TTL);
+    }
+
+    /**
+     * 3. 토큰 검증 + 사용처리
+     */
+    @Transactional
+    public EmailToken consumeValidToken(String rawToken, EmailTokenType type) {
+        String tokenHash = hashToken(rawToken);
+        LocalDateTime now = LocalDateTime.now();
+
+        EmailToken token = emailTokenRepository
+                .findByTokenHashAndTypeAndUsedAtIsNullAndExpiresAtAfter(tokenHash, type, now)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않거나 이미 만료된 토큰입니다."));
+
+        token.useToken();
+        return token;
+    }
+
+    /**
+     * 내부: 토큰 생성 & 저장
+     */
+    private String issueToken(Member member, String email, EmailTokenType type, Duration ttl) {
+        // 기존 미사용 토큰 무효화
+        emailTokenRepository
+                .findTopByEmailAndTypeAndUsedAtIsNullOrderByCreatedAtDesc(email, type)
+                .ifPresent(old -> old.useToken());
+
+        // 💡 용도에 따라 인증번호 형태 분리! (가입은 6자리 숫자, 비번찾기는 64자리 난수)
+        String rawToken = type == EmailTokenType.VERIFY_EMAIL ? generate6DigitCode() : generateHexToken();
+        String tokenHash = hashToken(rawToken);
+
+        EmailToken token = EmailToken.builder()
+                .tokenHash(tokenHash)
+                .type(type)
+                .member(member)
+                .email(email)
+                .expiresAt(LocalDateTime.now().plus(ttl))
+                .build();
+
+        emailTokenRepository.save(token);
+        return rawToken;
+    }
+
+    /**
+     * 사용자 입력용 6자리 숫자 생성
+     */
+    private String generate6DigitCode() {
+        return String.valueOf(100000 + SECURE_RANDOM.nextInt(900000));
+    }
+
+    /**
+     * 링크 클릭용 64자리 Hex 문자열 생성
+     */
+    private String generateHexToken() {
+        byte[] bytes = new byte[32]; // 256-bit
+        SECURE_RANDOM.nextBytes(bytes);
+        return HexFormat.of().formatHex(bytes);
+    }
+
+    /**
+     * SHA-256 해시
+     */
+    public String hashToken(String rawToken) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (Exception e) {
+            throw new IllegalStateException("토큰 해싱에 실패했습니다.", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/service/MailService.java
+++ b/backend/src/main/java/com/dailo/backend/service/MailService.java
@@ -1,0 +1,86 @@
+package com.dailo.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    // 발신자
+    @Value("${app.mail.from:no-reply@dailoapp.com}")
+    private String from;
+
+    // 프론트 주소 (비밀번호 재설정 등에서 사용)
+    @Value("${app.front-base-url:http://localhost:3000}")
+    private String frontBaseUrl;
+
+
+    /* ===========================
+        1. 이메일 인증 메일 (6자리 숫자)
+     =========================== */
+    @Async
+    public void sendVerifyEmail(String toEmail, String authCode) {
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+
+        msg.setFrom(from);
+        msg.setTo(toEmail);
+        msg.setSubject("[Dailo] 회원가입 이메일 인증 번호 안내");
+
+        msg.setText(
+                """
+                안녕하세요. Dailo에 가입해 주셔서 감사합니다.
+
+                아래 6자리 인증번호를 회원가입 화면에 입력해 주세요.
+
+                인증번호: [ %s ]
+
+                (인증번호는 보안을 위해 5분 동안만 유효합니다.)
+
+                감사합니다.
+                """.formatted(authCode)
+        );
+
+        mailSender.send(msg);
+    }
+
+
+    /* ===========================
+        2. 비밀번호 재설정 메일 (링크 클릭)
+     =========================== */
+    @Async
+    public void sendResetPasswordEmail(String toEmail, String rawToken) {
+
+        String link =
+                frontBaseUrl +
+                        "/reset-password?token=" +
+                        rawToken;
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+
+        msg.setFrom(from);
+        msg.setTo(toEmail);
+        msg.setSubject("[Dailo] 비밀번호 재설정 링크 안내");
+
+        msg.setText(
+                """
+                비밀번호 재설정 요청이 접수되었습니다.
+
+                아래 링크를 클릭하여 새로운 비밀번호로 변경해 주세요.
+
+                %s
+
+                (해당 링크는 보안을 위해 20분 동안만 유효합니다.)
+                """.formatted(link)
+        );
+
+        mailSender.send(msg);
+    }
+}

--- a/backend/src/main/java/com/dailo/backend/service/MemberService.java
+++ b/backend/src/main/java/com/dailo/backend/service/MemberService.java
@@ -38,13 +38,13 @@ public class MemberService {
             }
         }
 
-        // 💡 엔티티 값 변경
+        //엔티티 값 변경
         member.updateProfile(newNickname, request.getProfileImageUrl());
 
         return createDtoWithPresignedUrl(member);
     }
 
-    // 💡 이미지 전용 업데이트
+    // 이미지 전용 업데이트
     @Transactional
     public MemberResponseDto updateProfileImage(Long memberId, String imageKey) {
         Member member = memberRepository.findById(memberId)
@@ -78,9 +78,7 @@ public class MemberService {
         });
     }
 
-    /**
-     * 💡 [공통 로직] 엔티티의 S3 Key를 Presigned URL로 변환하여 DTO 생성
-     */
+
     private MemberResponseDto createDtoWithPresignedUrl(Member member) {
         String key = member.getProfileImageUrl(); // DB에는 "profile/uuid.jpg" 형태로 저장됨
         String presignedUrl = null;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=backend
 server.port=8080
 
 # MySQL Connection
-spring.datasource.url=jdbc:mysql://localhost:3306/dailo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3307/dailo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:changeme}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -19,7 +19,7 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
 # JWT
-jwt.secret=vmfhaltkfkdgodyroqkfwkdbalroqkfwkdbalsucvmfhaltkfkdgodyroqkfwkdbalroqkfwkdbalsucvmfhaltkfkdgodyroqkfwkdbalroqkfwkdbalsuc
+jwt.secret=${JWT_SECRET}
 jwt.access-token-validity-in-seconds=1800  
 # 30?
 jwt.refresh-token-validity-in-seconds=604800
@@ -49,3 +49,33 @@ spring.servlet.multipart.max-request-size=100MB
 crawler.api.url=${CRAWLER_API_URL:http://localhost:8000}
 crawler.api.year=2025
 crawler.api.region=\uCDA9\uC8FC\uC2DC
+
+# OAuth2 Kakao
+# 1. ????? ?? (??? ??)
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname, profile_image
+
+# 2. ??? API ?? ?? (??? ??? ??)
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# ???(CloudFront, Nginx ?)? ???? X-Forwarded-* ??? ????? ??
+server.forward-headers-strategy=framework
+
+# Mail (Gmail SMTP - Dev/Test)
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+# optional: ?? From / ??? URL
+app.mail.from=${MAIL_FROM:no-reply@dailoapp.com}
+app.front-base-url=${FRONT_BASE_URL:http://localhost:8080}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 # Test Database (MySQL - dailo_test)
-spring.datasource.url=jdbc:mysql://localhost:3306/dailo_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3307/dailo_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:changeme}
@@ -16,3 +16,10 @@ jwt.refresh-token-validity-in-seconds=604800
 
 # Logging
 logging.level.org.hibernate.SQL=DEBUG
+
+# S3 (test dummy)
+cloud.aws.credentials.access-key=dummy
+cloud.aws.credentials.secret-key=dummy
+cloud.aws.region=ap-northeast-2
+cloud.aws.s3.bucket=dummy-bucket
+


### PR DESCRIPTION
## 개요
이메일 사전 인증 기반의 자체 회원가입/로그인 로직 및 JWT(Access/Refresh Token) 인증 체계 구축
카카오 소셜 로그인 연동 및 보안을 위한 환경변수 분리 작업 완료

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #52 

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
[x] 이메일 인증번호 발송 및 검증 로직 구현 (MailService 비동기 @Async 적용)
[x] JWT 발급 및 검증 로직 구현 (TokenProvider)
[x] 리프레시 토큰(Refresh Token) 도입 및 DB 저장 로직 추가
[x] 토큰 재발급(Reissue) API 구현
[x] 카카오 OAuth2 소셜 로그인 연동 (CustomOAuth2UserService, SuccessHandler)

## 체크리스트

