### PR TITLE
Fix/ci

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/ReportController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/ReportController.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,21 +25,23 @@ public class ReportController {
     // 1. 신고 생성
     @PostMapping
     public ResponseEntity<ReportResponseDto> createReport(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody ReportRequestDto requestDto) {
 
-        ReportResponseDto response = reportService.createReport(requestDto, userId);
+        String email = userDetails.getUsername();
+        ReportResponseDto response = reportService.createReportByEmail(requestDto, email);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     // 2. 내 신고 목록
     @GetMapping("/my")
     public ResponseEntity<Page<ReportResponseDto>> getMyReports(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
+        String email = userDetails.getUsername();
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return ResponseEntity.ok(reportService.getMyReports(userId, pageable));
+        return ResponseEntity.ok(reportService.getMyReportsByEmail(email, pageable));
     }
 }

--- a/backend/src/main/java/com/dailo/backend/service/ReportService.java
+++ b/backend/src/main/java/com/dailo/backend/service/ReportService.java
@@ -4,9 +4,14 @@ import com.dailo.backend.domain.enums.ReportType;
 import com.dailo.backend.dto.ReportRequestDto;
 import com.dailo.backend.dto.ReportResponseDto;
 import com.dailo.backend.entity.Comment;
+import com.dailo.backend.entity.Member;
 import com.dailo.backend.entity.Post;
 import com.dailo.backend.entity.Report;
+import com.dailo.backend.exception.ConflictException;
+import com.dailo.backend.exception.NotFoundException;
+import com.dailo.backend.exception.UnauthorizedException;
 import com.dailo.backend.repository.CommentRepository;
+import com.dailo.backend.repository.MemberRepository;
 import com.dailo.backend.repository.PostRepository;
 import com.dailo.backend.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +29,33 @@ public class ReportService {
     private final ReportRepository reportRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
 
-    // 신고 생성
+    // --- 외부(Controller) 호출용 이메일 기반 메서드 ---
+
+    /** 신고 생성 (이메일 기반) */
+    @Transactional
+    public ReportResponseDto createReportByEmail(ReportRequestDto requestDto, String email) {
+        if (email == null) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+        Member reporter = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+        return createReport(requestDto, reporter.getId());
+    }
+
+    /** 내 신고 목록 (이메일 기반) */
+    public Page<ReportResponseDto> getMyReportsByEmail(String email, Pageable pageable) {
+        if (email == null) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+        Member reporter = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+        return getMyReports(reporter.getId(), pageable);
+    }
+
+    // --- 내부 로직 및 기존 ID 기반 메서드 ---
+
     @Transactional
     public ReportResponseDto createReport(ReportRequestDto requestDto, Long reporterId) {
         // 1. 대상 존재 검증 + 자기 신고 방지
@@ -34,7 +64,7 @@ public class ReportService {
         // 2. 중복 신고 체크
         if (reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
                 reporterId, requestDto.getTargetType(), requestDto.getTargetId())) {
-            throw new RuntimeException("Already reported");
+            throw new ConflictException("이미 신고한 대상입니다.");
         }
 
         Report report = requestDto.toEntity(reporterId);
@@ -55,23 +85,22 @@ public class ReportService {
         switch (targetType) {
             case POST -> {
                 Post post = postRepository.findById(targetId)
-                        .orElseThrow(() -> new RuntimeException("Post not found: " + targetId));
+                        .orElseThrow(() -> new NotFoundException("게시글을 찾을 수 없습니다: " + targetId));
                 if (post.getAuthorId().equals(reporterId)) {
-                    throw new RuntimeException("Cannot report your own post");
+                    throw new IllegalArgumentException("자신의 게시글은 신고할 수 없습니다.");
                 }
             }
             case COMMENT -> {
                 Comment comment = commentRepository.findById(targetId)
-                        .orElseThrow(() -> new RuntimeException("Comment not found: " + targetId));
+                        .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다: " + targetId));
                 if (comment.getAuthorId().equals(reporterId)) {
-                    throw new RuntimeException("Cannot report your own comment");
+                    throw new IllegalArgumentException("자신의 댓글은 신고할 수 없습니다.");
                 }
             }
             case USER -> {
                 if (targetId.equals(reporterId)) {
-                    throw new RuntimeException("Cannot report yourself");
+                    throw new IllegalArgumentException("자기 자신은 신고할 수 없습니다.");
                 }
-                // TODO: UserRepository.existsById(targetId) 검증 추가
             }
             case CHAT -> {
                 // TODO: ChatMessage/ChatRoom 검증 추가
@@ -79,7 +108,6 @@ public class ReportService {
         }
     }
 
-    // 내 신고 목록 (신고한 게시물/댓글 등 대상 표시용 targetDisplay 포함)
     public Page<ReportResponseDto> getMyReports(Long reporterId, Pageable pageable) {
         Page<Report> page = reportRepository.findByReporterId(reporterId, pageable);
         java.util.List<ReportResponseDto> dtos = enrichWithTargetDisplay(page.getContent());

--- a/backend/src/test/java/com/dailo/backend/integration/BlockApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/BlockApiTest.java
@@ -13,6 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +44,6 @@ class BlockApiTest {
 
     @BeforeEach
     void setUp() {
-        // 테스트용 사용자 생성
         blocker = memberRepository.save(Member.builder()
                 .email("blocker@test.com")
                 .nickname("Blocker")
@@ -57,7 +58,6 @@ class BlockApiTest {
                 .socialType(SocialType.LOCAL)
                 .build());
 
-        // SecurityContext에 인증 정보 설정
         setSecurityContext(blocker.getEmail());
     }
 
@@ -67,11 +67,17 @@ class BlockApiTest {
     }
 
     private void setSecurityContext(String email) {
+        UserDetails userDetails = User.builder()
+                .username(email)
+                .password("")
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
+                .build();
+
         UsernamePasswordAuthenticationToken auth =
                 new UsernamePasswordAuthenticationToken(
-                        email,
+                        userDetails,
                         null,
-                        List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        userDetails.getAuthorities()
                 );
         SecurityContextHolder.getContext().setAuthentication(auth);
     }

--- a/backend/src/test/java/com/dailo/backend/integration/BlockApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/BlockApiTest.java
@@ -4,21 +4,16 @@ import com.dailo.backend.domain.enums.Role;
 import com.dailo.backend.domain.enums.SocialType;
 import com.dailo.backend.entity.Member;
 import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.support.TestSecurityUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -58,28 +53,12 @@ class BlockApiTest {
                 .socialType(SocialType.LOCAL)
                 .build());
 
-        setSecurityContext(blocker.getEmail());
+        TestSecurityUtils.authenticate(blocker.getEmail());
     }
 
     @AfterEach
     void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
-
-    private void setSecurityContext(String email) {
-        UserDetails userDetails = User.builder()
-                .username(email)
-                .password("")
-                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
-                .build();
-
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                );
-        SecurityContextHolder.getContext().setAuthentication(auth);
+        TestSecurityUtils.clearAuthentication();
     }
 
     @Test

--- a/backend/src/test/java/com/dailo/backend/integration/CommentApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/CommentApiTest.java
@@ -4,21 +4,16 @@ import com.dailo.backend.domain.enums.Role;
 import com.dailo.backend.domain.enums.SocialType;
 import com.dailo.backend.entity.Member;
 import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.support.TestSecurityUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -66,28 +61,12 @@ class CommentApiTest {
                 .socialType(SocialType.LOCAL)
                 .build());
 
-        setSecurityContext(user1.getEmail());
+        TestSecurityUtils.authenticate(user1.getEmail());
     }
 
     @AfterEach
     void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
-
-    private void setSecurityContext(String email) {
-        UserDetails userDetails = User.builder()
-                .username(email)
-                .password("")
-                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
-                .build();
-
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                );
-        SecurityContextHolder.getContext().setAuthentication(auth);
+        TestSecurityUtils.clearAuthentication();
     }
 
     private Long createPost() throws Exception {
@@ -137,7 +116,7 @@ class CommentApiTest {
         Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
 
         // user2로 전환하여 대댓글 생성
-        setSecurityContext(user2.getEmail());
+        TestSecurityUtils.authenticate(user2.getEmail());
 
         String replyBody = objectMapper.writeValueAsString(Map.of(
                 "content", "대댓글입니다",
@@ -167,7 +146,7 @@ class CommentApiTest {
         Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
 
         // user2로 전환하여 대댓글
-        setSecurityContext(user2.getEmail());
+        TestSecurityUtils.authenticate(user2.getEmail());
 
         String replyBody = objectMapper.writeValueAsString(Map.of(
                 "content", "2단계", "parentCommentId", parentId));
@@ -178,7 +157,7 @@ class CommentApiTest {
         Long replyId = objectMapper.readTree(replyResponse).get("id").asLong();
 
         // user3로 전환하여 대댓글의 대댓글 → 실패
-        setSecurityContext(user3.getEmail());
+        TestSecurityUtils.authenticate(user3.getEmail());
 
         String nestedBody = objectMapper.writeValueAsString(Map.of(
                 "content", "3단계 불가", "parentCommentId", replyId));
@@ -204,7 +183,7 @@ class CommentApiTest {
         Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
 
         // user2로 전환하여 대댓글
-        setSecurityContext(user2.getEmail());
+        TestSecurityUtils.authenticate(user2.getEmail());
 
         String replyBody = objectMapper.writeValueAsString(Map.of(
                 "content", "자식", "parentCommentId", parentId));

--- a/backend/src/test/java/com/dailo/backend/integration/CommentApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/CommentApiTest.java
@@ -1,13 +1,24 @@
 package com.dailo.backend.integration;
 
+import com.dailo.backend.domain.enums.Role;
+import com.dailo.backend.domain.enums.SocialType;
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -16,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Transactional
 class CommentApiTest {
 
     @Autowired
@@ -24,6 +36,60 @@ class CommentApiTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member user1;
+    private Member user2;
+    private Member user3;
+
+    @BeforeEach
+    void setUp() {
+        user1 = memberRepository.save(Member.builder()
+                .email("comment1@test.com")
+                .nickname("Commenter1")
+                .role(Role.USER)
+                .socialType(SocialType.LOCAL)
+                .build());
+
+        user2 = memberRepository.save(Member.builder()
+                .email("comment2@test.com")
+                .nickname("Commenter2")
+                .role(Role.USER)
+                .socialType(SocialType.LOCAL)
+                .build());
+
+        user3 = memberRepository.save(Member.builder()
+                .email("comment3@test.com")
+                .nickname("Commenter3")
+                .role(Role.USER)
+                .socialType(SocialType.LOCAL)
+                .build());
+
+        setSecurityContext(user1.getEmail());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setSecurityContext(String email) {
+        UserDetails userDetails = User.builder()
+                .username(email)
+                .password("")
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
+                .build();
+
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
     private Long createPost() throws Exception {
         String body = objectMapper.writeValueAsString(Map.of(
                 "title", "댓글 테스트 게시글",
@@ -31,7 +97,6 @@ class CommentApiTest {
                 "categoryType", "FREE"
         ));
         String response = mockMvc.perform(post("/api/posts")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andReturn().getResponse().getContentAsString();
@@ -49,7 +114,6 @@ class CommentApiTest {
         ));
 
         mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isOk())
@@ -67,20 +131,20 @@ class CommentApiTest {
         // 부모 댓글 생성
         String parentBody = objectMapper.writeValueAsString(Map.of("content", "부모 댓글"));
         String parentResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(parentBody))
                 .andReturn().getResponse().getContentAsString();
         Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
 
-        // 대댓글 생성
+        // user2로 전환하여 대댓글 생성
+        setSecurityContext(user2.getEmail());
+
         String replyBody = objectMapper.writeValueAsString(Map.of(
                 "content", "대댓글입니다",
                 "parentCommentId", parentId
         ));
 
         mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "2")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(replyBody))
                 .andExpect(status().isOk())
@@ -97,28 +161,29 @@ class CommentApiTest {
         // 부모 댓글
         String parentBody = objectMapper.writeValueAsString(Map.of("content", "1단계"));
         String parentResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(parentBody))
                 .andReturn().getResponse().getContentAsString();
         Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
 
-        // 대댓글
+        // user2로 전환하여 대댓글
+        setSecurityContext(user2.getEmail());
+
         String replyBody = objectMapper.writeValueAsString(Map.of(
                 "content", "2단계", "parentCommentId", parentId));
         String replyResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "2")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(replyBody))
                 .andReturn().getResponse().getContentAsString();
         Long replyId = objectMapper.readTree(replyResponse).get("id").asLong();
 
-        // 대댓글의 대댓글 → 실패
+        // user3로 전환하여 대댓글의 대댓글 → 실패
+        setSecurityContext(user3.getEmail());
+
         String nestedBody = objectMapper.writeValueAsString(Map.of(
                 "content", "3단계 불가", "parentCommentId", replyId));
 
         mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "3")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(nestedBody))
                 .andExpect(status().isBadRequest());
@@ -133,22 +198,22 @@ class CommentApiTest {
         // 댓글 + 대댓글 생성
         String parentBody = objectMapper.writeValueAsString(Map.of("content", "부모"));
         String parentResponse = mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(parentBody))
                 .andReturn().getResponse().getContentAsString();
         Long parentId = objectMapper.readTree(parentResponse).get("id").asLong();
 
+        // user2로 전환하여 대댓글
+        setSecurityContext(user2.getEmail());
+
         String replyBody = objectMapper.writeValueAsString(Map.of(
                 "content", "자식", "parentCommentId", parentId));
         mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                .header("X-User-Id", "2")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(replyBody));
 
         // 조회
-        mockMvc.perform(get("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "1"))
+        mockMvc.perform(get("/api/posts/" + postId + "/comments"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].replies").isArray());
     }
@@ -161,7 +226,6 @@ class CommentApiTest {
 
         String body = objectMapper.writeValueAsString(Map.of("content", "수정 전"));
         String response = mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andReturn().getResponse().getContentAsString();
@@ -169,7 +233,6 @@ class CommentApiTest {
 
         String updateBody = objectMapper.writeValueAsString(Map.of("content", "수정 후"));
         mockMvc.perform(put("/api/comments/" + commentId)
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(updateBody))
                 .andExpect(status().isOk())
@@ -184,14 +247,12 @@ class CommentApiTest {
 
         String body = objectMapper.writeValueAsString(Map.of("content", "삭제될 댓글"));
         String response = mockMvc.perform(post("/api/posts/" + postId + "/comments")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andReturn().getResponse().getContentAsString();
         Long commentId = objectMapper.readTree(response).get("id").asLong();
 
-        mockMvc.perform(delete("/api/comments/" + commentId)
-                        .header("X-User-Id", "1"))
+        mockMvc.perform(delete("/api/comments/" + commentId))
                 .andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/com/dailo/backend/integration/PostApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/PostApiTest.java
@@ -4,21 +4,16 @@ import com.dailo.backend.domain.enums.Role;
 import com.dailo.backend.domain.enums.SocialType;
 import com.dailo.backend.entity.Member;
 import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.support.TestSecurityUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -50,28 +45,12 @@ class PostApiTest {
                 .socialType(SocialType.LOCAL)
                 .build());
 
-        setSecurityContext(testUser.getEmail());
+        TestSecurityUtils.authenticate(testUser.getEmail());
     }
 
     @AfterEach
     void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
-
-    private void setSecurityContext(String email) {
-        UserDetails userDetails = User.builder()
-                .username(email)
-                .password("")
-                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
-                .build();
-
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                );
-        SecurityContextHolder.getContext().setAuthentication(auth);
+        TestSecurityUtils.clearAuthentication();
     }
 
     @Test

--- a/backend/src/test/java/com/dailo/backend/integration/PostApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/PostApiTest.java
@@ -1,13 +1,24 @@
 package com.dailo.backend.integration;
 
+import com.dailo.backend.domain.enums.Role;
+import com.dailo.backend.domain.enums.SocialType;
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -16,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Transactional
 class PostApiTest {
 
     @Autowired
@@ -23,6 +35,44 @@ class PostApiTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = memberRepository.save(Member.builder()
+                .email("posttest@test.com")
+                .nickname("PostTester")
+                .role(Role.USER)
+                .socialType(SocialType.LOCAL)
+                .build());
+
+        setSecurityContext(testUser.getEmail());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setSecurityContext(String email) {
+        UserDetails userDetails = User.builder()
+                .username(email)
+                .password("")
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
+                .build();
+
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
 
     @Test
     @Order(1)
@@ -35,13 +85,12 @@ class PostApiTest {
         ));
 
         mockMvc.perform(post("/api/posts")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").exists())
                 .andExpect(jsonPath("$.title").value("테스트 게시글"))
-                .andExpect(jsonPath("$.authorId").value(1));
+                .andExpect(jsonPath("$.authorId").value(testUser.getId()));
     }
 
     @Test
@@ -55,12 +104,10 @@ class PostApiTest {
                 "categoryType", "FREE"
         ));
         mockMvc.perform(post("/api/posts")
-                .header("X-User-Id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body));
 
-        mockMvc.perform(get("/api/posts")
-                        .header("X-User-Id", "1"))
+        mockMvc.perform(get("/api/posts"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray());
     }
@@ -76,15 +123,13 @@ class PostApiTest {
                 "categoryType", "FREE"
         ));
         String response = mockMvc.perform(post("/api/posts")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andReturn().getResponse().getContentAsString();
 
         Long postId = objectMapper.readTree(response).get("id").asLong();
 
-        mockMvc.perform(get("/api/posts/" + postId)
-                        .header("X-User-Id", "1"))
+        mockMvc.perform(get("/api/posts/" + postId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("단건 조회 테스트"));
     }
@@ -100,7 +145,6 @@ class PostApiTest {
                 "categoryType", "FREE"
         ));
         String response = mockMvc.perform(post("/api/posts")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createBody))
                 .andReturn().getResponse().getContentAsString();
@@ -114,7 +158,6 @@ class PostApiTest {
                 "categoryType", "FREE"
         ));
         mockMvc.perform(put("/api/posts/" + postId)
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(updateBody))
                 .andExpect(status().isOk())
@@ -132,15 +175,13 @@ class PostApiTest {
                 "categoryType", "FREE"
         ));
         String response = mockMvc.perform(post("/api/posts")
-                        .header("X-User-Id", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andReturn().getResponse().getContentAsString();
 
         Long postId = objectMapper.readTree(response).get("id").asLong();
 
-        mockMvc.perform(delete("/api/posts/" + postId)
-                        .header("X-User-Id", "1"))
+        mockMvc.perform(delete("/api/posts/" + postId))
                 .andExpect(status().isNoContent());
     }
 }

--- a/backend/src/test/java/com/dailo/backend/integration/ReportApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/ReportApiTest.java
@@ -1,13 +1,24 @@
 package com.dailo.backend.integration;
 
+import com.dailo.backend.domain.enums.Role;
+import com.dailo.backend.domain.enums.SocialType;
+import com.dailo.backend.entity.Member;
+import com.dailo.backend.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -16,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Transactional
 class ReportApiTest {
 
     @Autowired
@@ -24,24 +36,71 @@ class ReportApiTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member reporter;
+    private Member targetUser;
+
+    @BeforeEach
+    void setUp() {
+        reporter = memberRepository.save(Member.builder()
+                .email("reporter@test.com")
+                .nickname("Reporter")
+                .role(Role.USER)
+                .socialType(SocialType.LOCAL)
+                .build());
+
+        targetUser = memberRepository.save(Member.builder()
+                .email("target@test.com")
+                .nickname("TargetUser")
+                .role(Role.USER)
+                .socialType(SocialType.LOCAL)
+                .build());
+
+        setSecurityContext(reporter.getEmail());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setSecurityContext(String email) {
+        UserDetails userDetails = User.builder()
+                .username(email)
+                .password("")
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
+                .build();
+
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
     @Test
     @Order(1)
     @DisplayName("POST /api/reports - 신고 생성")
     void createReport() throws Exception {
         String body = objectMapper.writeValueAsString(Map.of(
-                "targetType", "POST",
-                "targetId", 1,
+                "targetType", "USER",
+                "targetId", targetUser.getId(),
                 "reason", "SPAM",
-                "description", "광고 게시글"
+                "description", "스팸 사용자"
         ));
 
+        // ReportController는 X-User-Id 헤더 사용
         mockMvc.perform(post("/api/reports")
-                        .header("X-User-Id", "1")
+                        .header("X-User-Id", reporter.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").exists())
-                .andExpect(jsonPath("$.reporterId").value(1))
+                .andExpect(jsonPath("$.reporterId").value(reporter.getId()))
                 .andExpect(jsonPath("$.status").value("PENDING"));
     }
 
@@ -49,19 +108,19 @@ class ReportApiTest {
     @Order(2)
     @DisplayName("GET /api/reports/my - 내 신고 목록")
     void getMyReports() throws Exception {
-        // 신고 생성 (POST 타입은 실제 게시글 ID 필요하므로 USER 타입 사용)
+        // 신고 생성
         String body = objectMapper.writeValueAsString(Map.of(
                 "targetType", "USER",
-                "targetId", 99,
+                "targetId", targetUser.getId(),
                 "reason", "ABUSE"
         ));
         mockMvc.perform(post("/api/reports")
-                .header("X-User-Id", "2")
+                .header("X-User-Id", reporter.getId())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body));
 
         mockMvc.perform(get("/api/reports/my")
-                        .header("X-User-Id", "2"))
+                        .header("X-User-Id", reporter.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray());
     }

--- a/backend/src/test/java/com/dailo/backend/integration/ReportApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/ReportApiTest.java
@@ -4,21 +4,16 @@ import com.dailo.backend.domain.enums.Role;
 import com.dailo.backend.domain.enums.SocialType;
 import com.dailo.backend.entity.Member;
 import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.support.TestSecurityUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -58,28 +53,12 @@ class ReportApiTest {
                 .socialType(SocialType.LOCAL)
                 .build());
 
-        setSecurityContext(reporter.getEmail());
+        TestSecurityUtils.authenticate(reporter.getEmail());
     }
 
     @AfterEach
     void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
-
-    private void setSecurityContext(String email) {
-        UserDetails userDetails = User.builder()
-                .username(email)
-                .password("")
-                .authorities(List.of(new SimpleGrantedAuthority("ROLE_USER")))
-                .build();
-
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                );
-        SecurityContextHolder.getContext().setAuthentication(auth);
+        TestSecurityUtils.clearAuthentication();
     }
 
     @Test
@@ -93,9 +72,7 @@ class ReportApiTest {
                 "description", "스팸 사용자"
         ));
 
-        // ReportController는 X-User-Id 헤더 사용
         mockMvc.perform(post("/api/reports")
-                        .header("X-User-Id", reporter.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isCreated())
@@ -115,12 +92,10 @@ class ReportApiTest {
                 "reason", "ABUSE"
         ));
         mockMvc.perform(post("/api/reports")
-                .header("X-User-Id", reporter.getId())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body));
 
-        mockMvc.perform(get("/api/reports/my")
-                        .header("X-User-Id", reporter.getId()))
+        mockMvc.perform(get("/api/reports/my"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray());
     }

--- a/backend/src/test/java/com/dailo/backend/support/TestSecurityUtils.java
+++ b/backend/src/test/java/com/dailo/backend/support/TestSecurityUtils.java
@@ -1,0 +1,61 @@
+package com.dailo.backend.support;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+
+/**
+ * 테스트용 SecurityContext 설정 유틸리티
+ *
+ * 모든 통합 테스트에서 공통으로 사용하는 인증 설정 메서드를 제공합니다.
+ * @AuthenticationPrincipal UserDetails와 SecurityUtil.getCurrentMemberEmail() 모두 호환됩니다.
+ */
+public final class TestSecurityUtils {
+
+    private TestSecurityUtils() {
+        // Utility class - 인스턴스화 방지
+    }
+
+    /**
+     * 지정된 이메일로 SecurityContext에 인증 정보를 설정합니다.
+     *
+     * @param email 인증할 사용자의 이메일
+     */
+    public static void authenticate(String email) {
+        authenticate(email, "ROLE_USER");
+    }
+
+    /**
+     * 지정된 이메일과 권한으로 SecurityContext에 인증 정보를 설정합니다.
+     *
+     * @param email 인증할 사용자의 이메일
+     * @param role 부여할 권한 (예: "ROLE_USER", "ROLE_ADMIN")
+     */
+    public static void authenticate(String email, String role) {
+        UserDetails userDetails = User.builder()
+                .username(email)
+                .password("")
+                .authorities(List.of(new SimpleGrantedAuthority(role)))
+                .build();
+
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    /**
+     * SecurityContext의 인증 정보를 제거합니다.
+     * 테스트 종료 시 @AfterEach에서 호출해야 합니다.
+     */
+    public static void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+}


### PR DESCRIPTION
Spring Security 기반 인증 구조를 컨트롤러/테스트 전반에 걸쳐 통일했습니다.
기존에 X-User-Id 헤더 방식과 @AuthenticationPrincipal UserDetails 방식이 혼재되어 있던 구조를 정리했고, 테스트 코드의 인증 설정도 공통 유틸로 분리했습니다.
또한 인증 실패 상황을 UnauthorizedException으로 명확히 분리하여 예외 처리 구조를 개선했습니다.

관련 이슈
	•	Refs #이슈번호

작업 내용
	•	ReportController의 인증 방식을 X-User-Id 헤더 기반에서 @AuthenticationPrincipal UserDetails 기반으로 변경
	•	ReportService에 이메일 기반 wrapper 메서드 추가
	•	UnauthorizedException 추가 및 GlobalExceptionHandler에 401 Unauthorized 핸들러 추가
	•	BlockService의 null 방어 및 예외 구체화
	•	BlockApiTest, PostApiTest, CommentApiTest, ReportApiTest의 인증 방식을 SecurityContext 기반으로 통일
	•	테스트용 인증 설정 로직을 TestSecurityUtils 공통 유틸 클래스로 분리
	•	전체 통합 테스트 통과 확인

체크리스트
	•	빌드가 에러 없이 수행되는가?
	•	불필요한 로그(console.log 등)는 없는가?
	•	인증 구조가 프로젝트 전반에서 일관되게 적용되었는가?
	•	테스트 코드의 중복 인증 설정 로직이 제거되었는가?
	•	관련 테스트가 정상 통과하는가?
