### PR TITLE
fix: app name change "dailo" -> "다일로"

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Dailo",
+    "name": "다일로",
     "slug": "app",
     "version": "1.0.0",
     "orientation": "portrait",


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->
앱 이름 dailo라하면 사람들이 읽는 방법 모를 거 같아서 다일로로 변경했습니다 
