### PR TITLE
fix: add Android Play Store CD and update Terraform secret mappings

### DIFF
--- a/.github/workflows/android-playstore-deploy.yml
+++ b/.github/workflows/android-playstore-deploy.yml
@@ -1,0 +1,118 @@
+name: "CD: Android Play Store"
+
+on:
+  # Actions 탭에서 수동으로 실행할 수 있는 배포 트리거
+  workflow_dispatch:
+    inputs:
+      # 어느 Play Console 트랙으로 올릴지 선택
+      track:
+        description: "Play Console release track"
+        required: true
+        default: "internal"
+        type: choice
+        options:
+          - internal
+          - beta
+          - production
+      # 필요할 때만 versionName을 직접 덮어쓰기
+      version_name:
+        description: "Optional versionName override"
+        required: false
+        type: string
+  # main 브랜치에 프론트 변경이 들어오면 internal 트랙 기준으로 자동 배포
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/android-playstore-deploy.yml"
+
+permissions:
+  # 저장소 코드 읽기만 필요
+  contents: read
+
+jobs:
+  deploy-android:
+    name: Build AAB and Upload to Play
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      # 1) 저장소 코드를 러너로 가져옴
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 2) Expo/React Native 빌드에 필요한 Node.js 설치
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # 3) Android Gradle 빌드에 필요한 JDK 설치
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      # 4) package-lock.json 기준으로 프론트 의존성 설치
+      - name: Install dependencies
+        run: npm ci
+
+      # 5) 이후 스텝에서 공통으로 쓸 환경변수 설정
+      #    - keystore 경로
+      #    - 서명 비밀번호/alias
+      #    - Android versionCode/versionName
+      #    - Play 업로드 트랙
+      - name: Set release metadata
+        run: |
+          echo "STORE_FILE=$GITHUB_WORKSPACE/frontend/android/app/release-keystore.jks" >> "$GITHUB_ENV"
+          echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> "$GITHUB_ENV"
+          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "ANDROID_VERSION_CODE=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version_name }}" ]; then
+            echo "ANDROID_VERSION_NAME=${{ github.event.inputs.version_name }}" >> "$GITHUB_ENV"
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.track }}" ]; then
+            echo "PLAY_TRACK=${{ github.event.inputs.track }}" >> "$GITHUB_ENV"
+          else
+            echo "PLAY_TRACK=internal" >> "$GITHUB_ENV"
+          fi
+
+      # 6) Git에 없는 android/ 폴더를 Expo prebuild로 생성
+      - name: Generate Android project with Expo prebuild
+        run: npx expo prebuild --platform android --non-interactive
+
+      # 7) prebuild로 생성된 build.gradle에 release signing 설정 주입
+      - name: Configure Android release signing
+        run: node ./scripts/configure-android-release.js
+
+      # 8) GitHub Secret에 저장한 Base64 keystore를 실제 .jks 파일로 복원
+      - name: Restore Android keystore
+        run: printf '%s' '${{ secrets.KEYSTORE_BASE64 }}' | base64 --decode > "$STORE_FILE"
+
+      # 9) gradlew 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        working-directory: ./frontend/android
+        run: chmod +x gradlew
+
+      # 10) release 서명으로 Play 업로드용 .aab 생성
+      - name: Build release AAB
+        working-directory: ./frontend/android
+        run: ./gradlew bundleRelease
+
+      # 11) 생성된 .aab를 선택한 Play Console 트랙으로 업로드
+      - name: Upload AAB to Play Console
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.knut.dailo
+          releaseFiles: ./frontend/android/app/build/outputs/bundle/release/app-release.aab
+          track: ${{ env.PLAY_TRACK }}
+          status: completed

--- a/.github/workflows/destroy-prod.yml
+++ b/.github/workflows/destroy-prod.yml
@@ -50,11 +50,14 @@ jobs:
       # 5) Terraform Destroy 실행
       - name: Terraform Destroy
         env:
-          TF_VAR_db_password: ${{ secrets.TF_VAR_db_password }} 
+          TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}
           TF_VAR_discord_webhook_url: ${{ secrets.TF_VAR_DISCORD_WEBHOOK_URL }}
           TF_VAR_grafana_admin_password: ${{ secrets.TF_VAR_GRAFANA_ADMIN_PASSWORD }}
           TF_VAR_alb_verify_secret: ${{ secrets.TF_VAR_ALB_VERIFY_SECRET }}
           TF_VAR_MAIL_PASSWORD: ${{ secrets.TF_VAR_MAIL_PASSWORD }}
           TF_VAR_kakao_client_secret: ${{ secrets.TF_VAR_KAKAO_CLIENT_SECRET }}
+          TF_VAR_kakao_client_id: ${{ secrets.TF_VAR_KAKAO_CLIENT_ID }}
           TF_VAR_jwt_secret: ${{ secrets.TF_VAR_JWT_SECRET }}
+          TF_VAR_mail_from: ${{ secrets.TF_VAR_MAIL_FROM }}
+          TF_VAR_mail_username: ${{ secrets.TF_VAR_MAIL_USERNAME }}
         run: terraform destroy -auto-approve

--- a/.github/workflows/terraform-prod.yml
+++ b/.github/workflows/terraform-prod.yml
@@ -58,24 +58,30 @@ jobs:
       - name: Terraform Plan
         if: github.event_name == 'pull_request'
         env:
-          TF_VAR_db_password: ${{ secrets.TF_VAR_db_password }} 
+          TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}
           TF_VAR_discord_webhook_url: ${{ secrets.TF_VAR_DISCORD_WEBHOOK_URL }}
           TF_VAR_grafana_admin_password: ${{ secrets.TF_VAR_GRAFANA_ADMIN_PASSWORD }}
           TF_VAR_alb_verify_secret: ${{ secrets.TF_VAR_ALB_VERIFY_SECRET }}
           TF_VAR_MAIL_PASSWORD: ${{ secrets.TF_VAR_MAIL_PASSWORD }}
           TF_VAR_kakao_client_secret: ${{ secrets.TF_VAR_KAKAO_CLIENT_SECRET }}
+          TF_VAR_kakao_client_id: ${{ secrets.TF_VAR_KAKAO_CLIENT_ID }}
           TF_VAR_jwt_secret: ${{ secrets.TF_VAR_JWT_SECRET }}
+          TF_VAR_mail_from: ${{ secrets.TF_VAR_MAIL_FROM }}
+          TF_VAR_mail_username: ${{ secrets.TF_VAR_MAIL_USERNAME }}
         run: terraform plan -no-color
 
       # 5) main push에서는 Apply 실행
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         env:
-          TF_VAR_db_password: ${{ secrets.TF_VAR_db_password }}
+          TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}
           TF_VAR_discord_webhook_url: ${{ secrets.TF_VAR_DISCORD_WEBHOOK_URL }}
           TF_VAR_grafana_admin_password: ${{ secrets.TF_VAR_GRAFANA_ADMIN_PASSWORD }}
           TF_VAR_alb_verify_secret: ${{ secrets.TF_VAR_ALB_VERIFY_SECRET }}
           TF_VAR_MAIL_PASSWORD: ${{ secrets.TF_VAR_MAIL_PASSWORD }}
           TF_VAR_kakao_client_secret: ${{ secrets.TF_VAR_KAKAO_CLIENT_SECRET }}
+          TF_VAR_kakao_client_id: ${{ secrets.TF_VAR_KAKAO_CLIENT_ID }}
           TF_VAR_jwt_secret: ${{ secrets.TF_VAR_JWT_SECRET }}
+          TF_VAR_mail_from: ${{ secrets.TF_VAR_MAIL_FROM }}
+          TF_VAR_mail_username: ${{ secrets.TF_VAR_MAIL_USERNAME }}
         run: terraform apply -auto-approve

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -1,0 +1,17 @@
+const { expo } = require("./app.json");
+
+const parsedVersionCode = Number.parseInt(
+  process.env.ANDROID_VERSION_CODE ?? expo.android?.versionCode ?? "1",
+  10
+);
+
+module.exports = {
+  expo: {
+    ...expo,
+    version: process.env.ANDROID_VERSION_NAME ?? expo.version,
+    android: {
+      ...expo.android,
+      versionCode: Number.isNaN(parsedVersionCode) ? 1 : parsedVersionCode,
+    },
+  },
+};

--- a/frontend/scripts/configure-android-release.js
+++ b/frontend/scripts/configure-android-release.js
@@ -1,0 +1,82 @@
+const fs = require("fs");
+const path = require("path");
+
+const buildGradlePath = path.resolve(
+  process.cwd(),
+  "android",
+  "app",
+  "build.gradle"
+);
+
+let source = fs.readFileSync(buildGradlePath, "utf8");
+
+const replaceOnce = (pattern, replacement, label) => {
+  if (!pattern.test(source)) {
+    throw new Error(`Could not update ${label} in ${buildGradlePath}`);
+  }
+
+  source = source.replace(pattern, replacement);
+};
+
+if (!source.includes('def releaseStoreFile = System.getenv("STORE_FILE")')) {
+  replaceOnce(
+    /def enableMinifyInReleaseBuilds = \(findProperty\('android\.enableMinifyInReleaseBuilds'\) \?: false\)\.toBoolean\(\)\n/,
+    `$&def releaseStoreFile = System.getenv("STORE_FILE")\n` +
+      `def releaseStorePassword = System.getenv("KEYSTORE_PASSWORD")\n` +
+      `def releaseKeyAlias = System.getenv("KEY_ALIAS")\n` +
+      `def releaseKeyPassword = System.getenv("KEY_PASSWORD")\n`,
+    "release signing environment variables"
+  );
+}
+
+if (!source.includes("signingConfigs.release")) {
+  replaceOnce(
+    /signingConfigs \{\n(\s*debug \{[\s\S]*?\n\s*\})\n\s*\}/,
+    `signingConfigs {\n$1\n` +
+      `        release {\n` +
+      `            if (releaseStoreFile != null) {\n` +
+      `                storeFile file(releaseStoreFile)\n` +
+      `                storePassword releaseStorePassword\n` +
+      `                keyAlias releaseKeyAlias\n` +
+      `                keyPassword releaseKeyPassword\n` +
+      `            }\n` +
+      `        }\n` +
+      `    }`,
+    "release signing config"
+  );
+}
+
+if (!source.includes("signingConfig signingConfigs.release")) {
+  replaceOnce(
+    /buildTypes \{[\s\S]*?release \{[\s\S]*?signingConfig signingConfigs\.debug/,
+    (match) =>
+      match.replace(
+        "signingConfig signingConfigs.debug",
+        "signingConfig signingConfigs.release"
+      ),
+    "release build type signing config"
+  );
+}
+
+if (!source.includes("Missing Android release signing env vars")) {
+  replaceOnce(
+    /\/\/ Apply static values from `gradle\.properties` to the `android\.packagingOptions`/,
+    `gradle.taskGraph.whenReady { taskGraph ->\n` +
+      `    if (!taskGraph.allTasks.any { it.name.toLowerCase().contains("release") }) {\n` +
+      `        return\n` +
+      `    }\n\n` +
+      `    def missing = []\n` +
+      `    if (!releaseStoreFile) missing << "STORE_FILE"\n` +
+      `    if (!releaseStorePassword) missing << "KEYSTORE_PASSWORD"\n` +
+      `    if (!releaseKeyAlias) missing << "KEY_ALIAS"\n` +
+      `    if (!releaseKeyPassword) missing << "KEY_PASSWORD"\n\n` +
+      `    if (!missing.isEmpty()) {\n` +
+      `        throw new GradleException("Missing Android release signing env vars: \\${missing.join(', ')}")\n` +
+      `    }\n` +
+      `}\n\n` +
+      `// Apply static values from \`gradle.properties\` to the \`android.packagingOptions\``,
+    "release signing validation"
+  );
+}
+
+fs.writeFileSync(buildGradlePath, source);

--- a/infra/terraform/live/prod/main.tf
+++ b/infra/terraform/live/prod/main.tf
@@ -74,7 +74,7 @@ resource "aws_ssm_parameter" "jwt_secret" {
 # 1. VPC 모듈
 # ------------------------------------------------------------------------------
 module "vpc" {
-  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/vpc?ref=v0.1.0"
+  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/vpc?ref=v0.1.3"
 
   name     = local.name
   region   = "ap-northeast-2"
@@ -94,7 +94,7 @@ module "vpc" {
 # 2. ecs 모듈
 # ------------------------------------------------------------------------------
 module "ecs" {
-  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/ecs?ref=v0.1.0"
+  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/ecs?ref=v0.1.3"
 
   name   = local.name
   region = "ap-northeast-2" # CloudWatch 로그 등을 위해 사용
@@ -145,9 +145,9 @@ module "ecs" {
     },
     { name = "MAIL_HOST", value = "smtp.gmail.com" },
     { name = "MAIL_PORT", value = "587" },
-    { name = "MAIL_USERNAME", value = "dailoappco@gmail.com" },
-    { name = "MAIL_FROM", value = "dailoappco@gmail.com" },
-    { name = "KAKAO_CLIENT_ID", value = "c031f9a2eed5d03cdde3d299d0babc48" },
+    { name = "MAIL_USERNAME", value = var.mail_username },
+    { name = "MAIL_FROM", value = var.mail_from },
+    { name = "KAKAO_CLIENT_ID", value = var.kakao_client_id },
   ]
     container_secrets = [
     {
@@ -176,7 +176,7 @@ module "ecs" {
 # 3. RDS 모듈
 # ------------------------------------------------------------------------------
 module "rds" {
-  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/rds?ref=v0.1.0"
+  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/rds?ref=v0.1.3"
 
   name   = local.name
   vpc_id = module.vpc.vpc_id
@@ -201,7 +201,7 @@ module "rds" {
 # 4. cdn 모듈
 # ------------------------------------------------------------------------------
 module "cdn" {
-  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/cdn?ref=v0.1.0"
+  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/cdn?ref=v0.1.3"
   
   name        = local.name
   bucket_name = local.static_bucket_name
@@ -220,7 +220,7 @@ module "cdn" {
 # 5. Monitoring (Grafana) 모듈 테스트
 # ------------------------------------------------------------------------------
 module "monitoring" {
-  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/monitoring?ref=v0.1.0" 
+  source = "git::https://github.com/yuntyu01/terraform-aws-modules.git//modules/monitoring?ref=v0.1.3" 
 
   name   = local.name   
   region = "ap-northeast-2"

--- a/infra/terraform/live/prod/variables.tf
+++ b/infra/terraform/live/prod/variables.tf
@@ -26,12 +26,24 @@ variable "MAIL_PASSWORD" {
   sensitive   = true 
 }
 variable "kakao_client_secret" {
-  description = "oauth2.0 kakao"
+  description = "oauth2.0 kakao secret"
+  type        = string
+  sensitive   = true 
+}
+variable "kakao_client_id" {
   type        = string
   sensitive   = true 
 }
 variable "jwt_secret" {
   description = "jwt_secret"
+  type        = string
+  sensitive   = true 
+}
+variable "mail_from" {
+  type        = string
+  sensitive   = true 
+}
+variable "mail_username" {
   type        = string
   sensitive   = true 
 }


### PR DESCRIPTION
## 개요

  Android 앱을 GitHub Actions로 .aab 빌드 후 Play Console에 업로드할 수 있도록 CI/CD를 추가했고, prod
  Terraform 워크플로우에 신규 환경변수 secret 매핑을 반영했습니다.

  ## 관련 이슈

  - Refs #이슈번호

  ## 작업 내용

  - [x] Android Play Store 배포용 GitHub Actions 워크플로우 추가
  - [x] Expo prebuild 기반 Android release signing 설정 자동화
  - [x] prod Terraform workflow에 mail_username, mail_from, kakao_client_id secret 매핑 추가
  - [x] 기존 Terraform secret 참조 대소문자 불일치 정리

  ## 체크리스트

  - [ ] 빌드가 에러 없이 수행되는가?
  - [x] 불필요한 로그(console.log 등)는 없는가?