### PR TITLE
feat: Playstore CD 파이프라인 브랜치별 트랙 자동 분기

### DIFF
--- a/.github/workflows/android-playstore-deploy.yml
+++ b/.github/workflows/android-playstore-deploy.yml
@@ -1,10 +1,9 @@
 name: "CD: Android Play Store"
 
 on:
-  # Actions 탭에서 수동으로 실행할 수 있는 배포 트리거
+  # 수동 실행 트리거
   workflow_dispatch:
     inputs:
-      # 어느 Play Console 트랙으로 올릴지 선택
       track:
         description: "Play Console release track"
         required: true
@@ -15,21 +14,20 @@ on:
           - internal
           - beta
           - production
-      # 필요할 때만 versionName을 직접 덮어쓰기
       version_name:
         description: "Optional versionName override"
         required: false
         type: string
-  # main 브랜치에 프론트 변경이 들어오면 internal 트랙 기준으로 자동 배포
+  # stage나 main 브랜치에 푸시될 때 자동 실행
   push:
     branches:
+      - stage
       - main
     paths:
       - "frontend/**"
       - ".github/workflows/android-playstore-deploy.yml"
 
 permissions:
-  # 저장소 코드 읽기만 필요
   contents: read
 
 jobs:
@@ -41,11 +39,9 @@ jobs:
         working-directory: ./frontend
 
     steps:
-      # 1) 저장소 코드를 러너로 가져옴
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 2) Expo/React Native 빌드에 필요한 Node.js 설치
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -53,7 +49,6 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      # 3) Android Gradle 빌드에 필요한 JDK 설치
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -61,15 +56,12 @@ jobs:
           java-version: "17"
           cache: gradle
 
-      # 4) package-lock.json 기준으로 프론트 의존성 설치
       - name: Install dependencies
         run: npm ci
 
-      # 5) 이후 스텝에서 공통으로 쓸 환경변수 설정
-      #    - keystore 경로
-      #    - 서명 비밀번호/alias
-      #    - Android versionCode/versionName
-      #    - Play 업로드 트랙
+      # 브랜치 이름에 따라 트랙을 동적으로 배포
+      # main: 비공개 테스트(alpha)
+      # stage: 내부 테스트(internal)
       - name: Set release metadata
         run: |
           echo "STORE_FILE=$GITHUB_WORKSPACE/frontend/android/app/release-keystore.jks" >> "$GITHUB_ENV"
@@ -77,38 +69,45 @@ jobs:
           echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> "$GITHUB_ENV"
           echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> "$GITHUB_ENV"
           echo "ANDROID_VERSION_CODE=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+          
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version_name }}" ]; then
             echo "ANDROID_VERSION_NAME=${{ github.event.inputs.version_name }}" >> "$GITHUB_ENV"
           fi
+          
+          # 1) 수동 실행(workflow_dispatch)일 경우 -> 사람이 선택한 트랙
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.track }}" ]; then
             echo "PLAY_TRACK=${{ github.event.inputs.track }}" >> "$GITHUB_ENV"
+            
+          # 2) main 브랜치 푸시일 경우 -> alpha 트랙 (비공개 테스트)
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "PLAY_TRACK=alpha" >> "$GITHUB_ENV"
+            
+          # 3) stage 브랜치 푸시일 경우 -> internal 트랙 (내부 테스트)
+          elif [ "${{ github.ref }}" = "refs/heads/stage" ]; then
+            echo "PLAY_TRACK=internal" >> "$GITHUB_ENV"
+            
+          # 4) 혹시 모를 예외 상황 방어용 기본값
           else
             echo "PLAY_TRACK=internal" >> "$GITHUB_ENV"
           fi
 
-      # 6) Git에 없는 android/ 폴더를 Expo prebuild로 생성
       - name: Generate Android project with Expo prebuild
         run: npx expo prebuild --platform android --non-interactive
 
-      # 7) prebuild로 생성된 build.gradle에 release signing 설정 주입
       - name: Configure Android release signing
         run: node ./scripts/configure-android-release.js
 
-      # 8) GitHub Secret에 저장한 Base64 keystore를 실제 .jks 파일로 복원
       - name: Restore Android keystore
         run: printf '%s' '${{ secrets.KEYSTORE_BASE64 }}' | base64 --decode > "$STORE_FILE"
 
-      # 9) gradlew 실행 권한 부여
       - name: Grant execute permission for gradlew
         working-directory: ./frontend/android
         run: chmod +x gradlew
 
-      # 10) release 서명으로 Play 업로드용 .aab 생성
       - name: Build release AAB
         working-directory: ./frontend/android
         run: ./gradlew bundleRelease
 
-      # 11) 생성된 .aab를 선택한 Play Console 트랙으로 업로드
       - name: Upload AAB to Play Console
         uses: r0adkll/upload-google-play@v1
         with:


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->
CD 배포 파이프라인을 단일 워크플로우로 병합하고, 브랜치(stage, main)에 따라 Google Play 배포 트랙(internal, alpha)이 자동으로 지정되도록 동적 라우팅 로직을 추가했습니다.
워크플로우 파일을 분리할 경우 GITHUB_RUN_NUMBER가 개별 카운트되어 구글 플레이 업로드 시 versionCode 충돌이 발생하는 치명적인 구조적 결함을 해결하기 위한 선제적 조치입니다.

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->
- [x] 배포 워크플로우 단일 파일 통합: stage와 main 배포가 하나의 GITHUB_RUN_NUMBER를 공유하도록 강제하여 버전 코드 충돌 예방
- [x] 브랜치별 배포 트랙 자동 분기 구현: - stage 브랜치 Push -> internal (내부 테스트) 배포
- [x] 수동 배포 기능 유지: workflow_dispatch 실행 시 사람이 직접 트랙(alpha, internal 등)과 versionName을 선택해 덮어쓸 수 있도록 예외 처리

## 체크리스트
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
