### PR TITLE
[FIX] 소셜 로그인 수정

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/AuthController.java
@@ -25,19 +25,12 @@ public class AuthController {
     private final AuthService authService;
     private final KakaoNativeLoginService kakaoNativeLoginService;
 
-    /* ================= 1. 회원가입 사전 이메일 인증 ================= */
-
     @Operation(summary = "회원가입 인증번호 발송", description = "가입 전 이메일 중복 확인 후 6자리 인증번호를 메일로 발송합니다.")
     @PostMapping("/email/send")
-    public ResponseEntity<Void> sendSignUpEmail(
-            @RequestParam("email") String email
-    ) {
+    public ResponseEntity<Void> sendSignUpEmail(@RequestParam("email") String email) {
         authService.sendSignUpEmail(email);
-        return ResponseEntity.noContent().build(); // 204
+        return ResponseEntity.noContent().build();
     }
-
-
-    /* ================= 2. 회원가입 / 로그인 ================= */
 
     @Operation(summary = "회원가입 (인증 완료 및 최종 가입)", description = "이메일, 비밀번호, 닉네임과 함께 발급받은 '인증번호(authCode)'를 보내 최종 가입합니다.")
     @PostMapping("/signup")
@@ -49,9 +42,7 @@ public class AuthController {
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 JWT를 발급합니다.")
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> login(
-            @RequestBody LoginRequestDto requestDto
-    ) {
+    public ResponseEntity<TokenDto> login(@RequestBody LoginRequestDto requestDto) {
         return ResponseEntity.ok(authService.login(requestDto));
     }
 
@@ -63,13 +54,9 @@ public class AuthController {
         return ResponseEntity.ok(kakaoNativeLoginService.loginWithKakaoToken(requestDto));
     }
 
-    /* ================= 3. 비밀번호 재설정 ================= */
-
     @Operation(summary = "비밀번호 재설정 요청", description = "가입된 이메일로 비밀번호 재설정용 64자리 토큰을 발송합니다.")
     @PostMapping("/password-reset/request")
-    public ResponseEntity<Void> requestPasswordReset(
-            @RequestParam("email") String email
-    ) {
+    public ResponseEntity<Void> requestPasswordReset(@RequestParam("email") String email) {
         authService.requestPasswordReset(email);
         return ResponseEntity.noContent().build();
     }
@@ -84,23 +71,15 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-    /* ================= 4. 토큰 재발급 ================= */
-
     @Operation(summary = "토큰 재발급", description = "만료된 Access Token과 Refresh Token을 보내 새로운 토큰 셋을 발급받습니다.")
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto> reissue(
-            @RequestBody com.dailo.backend.dto.auth.TokenRequestDto requestDto
-    ) {
+    public ResponseEntity<TokenDto> reissue(@RequestBody com.dailo.backend.dto.auth.TokenRequestDto requestDto) {
         return ResponseEntity.ok(authService.reissue(requestDto));
     }
-    /* ================= 5. 로그아웃================= */
 
     @Operation(summary = "로그아웃", description = "DB에서 사용자의 Refresh Token을 삭제합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        // JWT 필터를 통과한 유저 정보에서 이메일 추출하여 삭제
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal UserDetails userDetails) {
         authService.logout(userDetails.getUsername());
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/dailo/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/MemberController.java
@@ -23,58 +23,50 @@ public class MemberController {
     private final MemberService memberService;
     private final S3UploadService s3UploadService;
 
-    // 1. 내 정보 조회
     @GetMapping("/me")
     public ResponseEntity<MemberResponseDto> getMyProfile(@AuthenticationPrincipal UserDetails userDetails) {
-        String email = userDetails.getUsername(); // 💡 Long 파싱 제거!
+        String email = userDetails.getUsername();
         return ResponseEntity.ok(memberService.getMyProfile(email));
     }
 
-    // 2. 프로필 수정
     @PatchMapping("/me")
     public ResponseEntity<MemberResponseDto> updateProfile(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody MemberUpdateRequestDto request) {
-        String email = userDetails.getUsername(); // 💡 Long 파싱 제거!
+        String email = userDetails.getUsername();
         return ResponseEntity.ok(memberService.updateProfile(email, request));
     }
 
-    // 3. 회원 탈퇴
     @DeleteMapping("/me")
     public ResponseEntity<Map<String, String>> withdraw(@AuthenticationPrincipal UserDetails userDetails) {
-        String email = userDetails.getUsername(); // 💡 Long 파싱 제거!
+        String email = userDetails.getUsername();
         memberService.withdraw(email);
 
-        // 💡 기획서 명세대로 JSON 반환
         Map<String, String> response = new HashMap<>();
         response.put("status", "SUCCESS");
         response.put("message", "탈퇴 처리되었습니다.");
         return ResponseEntity.ok(response);
     }
 
-    // 4. 닉네임 중복 체크
     @GetMapping("/check-nickname")
     public ResponseEntity<Map<String, Boolean>> checkNickname(@RequestParam String nickname) {
         boolean isDuplicate = memberService.checkNicknameDuplicate(nickname);
 
-        // 💡 기획서 명세대로 { "isAvailable": true/false } 반환
         Map<String, Boolean> response = new HashMap<>();
-        response.put("isAvailable", !isDuplicate); // 중복이 아니어야 사용 가능(true)
+        response.put("isAvailable", !isDuplicate);
         return ResponseEntity.ok(response);
     }
 
-    // 5. 프로필 이미지 업로드 API
     @PostMapping(value = "/me/image", consumes = "multipart/form-data")
     public ResponseEntity<Map<String, String>> uploadProfileImage(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestPart("file") MultipartFile file) throws IOException {
 
-        String email = userDetails.getUsername(); // 💡 Long 파싱 제거!
+        String email = userDetails.getUsername();
 
         String imageKey = s3UploadService.upload(file, "profile");
         memberService.updateProfileImage(email, imageKey);
 
-        // 💡 기획서 명세대로 이미지 URL만 JSON으로 반환
         String imageUrl = s3UploadService.getPresignedUrl(imageKey);
         Map<String, String> response = new HashMap<>();
         response.put("imageUrl", imageUrl);

--- a/backend/src/main/java/com/dailo/backend/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/dailo/backend/jwt/JwtFilter.java
@@ -25,30 +25,23 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        // 1. Request Header에서 토큰 꺼내기
         String jwt = resolveToken(request);
 
-        // 2. 토큰 유효성 검사
         if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-            // 3. 토큰에서 인증 정보(Authentication) 추출
             Authentication authentication = tokenProvider.getAuthentication(jwt);
 
-            // 4. 정지 회원 체크 (이메일 기반)
-            // authentication.getName()은 이제 유저의 이메일(String)입니다.
+            // JWT subject를 이메일로 사용하므로 authentication.getName()은 이메일입니다.
             String email = authentication.getName();
 
-            // DB에서 해당 이메일로 회원을 찾아 정지(Suspended) 상태인지 확인
             boolean isSuspended = memberRepository.findByEmail(email)
                     .map(member -> member.isSuspended())
                     .orElse(false);
 
             if (isSuspended) {
-                // 정지된 회원이면 403 Forbidden 응답 후 필터 중단
                 response.sendError(HttpServletResponse.SC_FORBIDDEN, "정지된 계정입니다.");
                 return;
             }
 
-            // 5. 정상이면 SecurityContext에 인증 정보 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/backend/src/main/java/com/dailo/backend/jwt/TokenProvider.java
+++ b/backend/src/main/java/com/dailo/backend/jwt/TokenProvider.java
@@ -25,20 +25,17 @@ public class TokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;
 
     private final Key key;
 
-    // application.yml에서 secret 값 가져와서 암호화 키 생성
     public TokenProvider(@Value("${jwt.secret}") String secretKey) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    // 토큰 생성
     public TokenDto generateTokenDto(Authentication authentication) {
-        // 권한 가져오기
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
@@ -47,33 +44,7 @@ public class TokenProvider {
 
         Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
         String accessToken = Jwts.builder()
-                .setSubject(authentication.getName())       // payload "sub": "name"
-                .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
-                .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022
-                .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
-                .compact();
-
-        String refreshToken = Jwts.builder()
-                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
-                .signWith(key, SignatureAlgorithm.HS512)
-                .compact();
-
-        return TokenDto.builder()
-                .grantType(BEARER_TYPE)
-                .accessToken(accessToken)
-                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
-                .refreshToken(refreshToken)
-                .build();
-    }
-
-    // 멤버 ID와 역할로 토큰 직접 생성 (이메일 인증 등에서 사용)
-    public TokenDto generateTokenDtoForMember(String memberId, String role) {
-        long now = (new Date()).getTime();
-        String authorities = "ROLE_" + role;
-
-        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
-        String accessToken = Jwts.builder()
-                .setSubject(memberId)
+                .setSubject(authentication.getName())
                 .claim(AUTHORITIES_KEY, authorities)
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS512)
@@ -92,16 +63,38 @@ public class TokenProvider {
                 .build();
     }
 
-    // 토큰에서 인증 정보 꺼내기
+    public TokenDto generateTokenDtoForMember(String subject, String role) {
+        long now = (new Date()).getTime();
+        String authorities = "ROLE_" + role;
+
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(subject)
+                .claim(AUTHORITIES_KEY, authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .refreshToken(refreshToken)
+                .build();
+    }
+
     public Authentication getAuthentication(String accessToken) {
-        // 토큰 복호화
         Claims claims = parseClaims(accessToken);
 
         if (claims.get(AUTHORITIES_KEY) == null) {
             throw new RuntimeException("권한 정보가 없는 토큰입니다.");
         }
 
-        // 클레임에서 권한 정보 가져오기
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
                         .map(SimpleGrantedAuthority::new)
@@ -112,7 +105,6 @@ public class TokenProvider {
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
-    // 유효성 검증
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);

--- a/backend/src/main/java/com/dailo/backend/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/dailo/backend/service/CustomOAuth2UserService.java
@@ -24,66 +24,72 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
+    private static final String DEFAULT_SOCIAL_PASSWORD = "oauth2user";
+
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder; // ✅ 추가
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        // 1) 어떤 소셜 로그인인지 (kakao)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         if (!"kakao".equalsIgnoreCase(registrationId)) {
             throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
         }
 
-        // 2) 카카오 데이터를 규격화
         OAuth2UserInfo oAuth2UserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
         String providerId = oAuth2UserInfo.getProviderId();
 
-        // 3) 기존 회원인지 확인 (socialType + socialId)
         Optional<Member> memberOptional =
                 memberRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, providerId);
 
         Member member;
         if (memberOptional.isPresent()) {
             member = memberOptional.get();
-
-            // 닉네임/프로필 변경 반영
-            member.updateProfile(oAuth2UserInfo.getNickname(), oAuth2UserInfo.getImageUrl());
-
-            // 변경 저장(영속 상태면 생략 가능하지만 명시해도 무방)
+            member.updateProfile(
+                    oAuth2UserInfo.getNickname() != null ? oAuth2UserInfo.getNickname() : member.getNickname(),
+                    oAuth2UserInfo.getImageUrl()
+            );
             memberRepository.save(member);
         } else {
-            // 이메일 미제공 대비: kakao_{id} 형태로 저장
-            String email = (oAuth2UserInfo.getEmail() != null && !oAuth2UserInfo.getEmail().isBlank())
-                    ? oAuth2UserInfo.getEmail()
-                    : "kakao_" + providerId;
+            String email = resolveEmail(oAuth2UserInfo.getEmail(), providerId);
+
+            if (memberRepository.existsByEmail(email)) {
+                throw new OAuth2AuthenticationException("이미 동일한 이메일로 가입된 계정이 존재합니다. 기존 방식으로 로그인해주세요.");
+            }
 
             member = Member.builder()
                     .email(email)
-                    .nickname(oAuth2UserInfo.getNickname() != null ? oAuth2UserInfo.getNickname() : "카카오유저")
+                    .nickname(
+                            oAuth2UserInfo.getNickname() != null && !oAuth2UserInfo.getNickname().isBlank()
+                                    ? oAuth2UserInfo.getNickname()
+                                    : "카카오유저"
+                    )
                     .profileImageUrl(oAuth2UserInfo.getImageUrl())
                     .role(Role.USER)
                     .socialType(SocialType.KAKAO)
                     .socialId(providerId)
-
-                    // ✅ 더미 BCrypt 비밀번호 (폼로그인/기타 인증과 섞일 때 null/평문 문제 방지)
-                    .password(passwordEncoder.encode("oauth2user"))
+                    .password(passwordEncoder.encode(DEFAULT_SOCIAL_PASSWORD))
                     .build();
 
             memberRepository.save(member);
         }
 
-        // 4) SecurityContext에 저장될 OAuth2User 반환
-        // role에 맞춰 ROLE_USER / ROLE_ADMIN 등 부여
         String roleName = (member.getRole() != null) ? member.getRole().name() : "USER";
 
         return new DefaultOAuth2User(
                 List.of(new SimpleGrantedAuthority("ROLE_" + roleName)),
                 oAuth2User.getAttributes(),
-                "id" // Kakao user-name-attribute = id
+                "id"
         );
+    }
+
+    private String resolveEmail(String kakaoEmail, String providerId) {
+        if (kakaoEmail != null && !kakaoEmail.isBlank()) {
+            return kakaoEmail;
+        }
+        return "kakao_" + providerId + "@kakao.local";
     }
 }

--- a/backend/src/main/java/com/dailo/backend/service/KakaoNativeLoginService.java
+++ b/backend/src/main/java/com/dailo/backend/service/KakaoNativeLoginService.java
@@ -15,74 +15,114 @@ import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * 앱 내 카카오톡(네이티브) 로그인: 카카오 액세스 토큰으로 사용자 정보 조회 후 회원 찾기/생성 및 JWT 발급
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoNativeLoginService {
 
     private static final String KAKAO_USER_ME_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String DEFAULT_SOCIAL_PASSWORD = "oauth2user";
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     @Transactional
     public TokenDto loginWithKakaoToken(KakaoNativeLoginRequestDto request) {
-        String accessToken = request.getAccessToken();
-        if (accessToken == null || accessToken.isBlank()) {
+        String accessToken = validateAccessToken(request);
+        OAuth2UserInfo userInfo = getKakaoUserInfo(accessToken);
+        Member member = findOrCreateKakaoMember(userInfo);
+        Member savedMember = memberRepository.save(member);
+
+        log.info("카카오 로그인 성공 - Member ID: {}", savedMember.getId());
+
+        return tokenProvider.generateTokenDtoForMember(
+                savedMember.getEmail(),
+                savedMember.getRole() != null ? savedMember.getRole().name() : Role.USER.name()
+        );
+    }
+
+    private String validateAccessToken(KakaoNativeLoginRequestDto request) {
+        if (request == null || request.getAccessToken() == null || request.getAccessToken().isBlank()) {
             throw new IllegalArgumentException("카카오 액세스 토큰이 없습니다.");
         }
+        return request.getAccessToken();
+    }
 
+    private OAuth2UserInfo getKakaoUserInfo(String accessToken) {
         Map<String, Object> kakaoAttributes = fetchKakaoUserMe(accessToken);
-        OAuth2UserInfo oAuth2UserInfo = new KakaoUserInfo(kakaoAttributes);
-        String providerId = oAuth2UserInfo.getProviderId();
+        OAuth2UserInfo userInfo = new KakaoUserInfo(kakaoAttributes);
+
+        String providerId = userInfo.getProviderId();
+        if (providerId == null || providerId.isBlank()) {
+            throw new IllegalArgumentException("카카오 사용자 식별값을 가져올 수 없습니다.");
+        }
+
+        log.debug("카카오 로그인 시도 - providerId: {}", providerId);
+        return userInfo;
+    }
+
+    private Member findOrCreateKakaoMember(OAuth2UserInfo userInfo) {
+        String providerId = userInfo.getProviderId();
 
         Optional<Member> memberOptional =
                 memberRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, providerId);
 
-        Member member;
         if (memberOptional.isPresent()) {
-            member = memberOptional.get();
-            member.updateProfile(oAuth2UserInfo.getNickname(), oAuth2UserInfo.getImageUrl());
-            memberRepository.save(member);
-        } else {
-            String email = (oAuth2UserInfo.getEmail() != null && !oAuth2UserInfo.getEmail().isBlank())
-                    ? oAuth2UserInfo.getEmail()
-                    : "kakao_" + providerId;
-
-            member = Member.builder()
-                    .email(email)
-                    .nickname(oAuth2UserInfo.getNickname() != null ? oAuth2UserInfo.getNickname() : "카카오유저")
-                    .profileImageUrl(oAuth2UserInfo.getImageUrl())
-                    .role(Role.USER)
-                    .socialType(SocialType.KAKAO)
-                    .socialId(providerId)
-                    .password(passwordEncoder.encode("oauth2user"))
-                    .build();
-            memberRepository.save(member);
+            Member existingMember = memberOptional.get();
+            existingMember.updateProfile(
+                    userInfo.getNickname() != null ? userInfo.getNickname() : existingMember.getNickname(),
+                    userInfo.getImageUrl()
+            );
+            log.info("기존 카카오 회원 로그인 처리 - Member ID: {}", existingMember.getId());
+            return existingMember;
         }
 
-        return tokenProvider.generateTokenDtoForMember(
-                String.valueOf(member.getId()),
-                member.getRole() != null ? member.getRole().name() : "USER"
-        );
+        log.info("신규 카카오 회원 가입 진행");
+
+        String email = resolveEmail(userInfo.getEmail(), providerId);
+
+        if (memberRepository.existsByEmail(email)) {
+            log.warn("이메일 중복으로 카카오 회원가입 실패 - email: {}", email);
+            throw new IllegalStateException("이미 동일한 이메일로 가입된 계정이 존재합니다. 기존 방식으로 로그인해주세요.");
+        }
+
+        return Member.builder()
+                .email(email)
+                .nickname(
+                        userInfo.getNickname() != null && !userInfo.getNickname().isBlank()
+                                ? userInfo.getNickname()
+                                : "카카오유저"
+                )
+                .profileImageUrl(userInfo.getImageUrl())
+                .role(Role.USER)
+                .socialType(SocialType.KAKAO)
+                .socialId(providerId)
+                .password(passwordEncoder.encode(DEFAULT_SOCIAL_PASSWORD))
+                .build();
+    }
+
+    private String resolveEmail(String kakaoEmail, String providerId) {
+        if (kakaoEmail != null && !kakaoEmail.isBlank()) {
+            return kakaoEmail;
+        }
+        return "kakao_" + providerId + "@kakao.local";
     }
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> fetchKakaoUserMe(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(MediaType.parseMediaTypes(MediaType.APPLICATION_JSON_VALUE));
+
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
         try {
@@ -92,12 +132,19 @@ public class KakaoNativeLoginService {
                     entity,
                     Map.class
             );
+
             if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
                 return (Map<String, Object>) response.getBody();
             }
+
+            log.error("Kakao /v2/user/me 응답 이상 - status: {}", response.getStatusCode());
+            throw new IllegalStateException("카카오 사용자 정보 조회에 실패했습니다.");
+        } catch (HttpClientErrorException.Unauthorized | HttpClientErrorException.Forbidden e) {
+            log.warn("유효하지 않은 카카오 토큰 - status: {}", e.getStatusCode());
+            throw new IllegalArgumentException("카카오 토큰이 유효하지 않거나 만료되었습니다.");
         } catch (RestClientException e) {
-            log.warn("Kakao /v2/user/me failed: {}", e.getMessage());
+            log.error("Kakao /v2/user/me API 호출 중 통신 오류", e);
+            throw new IllegalStateException("카카오 서버와 통신 중 오류가 발생했습니다.");
         }
-        throw new IllegalArgumentException("카카오 토큰이 유효하지 않거나 만료되었습니다.");
     }
 }

--- a/backend/src/main/java/com/dailo/backend/service/MemberService.java
+++ b/backend/src/main/java/com/dailo/backend/service/MemberService.java
@@ -16,17 +16,15 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final S3UploadService s3UploadService;
 
-    // 내 정보 조회
-    public MemberResponseDto getMyProfile(String email) { // 💡 파라미터 변경
-        Member member = memberRepository.findByEmail(email) // 💡 이메일로 조회
+    public MemberResponseDto getMyProfile(String email) {
+        Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("회원 정보가 없습니다."));
 
         return createDtoWithPresignedUrl(member);
     }
 
-    // 프로필 수정
     @Transactional
-    public MemberResponseDto updateProfile(String email, MemberUpdateRequestDto request) { // 💡 파라미터 변경
+    public MemberResponseDto updateProfile(String email, MemberUpdateRequestDto request) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("회원 정보가 없습니다."));
 
@@ -41,7 +39,6 @@ public class MemberService {
         return createDtoWithPresignedUrl(member);
     }
 
-    // 이미지 전용 업데이트
     @Transactional
     public void updateProfileImage(String email, String imageKey) {
         Member member = memberRepository.findByEmail(email)
@@ -50,7 +47,6 @@ public class MemberService {
         member.updateProfile(member.getNickname(), imageKey);
     }
 
-    // 회원 탈퇴
     @Transactional
     public void withdraw(String email) {
         Member member = memberRepository.findByEmail(email)
@@ -58,12 +54,10 @@ public class MemberService {
         member.withdraw();
     }
 
-    // 닉네임 중복 체크
     public boolean checkNicknameDuplicate(String nickname) {
         return memberRepository.existsByNickname(nickname);
     }
 
-    /** id=1 회원 닉네임이 비어 있으면 "회원1"로 설정 */
     @Transactional
     public void ensureMember1Nickname() {
         memberRepository.findById(1L).ifPresent(m -> {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -54,8 +54,9 @@ spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
-spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
-spring.security.oauth2.client.registration.kakao.scope=profile_nickname, profile_image
+#spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.kakao.redirect-uri=https://dailoapp.com/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image
 
 # 2. ??? API ?? ?? (??? ??? ??)
 spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
## 개요
카카오 네이티브 로그인 JWT subject를 이메일 기준으로 수정하고, JWT 인증 흐름과 회원 조회 로직을 정리했습니다.

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
카카오 네이티브 로그인 JWT subject를 memberId → email 기준으로 수정
JwtFilter 인증 로직 이메일 기준으로 정리
KakaoUserInfo 응답 파싱 안정성 개선
OAuth2 회원 생성/로그인 로직 정리


## 체크리스트

빌드가 에러 없이 수행되는가?
불필요한 로그(console.log 등)는 없는가?
