### PR TITLE
[FEAT/FIX] 토큰 재발급 로직 개선, 타 사용자 댓글 조회 추가 및 UI/UX 전반 수정

### DIFF
--- a/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
@@ -103,6 +103,8 @@ public class SecurityConfig {
 
                         // 타 사용자 프로필 조회는 공개 (숫자 ID만 매칭)
                         .requestMatchers(HttpMethod.GET, "/api/members/{id:\\d+}").permitAll()
+                        // 타 사용자 댓글 목록 조회는 공개
+                        .requestMatchers(HttpMethod.GET, "/api/members/{id:\\d+}/comments").permitAll()
                         // 나머지 회원 API는 인증 필요
                         .requestMatchers("/api/members/**").authenticated()
 

--- a/backend/src/main/java/com/dailo/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.dailo.backend.dto.auth.KakaoNativeLoginRequestDto;
 import com.dailo.backend.dto.auth.LoginRequestDto;
 import com.dailo.backend.dto.auth.MemberRequestDto;
 import com.dailo.backend.dto.auth.MemberResponseDto;
+import com.dailo.backend.dto.auth.TokenRequestDto;
 import com.dailo.backend.jwt.TokenDto;
 import com.dailo.backend.service.AuthService;
 import com.dailo.backend.service.KakaoNativeLoginService;
@@ -71,9 +72,9 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "토큰 재발급", description = "만료된 Access Token과 Refresh Token을 보내 새로운 토큰 셋을 발급받습니다.")
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 보내 새로운 토큰 셋을 발급받습니다.")
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto> reissue(@RequestBody com.dailo.backend.dto.auth.TokenRequestDto requestDto) {
+    public ResponseEntity<TokenDto> reissue(@RequestBody TokenRequestDto requestDto) {
         return ResponseEntity.ok(authService.reissue(requestDto));
     }
 

--- a/backend/src/main/java/com/dailo/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/CommentController.java
@@ -81,4 +81,16 @@ public class CommentController {
         int likeCount = commentService.getCommentLikeCount(id);
         return ResponseEntity.ok(java.util.Map.of("liked", liked, "likeCount", likeCount));
     }
+
+    // 6. 특정 사용자의 댓글 목록 조회 (공개)
+    @GetMapping("/members/{memberId}/comments")
+    public Page<CommentResponseDto> getCommentsByMemberId(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        String email = SecurityUtil.getCurrentMemberEmail();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return commentService.getCommentsByMemberId(memberId, email, pageable);
+    }
 }

--- a/backend/src/main/java/com/dailo/backend/dto/CommentResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/CommentResponseDto.java
@@ -18,6 +18,8 @@ public class CommentResponseDto {
 
     private Long id;
     private Long postId;
+    /** 게시글 제목 (사용자별 댓글 목록 조회 시 사용) */
+    private String postTitle;
     private Long parentCommentId;
     private Long authorId;
     /** 댓글 작성자 닉네임 (표시용) */

--- a/backend/src/main/java/com/dailo/backend/dto/auth/TokenRequestDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/auth/TokenRequestDto.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class TokenRequestDto {
-    private String accessToken;
+
+    // 재발급은 refresh token만 받도록 단순화
     private String refreshToken;
 }

--- a/backend/src/main/java/com/dailo/backend/dto/event/EventDetailResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/event/EventDetailResponse.java
@@ -19,7 +19,10 @@ import java.util.List;
 public class EventDetailResponse {
     private Long id;
     private String title;
-    private List<String> posterUrls;     // 포스터 이미지 리스트
+    /** 대표 썸네일(리스트·지도·상세 상단 공통) */
+    private String thumbnailUrl;
+    /** 상세 포스터 이미지 리스트 (0번 = 대표 썸네일) */
+    private List<String> posterUrls;
     private LocalDateTime startAt;       // 시작 일시
     private LocalDateTime endAt;         // 종료 일시
     private String placeName;            // 장소명
@@ -69,10 +72,27 @@ public class EventDetailResponse {
             }
         }
 
+        // 대표 썸네일
+        String thumb = event.getThumbnailUrl();
+
+        // 포스터 리스트: 0번에 대표 썸네일을 두고, 나머지 고화질 포스터를 뒤에 이어 붙인다.
+        List<String> posters = new java.util.ArrayList<>();
+        if (thumb != null && !thumb.isBlank()) {
+            posters.add(thumb);
+        }
+        if (event.getPosterUrls() != null) {
+            for (String url : event.getPosterUrls()) {
+                if (url != null && !url.isBlank() && !url.equals(thumb)) {
+                    posters.add(url);
+                }
+            }
+        }
+
         return EventDetailResponse.builder()
                 .id(event.getId())
                 .title(event.getTitle())
-                .posterUrls(event.getPosterUrls())
+                .thumbnailUrl(thumb)
+                .posterUrls(posters)
                 .startAt(event.getStartAt())
                 .endAt(event.getEndAt())
                 .placeName(event.getPlaceName())
@@ -94,6 +114,7 @@ public class EventDetailResponse {
         return EventDetailResponse.builder()
                 .id(base.getId())
                 .title(base.getTitle())
+                .thumbnailUrl(base.getThumbnailUrl())
                 .posterUrls(base.getPosterUrls())
                 .startAt(base.getStartAt())
                 .endAt(base.getEndAt())

--- a/backend/src/main/java/com/dailo/backend/entity/RefreshToken.java
+++ b/backend/src/main/java/com/dailo/backend/entity/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.dailo.backend.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.Builder;
@@ -14,7 +15,8 @@ public class RefreshToken {
     @Id
     private String keyId; // 유저의 ID (이메일 또는 고유번호)
 
-    private String value; // Refresh Token 문자열
+    @Column(nullable = false, length = 1000)
+    private String value;
 
     @Builder
     public RefreshToken(String keyId, String value) {

--- a/backend/src/main/java/com/dailo/backend/jwt/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/dailo/backend/jwt/OAuth2SuccessHandler.java
@@ -1,7 +1,10 @@
 package com.dailo.backend.jwt;
 
+import com.dailo.backend.domain.enums.SocialType;
 import com.dailo.backend.entity.Member;
+import com.dailo.backend.entity.RefreshToken;
 import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.repository.RefreshTokenRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,6 +18,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository; // ㄱ 수정
 
     @Override
     public void onAuthenticationSuccess(
@@ -34,7 +39,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        // Kakao는 user-name-attribute=id로 설정되어 있으니 attributes에서 id를 꺼낼 수 있음
         Object kakaoIdObj = oAuth2User.getAttributes().get("id");
         String kakaoId = kakaoIdObj != null ? String.valueOf(kakaoIdObj) : null;
 
@@ -44,24 +48,28 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             return;
         }
 
-        Member member = memberRepository.findBySocialTypeAndSocialId(
-                com.dailo.backend.domain.enums.SocialType.KAKAO, kakaoId
-        ).orElseThrow(() -> new IllegalStateException("Member not found for kakaoId=" + kakaoId));;
+        Member member = memberRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, kakaoId)
+                .orElseThrow(() -> new IllegalStateException("Member not found for kakaoId=" + kakaoId));
 
         TokenDto tokenDto = tokenProvider.generateTokenDtoForMember(
-                String.valueOf(member.getId()),
+                member.getEmail(),
                 member.getRole().name()
         );
 
-        // 모바일 앱 딥링크로 리다이렉트 (Expo app.json의 scheme = "app")
+        RefreshToken refreshToken = RefreshToken.builder()
+                .keyId(member.getEmail())
+                .value(tokenDto.getRefreshToken())
+                .build();
+        refreshTokenRepository.save(refreshToken);
+
         String accessToken = URLEncoder.encode(tokenDto.getAccessToken(), StandardCharsets.UTF_8);
-        String refreshToken = URLEncoder.encode(tokenDto.getRefreshToken(), StandardCharsets.UTF_8);
+        String refreshTokenValue = URLEncoder.encode(tokenDto.getRefreshToken(), StandardCharsets.UTF_8);
         long expiresIn = tokenDto.getAccessTokenExpiresIn();
 
         String redirectUrl = String.format(
                 "app://kakao-login?accessToken=%s&refreshToken=%s&accessTokenExpiresIn=%d",
                 accessToken,
-                refreshToken,
+                refreshTokenValue,
                 expiresIn
         );
 

--- a/backend/src/main/java/com/dailo/backend/jwt/TokenProvider.java
+++ b/backend/src/main/java/com/dailo/backend/jwt/TokenProvider.java
@@ -50,7 +50,9 @@ public class TokenProvider {
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
 
+        //  refresh token에도 subject 저장
         String refreshToken = Jwts.builder()
+                .setSubject(authentication.getName())
                 .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
@@ -75,7 +77,9 @@ public class TokenProvider {
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
 
+        // refresh token에도 subject 저장
         String refreshToken = Jwts.builder()
+                .setSubject(subject)
                 .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
@@ -103,6 +107,11 @@ public class TokenProvider {
         UserDetails principal = new User(claims.getSubject(), "", authorities);
 
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // refresh token에서 subject(email) 꺼내는 메서드 추가
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
     }
 
     public boolean validateToken(String token) {

--- a/backend/src/main/java/com/dailo/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/CommentRepository.java
@@ -28,6 +28,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 작성자별 댓글 조회
     Page<Comment> findByAuthorId(Long authorId, Pageable pageable);
 
+    // 작성자별 댓글 조회 (삭제되지 않은 것만)
+    Page<Comment> findByAuthorIdAndDeletedAtIsNull(Long authorId, Pageable pageable);
+
     // 게시글별 댓글 수 조회
     long countByPost(Post post);
 

--- a/backend/src/main/java/com/dailo/backend/service/AuthService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AuthService.java
@@ -50,7 +50,7 @@ public class AuthService {
             throw new ConflictException("이미 가입된 이메일입니다.");
         }
 
-        String rawToken = emailTokenService.issueVerifyEmailToken(email);        // 메일 발송
+        String rawToken = emailTokenService.issueVerifyEmailToken(email);
         mailService.sendVerifyEmail(email, rawToken);
     }
 
@@ -63,23 +63,19 @@ public class AuthService {
 
         String email = requestDto.getEmail();
 
-        // 중복 가입 방어
         if (memberRepository.existsByEmail(email)) {
             throw new ConflictException("이미 가입된 이메일입니다.");
         }
 
-        // 💡 프론트에서 넘어온 인증번호(authCode)를 검증하고 사용 처리
         EmailToken token = emailTokenService.consumeValidToken(
                 requestDto.getAuthCode(),
                 EmailTokenType.VERIFY_EMAIL
         );
 
-        // 보안 검증
         if (!token.getEmail().equals(email)) {
             throw new IllegalArgumentException("인증된 이메일과 가입 요청 이메일이 일치하지 않습니다.");
         }
 
-        // 검증 통과 시 대기 상태(PENDING) 없이 즉시 정상 회원으로 변환 및 저장
         Member member = requestDto.toMember(passwordEncoder);
         Member saved = memberRepository.save(member);
 
@@ -110,7 +106,6 @@ public class AuthService {
             Authentication auth = authenticationManagerBuilder.getObject().authenticate(token);
             TokenDto tokenDto = tokenProvider.generateTokenDto(auth);
 
-            // 로그인 성공 시 Refresh Token을 DB에 저장
             RefreshToken refreshToken = RefreshToken.builder()
                     .keyId(auth.getName())
                     .value(tokenDto.getRefreshToken())
@@ -133,7 +128,6 @@ public class AuthService {
 
         Member member = memberRepository.findByEmail(email).orElse(null);
 
-        // 보안상 동일 응답
         if (member == null || member.getStatus() == MemberStatus.DELETED) {
             return;
         }
@@ -142,7 +136,6 @@ public class AuthService {
             return;
         }
 
-        // 기존 회원이므로 member 객체와 email을 함께 넘겨서 발급
         String rawToken = emailTokenService.issueResetPasswordToken(member);
         mailService.sendResetPasswordEmail(email, rawToken);
     }
@@ -177,28 +170,37 @@ public class AuthService {
      =========================== */
     @Transactional
     public TokenDto reissue(TokenRequestDto tokenRequestDto) {
-        // Refresh Token이 유효한지 검증
-        if (!tokenProvider.validateToken(tokenRequestDto.getRefreshToken())) {
-            throw new RuntimeException("Refresh Token이 유효하지 않습니다.");
+        // refresh token만으로 재발급 가능하게 변경
+        String requestRefreshToken = tokenRequestDto.getRefreshToken();
+
+        if (!tokenProvider.validateToken(requestRefreshToken)) {
+            throw new BadCredentialsException("Refresh Token이 유효하지 않습니다.");
         }
 
-        // 만료된 Access Token에서 유저 정보(Authentication) 가져오기
-        Authentication authentication = tokenProvider.getAuthentication(tokenRequestDto.getAccessToken());
+        //  refresh token의 subject(email) 추출
+        String email = tokenProvider.getSubject(requestRefreshToken);
 
-        // DB에서 유저 ID(이름)를 기반으로 저장된 Refresh Token 값 가져오기
-        RefreshToken refreshToken = refreshTokenRepository.findById(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다."));
+        //  DB에 저장된 refresh token 조회
+        RefreshToken savedRefreshToken = refreshTokenRepository.findById(email)
+                .orElseThrow(() -> new BadCredentialsException("로그아웃 된 사용자입니다."));
 
-        // DB에 저장된 토큰과 프론트에서 보낸 토큰이 일치하는지 검사
-        if (!refreshToken.getValue().equals(tokenRequestDto.getRefreshToken())) {
-            throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
+
+        // DB 값과 요청값 비교
+        if (!savedRefreshToken.getValue().equals(requestRefreshToken)) {
+            throw new BadCredentialsException("Refresh Token이 일치하지 않습니다.");
         }
 
-        // 모든 검증을 통과했으므로 새로운 Access Token & Refresh Token 생성
-        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        // 사용자 최신 권한/상태 기준으로 새 토큰 발급
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        // DB의 Refresh Token 정보 업데이트
-        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
+        TokenDto tokenDto = tokenProvider.generateTokenDtoForMember(
+                member.getEmail(),
+                member.getRole().name()
+        );
+
+        // refresh token rotation
+        RefreshToken newRefreshToken = savedRefreshToken.updateValue(tokenDto.getRefreshToken());
         refreshTokenRepository.save(newRefreshToken);
 
         return tokenDto;
@@ -209,7 +211,6 @@ public class AuthService {
      =========================== */
     @Transactional
     public void logout(String email) {
-        // DB에 해당 이메일(ID)로 저장된 Refresh Token이 있다면 삭제
         refreshTokenRepository.deleteById(email);
     }
 }

--- a/backend/src/main/java/com/dailo/backend/service/BlockService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BlockService.java
@@ -22,47 +22,47 @@ public class BlockService {
     private final BlockRepository blockRepository;
     private final MemberRepository memberRepository;
 
-    // --- 외부(Controller) 호출용 이메일 기반 메서드 ---
+    // --- 외부(Controller) 호출용 principal 기반 메서드 ---
 
-    /** 1. 차단하기 (이메일 기반) */
-    @Transactional
-    public BlockResponseDto blockUserByEmail(String email, Long blockedId) {
-        if (email == null) {
+    /** principal(email 또는 memberId)로 Member를 찾는 헬퍼 */
+    private Member findMemberByPrincipal(String principal) {
+        if (principal == null || principal.isBlank()) {
             throw new com.dailo.backend.exception.UnauthorizedException("로그인이 필요합니다.");
         }
-        Member blocker = memberRepository.findByEmail(email)
+        // memberId(숫자)인 경우
+        if (principal.matches("\\d+")) {
+            Long memberId = Long.valueOf(principal);
+            return memberRepository.findById(memberId)
+                    .orElseThrow(() -> new com.dailo.backend.exception.NotFoundException("사용자를 찾을 수 없습니다."));
+        }
+        // 이메일인 경우
+        return memberRepository.findByEmail(principal)
                 .orElseThrow(() -> new com.dailo.backend.exception.NotFoundException("사용자를 찾을 수 없습니다."));
+    }
+
+    /** 1. 차단하기 */
+    @Transactional
+    public BlockResponseDto blockUserByEmail(String principal, Long blockedId) {
+        Member blocker = findMemberByPrincipal(principal);
         return blockUser(blocker.getId(), blockedId);
     }
 
-    /** 2. 차단 해제 (이메일 기반) */
+    /** 2. 차단 해제 */
     @Transactional
-    public void unblockUserByEmail(String email, Long blockedId) {
-        if (email == null) {
-            throw new com.dailo.backend.exception.UnauthorizedException("로그인이 필요합니다.");
-        }
-        Member blocker = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new com.dailo.backend.exception.NotFoundException("사용자를 찾을 수 없습니다."));
+    public void unblockUserByEmail(String principal, Long blockedId) {
+        Member blocker = findMemberByPrincipal(principal);
         unblockUser(blocker.getId(), blockedId);
     }
 
-    /** 3. 내 차단 목록 조회 (이메일 기반) */
-    public List<BlockResponseDto> getMyBlocksByEmail(String email) {
-        if (email == null) {
-            throw new com.dailo.backend.exception.UnauthorizedException("로그인이 필요합니다.");
-        }
-        Member blocker = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new com.dailo.backend.exception.NotFoundException("사용자를 찾을 수 없습니다."));
+    /** 3. 내 차단 목록 조회 */
+    public List<BlockResponseDto> getMyBlocksByEmail(String principal) {
+        Member blocker = findMemberByPrincipal(principal);
         return getMyBlocks(blocker.getId());
     }
 
-    /** 4. 차단 방향 확인 (이메일 기반) */
-    public BlockCheckResponseDto checkBlockDirectionByEmail(String email, Long targetUserId) {
-        if (email == null) {
-            throw new com.dailo.backend.exception.UnauthorizedException("로그인이 필요합니다.");
-        }
-        Member me = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new com.dailo.backend.exception.NotFoundException("사용자를 찾을 수 없습니다."));
+    /** 4. 차단 방향 확인 */
+    public BlockCheckResponseDto checkBlockDirectionByEmail(String principal, Long targetUserId) {
+        Member me = findMemberByPrincipal(principal);
         return checkBlockDirection(me.getId(), targetUserId);
     }
 

--- a/backend/src/main/java/com/dailo/backend/service/ChatMessageService.java
+++ b/backend/src/main/java/com/dailo/backend/service/ChatMessageService.java
@@ -27,18 +27,30 @@ public class ChatMessageService {
     private final MemberRepository memberRepository; // 💡 추가: 이메일 조회를 위해 주입
     private final BlockService blockService;
 
-    // 💡 이메일로 내 ID를 찾아주는 헬퍼 메서드
-    private Long getMemberIdByEmail(String email) {
-        if (email == null) return null;
-        return memberRepository.findByEmail(email)
+    // principal(email 또는 memberId)로 내 ID를 찾아주는 헬퍼 메서드
+    private Long getMemberIdByPrincipal(String principal) {
+        if (principal == null || principal.isBlank()) {
+            throw new RuntimeException("인증된 사용자 정보가 없습니다.");
+        }
+
+        // 카카오 로그인 토큰 subject가 memberId인 경우 대응
+        if (principal.matches("\\d+")) {
+            Long memberId = Long.valueOf(principal);
+            return memberRepository.findById(memberId)
+                    .map(Member::getId)
+                    .orElseThrow(() -> new RuntimeException("Member not found: id=" + memberId));
+        }
+
+        // 일반 로그인(email subject) 대응
+        return memberRepository.findByEmail(principal)
                 .map(Member::getId)
-                .orElseThrow(() -> new RuntimeException("Member not found for email: " + email));
+                .orElseThrow(() -> new RuntimeException("Member not found: " + principal));
     }
 
     // 메시지 전송
     @Transactional
     public ChatMessageResponseDto sendMessage(Long roomId, String email, String content, MessageType messageType) {
-        Long senderId = getMemberIdByEmail(email);
+        Long senderId = getMemberIdByPrincipal(email);
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));
 
@@ -76,7 +88,7 @@ public class ChatMessageService {
 
     // 메시지 히스토리 조회
     public Page<ChatMessageResponseDto> getMessages(Long roomId, String email, Pageable pageable) {
-        Long userId = getMemberIdByEmail(email);
+        Long userId = getMemberIdByPrincipal(email);
 
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));

--- a/backend/src/main/java/com/dailo/backend/service/ChatRoomService.java
+++ b/backend/src/main/java/com/dailo/backend/service/ChatRoomService.java
@@ -32,17 +32,30 @@ public class ChatRoomService {
     private final MemberRepository memberRepository;
     private final BlockService blockService;
 
-    // 이메일로 내 ID를 찾아주는 헬퍼 메서드
-    private Long getMyIdByEmail(String email) {
-        return memberRepository.findByEmail(email)
+    // principal(email 또는 memberId)로 내 ID를 찾아주는 헬퍼 메서드
+    private Long getMyIdByPrincipal(String principal) {
+        if (principal == null || principal.isBlank()) {
+            throw new RuntimeException("인증된 사용자 정보가 없습니다.");
+        }
+
+        // 카카오 로그인 토큰 subject가 memberId인 경우 대응
+        if (principal.matches("\\d+")) {
+            Long memberId = Long.valueOf(principal);
+            return memberRepository.findById(memberId)
+                    .map(Member::getId)
+                    .orElseThrow(() -> new RuntimeException("Member not found: id=" + memberId));
+        }
+
+        // 일반 로그인(email subject) 대응
+        return memberRepository.findByEmail(principal)
                 .map(Member::getId)
-                .orElseThrow(() -> new RuntimeException("Member not found: " + email));
+                .orElseThrow(() -> new RuntimeException("Member not found: " + principal));
     }
 
     // 채팅방 생성 (1:1)
     @Transactional
     public ChatRoomResponseDto createRoom(String email, Long targetUserId) {
-        Long userId = getMyIdByEmail(email);
+        Long userId = getMyIdByPrincipal(email);
 
         // 1. 자기 자신과 채팅 불가
         if (userId.equals(targetUserId)) {
@@ -143,7 +156,7 @@ public class ChatRoomService {
 
     // 내 채팅방 목록
     public List<ChatRoomResponseDto> getMyRooms(String email) {
-        Long userId = getMyIdByEmail(email);
+        Long userId = getMyIdByPrincipal(email);
 
         List<ChatRoom> rooms = chatRoomRepository.findMyRooms(userId);
         List<Long> allUserIds = rooms.stream()
@@ -172,7 +185,7 @@ public class ChatRoomService {
 
     @Transactional
     public void markAsRead(Long roomId, String email) {
-        Long userId = getMyIdByEmail(email);
+        Long userId = getMyIdByPrincipal(email);
 
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));
@@ -185,7 +198,7 @@ public class ChatRoomService {
 
     @Transactional
     public void leaveRoom(Long roomId, String email) {
-        Long userId = getMyIdByEmail(email);
+        Long userId = getMyIdByPrincipal(email);
 
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));
@@ -201,7 +214,7 @@ public class ChatRoomService {
     }
 
     public ChatRoomResponseDto getRoom(Long roomId, String email) {
-        Long userId = getMyIdByEmail(email);
+        Long userId = getMyIdByPrincipal(email);
 
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));
@@ -219,7 +232,7 @@ public class ChatRoomService {
     // 채팅방 알림 토글
     @Transactional
     public boolean toggleNotification(Long roomId, String email) {
-        Long userId = getMyIdByEmail(email);
+        Long userId = getMyIdByPrincipal(email);
 
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));
@@ -237,7 +250,7 @@ public class ChatRoomService {
 
     // 채팅방 알림 상태 조회
     public boolean isNotificationOn(Long roomId, String email) {
-        Long userId = getMyIdByEmail(email);
+        Long userId = getMyIdByPrincipal(email);
 
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));

--- a/backend/src/main/java/com/dailo/backend/service/CommentService.java
+++ b/backend/src/main/java/com/dailo/backend/service/CommentService.java
@@ -261,4 +261,76 @@ public class CommentService {
                 .orElseThrow(() -> new NotFoundException("Comment not found: " + commentId));
         return comment.getLikeCount();
     }
+
+    // 7. 특정 사용자의 댓글 목록 조회
+    public Page<CommentResponseDto> getCommentsByMemberId(Long memberId, String email, Pageable pageable) {
+        Long viewerId = null;
+        if (email != null) {
+            viewerId = memberRepository.findByEmail(email)
+                    .map(Member::getId)
+                    .orElse(null);
+        }
+
+        // 차단 관계 확인
+        if (viewerId != null) {
+            Set<Long> blockedIds = blockService.getBlockedUserIds(viewerId);
+            if (blockedIds.contains(memberId)) {
+                throw new RuntimeException("차단한 사용자입니다.");
+            }
+        }
+
+        // 삭제되지 않은 댓글만 조회
+        Page<Comment> commentPage = commentRepository.findByAuthorIdAndDeletedAtIsNull(memberId, pageable);
+
+        // 게시글 정보 조회를 위한 ID 수집
+        Set<Long> postIds = commentPage.getContent().stream()
+                .map(c -> c.getPost().getId())
+                .collect(Collectors.toSet());
+
+        Map<Long, Post> postMap = postIds.isEmpty() ? Collections.emptyMap()
+                : postRepository.findAllById(postIds).stream()
+                .collect(Collectors.toMap(Post::getId, p -> p));
+
+        // 작성자 프로필 이미지 조회
+        String profileUrl = null;
+        Member author = memberRepository.findById(memberId).orElse(null);
+        if (author != null) {
+            String nickname = author.getNickname();
+            if (nickname == null || nickname.isBlank()) {
+                String authorEmail = author.getEmail();
+                nickname = (authorEmail != null && authorEmail.contains("@"))
+                        ? authorEmail.split("@")[0].trim()
+                        : "user_" + memberId;
+            }
+            if (author.getProfileImageUrl() != null && !author.getProfileImageUrl().isBlank()) {
+                try {
+                    profileUrl = s3UploadService.getPresignedUrl(author.getProfileImageUrl());
+                } catch (Exception ignored) {}
+            }
+
+            String finalNickname = nickname;
+            String finalProfileUrl = profileUrl;
+            return commentPage.map(comment -> {
+                CommentResponseDto dto = CommentResponseDto.from(comment, finalNickname, finalProfileUrl);
+                // 게시글 제목 추가를 위해 빌더로 새로 생성
+                Post post = postMap.get(comment.getPost().getId());
+                return CommentResponseDto.builder()
+                        .id(dto.getId())
+                        .postId(dto.getPostId())
+                        .postTitle(post != null ? post.getTitle() : null)
+                        .parentCommentId(dto.getParentCommentId())
+                        .authorId(dto.getAuthorId())
+                        .authorNickname(dto.getAuthorNickname())
+                        .authorProfileImageUrl(dto.getAuthorProfileImageUrl())
+                        .content(dto.getContent())
+                        .likeCount(dto.getLikeCount())
+                        .createdAt(dto.getCreatedAt())
+                        .updatedAt(dto.getUpdatedAt())
+                        .deleted(dto.isDeleted())
+                        .build();
+            });
+        }
+
+        return Page.empty(pageable);
+    }
 }

--- a/backend/src/main/java/com/dailo/backend/service/KakaoNativeLoginService.java
+++ b/backend/src/main/java/com/dailo/backend/service/KakaoNativeLoginService.java
@@ -6,9 +6,11 @@ import com.dailo.backend.dto.KakaoUserInfo;
 import com.dailo.backend.dto.OAuth2UserInfo;
 import com.dailo.backend.dto.auth.KakaoNativeLoginRequestDto;
 import com.dailo.backend.entity.Member;
+import com.dailo.backend.entity.RefreshToken;
 import com.dailo.backend.jwt.TokenDto;
 import com.dailo.backend.jwt.TokenProvider;
 import com.dailo.backend.repository.MemberRepository;
+import com.dailo.backend.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -34,6 +36,7 @@ public class KakaoNativeLoginService {
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
     private final RestTemplate restTemplate;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public TokenDto loginWithKakaoToken(KakaoNativeLoginRequestDto request) {
@@ -44,10 +47,19 @@ public class KakaoNativeLoginService {
 
         log.info("카카오 로그인 성공 - Member ID: {}", savedMember.getId());
 
-        return tokenProvider.generateTokenDtoForMember(
+        TokenDto tokenDto = tokenProvider.generateTokenDtoForMember(
                 savedMember.getEmail(),
                 savedMember.getRole() != null ? savedMember.getRole().name() : Role.USER.name()
         );
+
+        // 카카오 네이티브 로그인도 Refresh Token DB 저장
+        RefreshToken refreshToken = RefreshToken.builder()
+                .keyId(savedMember.getEmail())
+                .value(tokenDto.getRefreshToken())
+                .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return tokenDto;
     }
 
     private String validateAccessToken(KakaoNativeLoginRequestDto request) {
@@ -78,7 +90,6 @@ public class KakaoNativeLoginService {
 
         if (memberOptional.isPresent()) {
             Member existingMember = memberOptional.get();
-            // [CHANGED] 외부 URL 필드로 저장
             existingMember.updateProfile(
                     userInfo.getNickname() != null ? userInfo.getNickname() : existingMember.getNickname(),
                     userInfo.getImageUrl()
@@ -103,7 +114,6 @@ public class KakaoNativeLoginService {
                                 ? userInfo.getNickname()
                                 : "카카오유저"
                 )
-                // [CHANGED] 외부 URL 저장
                 .profileImageExternalUrl(userInfo.getImageUrl())
                 .profileImageKey(null)
                 .role(Role.USER)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=backend
 server.port=8080
 
 # MySQL Connection
-spring.datasource.url=jdbc:mysql://localhost:3307/dailo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/dailo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:changeme}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Dailo",
+    "name": "다일로",
     "slug": "app",
     "version": "1.0.0",
     "orientation": "portrait",

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -145,8 +145,8 @@ export default function TabsLayout() {
     return () => sub.remove();
   }, [navigation]);
 
-  // 아이폰은 하단 버튼 없음 → 여백 최소, Android(삼성 등)는 네비 버튼과 겹치지 않도록 safe area 적용
-  const bottomInset = Platform.OS === "ios" ? 0 : Math.max(insets.bottom ?? 0, 24);
+  // 하단 시스템 네비게이션 바 높이만큼만 안전 영역을 적용 (강제 여백 X)
+  const bottomInset = insets.bottom ?? 0;
   return (
     <Tabs
       tabBar={(props) => (

--- a/frontend/app/(tabs)/board/index.tsx
+++ b/frontend/app/(tabs)/board/index.tsx
@@ -13,6 +13,7 @@ import {
   Share,
   Image,
   ActivityIndicator,
+  RefreshControl,
 } from "react-native";
 import { useFocusEffect, useRoute, useNavigation } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
@@ -123,6 +124,24 @@ export default function BoardScreen() {
     reviewEventId
   );
   const sortedPosts = useMemo(() => apiPosts.map(toPost), [apiPosts]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = React.useCallback(async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await refetch();
+      try {
+        const res = await noticeService.getNotices({ page: 0, size: 1 });
+        const first = res.content?.[0] ?? null;
+        setLatestNotice(first);
+      } catch {
+        setLatestNotice(null);
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  }, [refreshing, refetch]);
 
   /** 축제 선택 모달: 과거 6개월 ~ 미래 12개월 행사 한 번에 로드, 월별로 그룹 */
   const loadBoardEventPickerByMonth = React.useCallback(async () => {
@@ -415,6 +434,14 @@ export default function BoardScreen() {
           style={styles.scroll}
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing || loading}
+              onRefresh={handleRefresh}
+              colors={["#6366F1"]}
+              tintColor="#6366F1"
+            />
+          }
         >
           {/* 공지 카드: 실제 공지사항 API 연동 */}
           <Pressable style={styles.noticeCard} onPress={() => router.push("/board/notice")}>

--- a/frontend/app/(tabs)/home/event-list.tsx
+++ b/frontend/app/(tabs)/home/event-list.tsx
@@ -74,6 +74,33 @@ function eventOverlapsDateRange(event: Event, range: DateRange): boolean {
   return eventStart <= range.end && eventEnd >= range.start;
 }
 
+/** 오늘 기준으로 이미 종료된 행사인지 여부 */
+function isEventEnded(event: Event): boolean {
+  if (!event.endAt) return false;
+  try {
+    const endStr = event.endAt.slice(0, 10);
+    const todayStr = new Date().toISOString().slice(0, 10);
+    return endStr < todayStr;
+  } catch {
+    return false;
+  }
+}
+
+/** 오늘 기준으로 행사 시작일까지 남은 일 수 (지났으면 0) */
+function daysUntilStart(event: Event): number {
+  try {
+    const start = new Date(event.startAt);
+    const today = new Date();
+    start.setHours(0, 0, 0, 0);
+    today.setHours(0, 0, 0, 0);
+    const diff = start.getTime() - today.getTime();
+    const days = Math.round(diff / (24 * 60 * 60 * 1000));
+    return Math.max(0, days);
+  } catch {
+    return 0;
+  }
+}
+
 /** 두 점 거리(km) 대략 계산 (Haversine 아님, 위도·경도 차이 근사) */
 function approxKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
   const R = 6371;
@@ -88,6 +115,9 @@ function approxKm(lat1: number, lng1: number, lat2: number, lng2: number): numbe
 
 export default function EventListScreen() {
   const router = useRouter();
+  // 홈 탭 행사 리스트 진입 시 기본 정렬은 "최신순"이 되도록,
+  // 인기/조회수 필터가 선택된 경우에만 sort 파라미터를 넘긴다.
+  const [popularFilter, setPopularFilter] = useState<string>("all");
   const sort: EventListSort =
     popularFilter === "all" ? null : (popularFilter as EventListSort);
   const { events, loading, error, refetch } = useEventList({ size: 50, sort });
@@ -98,7 +128,6 @@ export default function EventListScreen() {
   >(null);
   const [dateRange, setDateRange] = useState<DateRange | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
-  const [popularFilter, setPopularFilter] = useState<string>("all");
   const [distanceFilter, setDistanceFilter] = useState<string>("all");
   const [scaleFilter, setScaleFilter] = useState<string>("all");
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
@@ -140,6 +169,12 @@ export default function EventListScreen() {
   /** 날짜·카테고리·규모·검색·정렬(거리) 적용 */
   const filteredEvents = useMemo(() => {
     let list = events;
+    const hasCustomDateRange = !!dateRange;
+
+    // 기본 진입 시(기간 필터 없음)에는 이미 종료된 행사는 숨김
+    if (!hasCustomDateRange) {
+      list = list.filter((e) => !isEventEnded(e));
+    }
     if (dateRange) {
       list = list.filter((e) => eventOverlapsDateRange(e, dateRange));
     }
@@ -164,6 +199,9 @@ export default function EventListScreen() {
           approxKm(userLocation.lat, userLocation.lng, a.latitude, a.longitude) -
           approxKm(userLocation.lat, userLocation.lng, b.latitude, b.longitude)
       );
+    } else if (!hasCustomDateRange) {
+      // 기본 진입(기간·거리 필터 없음)에서는 오늘과 가까운 행사부터 정렬
+      list = [...list].sort((a, b) => daysUntilStart(a) - daysUntilStart(b));
     }
     return list;
   }, [
@@ -285,6 +323,7 @@ export default function EventListScreen() {
             filteredEvents.map((event: Event) => {
               const dateStr = formatDate(event.startAt);
               const timeStr = formatTimeRange(event.startAt, event.endAt);
+              const ended = isEventEnded(event);
               return (
                 <Pressable
                   key={event.id}
@@ -298,9 +337,16 @@ export default function EventListScreen() {
                     style={styles.eventImage}
                   />
                   <View style={styles.eventInfo}>
-                    <Text style={styles.eventCategory}>
-                      {categoryLabel(event.category)}
-                    </Text>
+                    <View style={styles.eventHeaderRow}>
+                      <Text style={styles.eventCategory}>
+                        {categoryLabel(event.category)}
+                      </Text>
+                      {ended && (
+                        <View style={styles.eventEndedBadge}>
+                          <Text style={styles.eventEndedBadgeText}>종료</Text>
+                        </View>
+                      )}
+                    </View>
                     <Text style={styles.eventTitle} numberOfLines={2}>
                       {event.title}
                     </Text>
@@ -483,13 +529,29 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     paddingVertical: 2,
   },
+  eventHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 4,
+  },
   eventCategory: {
     fontSize: 11,
     fontWeight: "600",
     color: "#6B7280",
     textTransform: "uppercase",
     letterSpacing: 0.5,
-    marginBottom: 4,
+  },
+  eventEndedBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    backgroundColor: "#E5E7EB",
+  },
+  eventEndedBadgeText: {
+    fontSize: 10,
+    fontWeight: "600",
+    color: "#6B7280",
   },
   eventTitle: {
     fontSize: 15,

--- a/frontend/app/(tabs)/home/index.tsx
+++ b/frontend/app/(tabs)/home/index.tsx
@@ -25,8 +25,8 @@ import { useNavigation } from "@react-navigation/native";
 import * as Location from "expo-location";
 import { useHomePopularPosts } from "../../../hooks/useBoard";
 import { useEventList } from "../../../hooks/useEvent";
-import type { PopularEventItem } from "../../../services/event.service";
 import type { Event } from "../../../types/event";
+import type { PopularEventItem } from "../../../services/event.service";
 import { useAuth } from "../../../hooks/useAuth";
 import { getDemoLocation } from "../../../services/demoLocationStorage";
 import * as eventReminder from "../../../services/eventReminder.service";
@@ -401,7 +401,34 @@ export default function HomeScreen() {
             ) : eventList.length === 0 ? (
               <Text style={styles.eventCardEmpty}>등록된 행사가 없어요</Text>
             ) : (
-              eventList.slice(0, 3).map((event) => {
+              // 홈 탭에서는 기본적으로 이미 종료된 행사는 숨기고,
+              // 오늘과 가장 가까운 시작일 순으로 정렬된 행사 중 3개만 노출
+              (() => {
+                const todayStr = new Date().toISOString().slice(0, 10);
+                const activeEvents = eventList.filter((e: Event) => {
+                  if (!e.endAt) return true;
+                  try {
+                    const endStr = e.endAt.slice(0, 10);
+                    return endStr >= todayStr;
+                  } catch {
+                    return true;
+                  }
+                });
+                const withDays = activeEvents.map((e) => {
+                  try {
+                    const start = new Date(e.startAt);
+                    const today = new Date();
+                    start.setHours(0, 0, 0, 0);
+                    today.setHours(0, 0, 0, 0);
+                    const diff = start.getTime() - today.getTime();
+                    const days = Math.round(diff / (24 * 60 * 60 * 1000));
+                    return { event: e, daysUntil: Math.max(0, days) };
+                  } catch {
+                    return { event: e, daysUntil: Number.MAX_SAFE_INTEGER };
+                  }
+                });
+                withDays.sort((a, b) => a.daysUntil - b.daysUntil);
+                return withDays.slice(0, 3).map(({ event }) => {
                 const dateStr = event.startAt
                   ? (() => {
                       try {
@@ -434,7 +461,7 @@ export default function HomeScreen() {
                         })()
                       : "";
                 const catLabel = { FESTIVAL: "축제", EXHIBITION: "전시", PERFORMANCE: "공연", EXPERIENCE_BOOTH: "체험부스", FOOD_TRUCK: "푸드트럭", TRAFFIC: "교통", CONSTRUCTION: "공사", ETC: "기타" }[event.category] ?? "기타";
-                return (
+                  return (
                   <Pressable
                     key={event.id}
                     style={styles.eventCard}
@@ -463,8 +490,9 @@ export default function HomeScreen() {
                       </View>
                     </View>
                   </Pressable>
-                );
-              })
+                  );
+                });
+              })()
             )}
           </View>
         </View>

--- a/frontend/app/(tabs)/map/_components/MapBottomSheet.tsx
+++ b/frontend/app/(tabs)/map/_components/MapBottomSheet.tsx
@@ -64,7 +64,16 @@ export function MapBottomSheet({
   const isCollapsed = mode === 'collapsed';
 
   const handlePressDetail = () => {
-    router.push(`/event/${event.id}?source=map`);
+    const thumb = (event.thumbnailUrl ?? '').trim();
+    // 지도 → 상세 이동 시, 등록 시 선택한 대표 썸네일(thumbnailUrl)을 함께 전달해
+    // 상세 상단 이미지가 큰 카드와 항상 일치하도록 함
+    router.push({
+      pathname: `/event/${event.id}`,
+      params: {
+        source: 'map',
+        ...(thumb ? { thumb } : {}),
+      },
+    } as never);
     onClose();
   };
 
@@ -158,6 +167,15 @@ export function MapBottomSheet({
             },
           ]}
         >
+          {/* 큰 카드 닫기 버튼 (우상단 X) */}
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={onClose}
+            activeOpacity={0.8}
+          >
+            <Ionicons name="close" size={18} color="#6B7280" />
+          </TouchableOpacity>
+
           <ScrollView
             style={styles.largeScroll}
             contentContainerStyle={styles.largeContent}
@@ -238,6 +256,20 @@ const styles = StyleSheet.create({
     bottom: 0,
     justifyContent: 'flex-end',
     alignItems: 'stretch',
+  },
+
+  // 큰 카드 우상단 닫기 버튼
+  closeButton: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.9)',
+    zIndex: 10,
   },
 
   // 공통 텍스트 스타일

--- a/frontend/app/(tabs)/mypage/board-commented.tsx
+++ b/frontend/app/(tabs)/mypage/board-commented.tsx
@@ -1,5 +1,5 @@
 // app/(tabs)/mypage/board-commented.tsx - 댓글 단 게시글 목록
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -8,12 +8,15 @@ import {
   ScrollView,
   FlatList,
   ActivityIndicator,
+  TextInput,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useFocusEffect } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useAuth } from "../../../hooks/useAuth";
+import { useAuth, useMyUserId } from "../../../hooks/useAuth";
 import { useMyCommentedPostList } from "../../../hooks/useBoard";
+import * as boardService from "../../../services/board.service";
+import type { CommentItem } from "../../../types/board";
 import { formatRelativeTime } from "../../../utils/formatDate";
 import type { PostListItem } from "../../../types/board";
 
@@ -26,6 +29,17 @@ type PostRow = {
   content: string;
   likes: number;
   comments: number;
+};
+
+type MyCommentRow = {
+  commentId: string;
+  postId: string;
+  postTitle?: string;
+  categoryType?: string;
+  /** 내가 쓴 댓글 내용 */
+  commentContent: string;
+  /** 댓글 작성 시각 (상대 시간 문자열) */
+  time: string;
 };
 
 function toPostRow(item: PostListItem): PostRow {
@@ -48,8 +62,13 @@ function toPostRow(item: PostListItem): PostRow {
 
 export default function BoardCommentedScreen() {
   const { isLoggedIn } = useAuth();
+  const myUserId = useMyUserId();
   const { posts, loading, error, refetch } = useMyCommentedPostList(!!isLoggedIn);
   const sortedPosts = useMemo(() => posts.map(toPostRow), [posts]);
+  const [myComments, setMyComments] = useState<MyCommentRow[]>([]);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [appliedSearch, setAppliedSearch] = useState("");
 
   useFocusEffect(
     React.useCallback(() => {
@@ -57,26 +76,99 @@ export default function BoardCommentedScreen() {
     }, [isLoggedIn, refetch])
   );
 
-  const renderPost = ({ item }: { item: PostRow }) => (
-    <Pressable style={styles.postRow} onPress={() => router.push(`/board/${item.id}`)}>
+  // 각 게시글의 댓글 목록을 조회해 "내가 쓴 댓글"만 모아서 리스트로 구성
+  useEffect(() => {
+    if (!isLoggedIn || !myUserId || !sortedPosts.length) {
+      setMyComments([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        setCommentsLoading(true);
+        const rows: MyCommentRow[] = [];
+        for (const post of sortedPosts) {
+          try {
+            const res = await boardService.getComments(post.id, { page: 0, size: 100 });
+            const contents = res.content ?? [];
+            const pushComment = (c: CommentItem) => {
+              const raw = c as Record<string, unknown>;
+              const authorId = Number(
+                (c.authorId as number | undefined) ??
+                  (raw.author_id as number | undefined) ??
+                  0
+              );
+              if (!Number.isFinite(authorId) || authorId !== myUserId) return;
+              const createdAt =
+                (c.createdAt as string | undefined) ??
+                (raw.createdAt as string | undefined) ??
+                (raw.created_at as string | undefined) ??
+                "";
+              rows.push({
+                commentId: String(c.id),
+                postId: post.id,
+                postTitle: post.title,
+                categoryType: post.tag,
+                commentContent: c.content ?? "",
+                time: formatRelativeTime(createdAt || post.time),
+              });
+            };
+            contents.forEach((c: CommentItem & { replies?: CommentItem[] }) => {
+              pushComment(c);
+              (c.replies ?? []).forEach(pushComment);
+            });
+          } catch {
+            // 해당 게시글 댓글 조회 실패는 무시
+          }
+        }
+        if (!cancelled) {
+          // 최신 순으로 정렬
+          setMyComments(
+            rows.sort((a, b) => (a.time > b.time ? -1 : 1))
+          );
+        }
+      } finally {
+        if (!cancelled) setCommentsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn, myUserId, sortedPosts]);
+
+  const filteredComments = useMemo(() => {
+    const q = appliedSearch.trim().toLowerCase();
+    if (!q) return myComments;
+    return myComments.filter((c) => {
+      const title = c.postTitle ?? "";
+      const content = c.commentContent ?? "";
+      return (
+        title.toLowerCase().includes(q) ||
+        content.toLowerCase().includes(q)
+      );
+    });
+  }, [myComments, appliedSearch]);
+
+  const renderPost = ({ item }: { item: MyCommentRow }) => (
+    <Pressable style={styles.postRow} onPress={() => router.push(`/board/${item.postId}`)}>
       <View style={styles.postRowBody}>
         <View style={styles.postRowTop}>
-          <Text style={styles.author}>{item.author}</Text>
-          {item.tag ? (
+          <Text style={styles.author}>내가 쓴 댓글</Text>
+          {item.categoryType ? (
             <View style={styles.tagBadge}>
-              <Text style={styles.tagText}>{item.tag}</Text>
+              <Text style={styles.tagText}>{item.categoryType}</Text>
             </View>
           ) : null}
           <Text style={styles.timeText}>{item.time}</Text>
         </View>
-        {item.title ? (
+        {item.postTitle ? (
           <Text style={styles.postTitle} numberOfLines={1} ellipsizeMode="tail">
-            {item.title}
+            {item.postTitle}
           </Text>
         ) : null}
-        {item.content ? (
+        {item.commentContent ? (
           <Text style={styles.postPreview} numberOfLines={2} ellipsizeMode="tail">
-            {item.content}
+            {item.commentContent}
           </Text>
         ) : null}
         <View style={styles.postRowFooter}>
@@ -102,7 +194,7 @@ export default function BoardCommentedScreen() {
             <Ionicons name="arrow-back" size={22} color="#111827" />
           </Pressable>
           <View style={styles.headerTitleWrap} pointerEvents="box-none">
-            <Text style={styles.headerTitle}>댓글단 게시글</Text>
+            <Text style={styles.headerTitle}>내가 쓴 댓글</Text>
           </View>
           <View style={styles.headerRight} />
         </View>
@@ -119,7 +211,7 @@ export default function BoardCommentedScreen() {
                 <Text style={styles.loginBtnText}>로그인</Text>
               </Pressable>
             </View>
-          ) : loading ? (
+          ) : loading || commentsLoading ? (
             <View style={styles.loadingWrap}>
               <ActivityIndicator size="large" color="#4C8BF5" />
               <Text style={styles.loadingText}>불러오는 중...</Text>
@@ -131,19 +223,61 @@ export default function BoardCommentedScreen() {
                 <Text style={styles.retryText}>다시 시도</Text>
               </Pressable>
             </View>
-          ) : sortedPosts.length === 0 ? (
+          ) : myComments.length === 0 ? (
             <View style={styles.emptyWrap}>
               <Text style={styles.emptyText}>아직 댓글 단 글이 없습니다.</Text>
             </View>
           ) : (
-            <View style={styles.listWrap}>
-              <FlatList
-                data={sortedPosts}
-                keyExtractor={(item) => item.id}
-                renderItem={renderPost}
-                scrollEnabled={false}
-              />
-            </View>
+            <>
+              {/* 검색창 */}
+              <View style={styles.searchBarWrap}>
+                <TextInput
+                  style={styles.searchInput}
+                  placeholder="게시글 제목 또는 댓글 내용 검색"
+                  placeholderTextColor="#9CA3AF"
+                  value={searchKeyword}
+                  onChangeText={setSearchKeyword}
+                  returnKeyType="search"
+                  onSubmitEditing={() =>
+                    setAppliedSearch(searchKeyword.trim())
+                  }
+                />
+                {searchKeyword.length > 0 ? (
+                  <Pressable
+                    onPress={() => setSearchKeyword("")}
+                    style={styles.searchClear}
+                    hitSlop={8}
+                  >
+                    <Ionicons
+                      name="close-circle"
+                      size={20}
+                      color="#9CA3AF"
+                    />
+                  </Pressable>
+                ) : null}
+                <Pressable
+                  onPress={() => setAppliedSearch(searchKeyword.trim())}
+                  style={styles.searchButton}
+                  hitSlop={8}
+                >
+                  <Ionicons name="search" size={22} color="#111827" />
+                </Pressable>
+              </View>
+
+              <View style={styles.listWrap}>
+                <FlatList
+                  data={filteredComments}
+                  keyExtractor={(item) => item.commentId}
+                  renderItem={renderPost}
+                  scrollEnabled={false}
+                />
+              </View>
+              {filteredComments.length === 0 && appliedSearch.trim() ? (
+                <Text style={styles.searchEmpty}>
+                  조건에 맞는 댓글이 없어요
+                </Text>
+              ) : null}
+            </>
           )}
         </ScrollView>
       </View>
@@ -152,8 +286,8 @@ export default function BoardCommentedScreen() {
 }
 
 const styles = StyleSheet.create({
-  safeArea: { flex: 1, backgroundColor: "#F9FAFB" },
-  container: { flex: 1, backgroundColor: "#F9FAFB" },
+  safeArea: { flex: 1, backgroundColor: "#FFFFFF" },
+  container: { flex: 1, backgroundColor: "#FFFFFF" },
   header: {
     flexDirection: "row",
     alignItems: "center",
@@ -203,6 +337,32 @@ const styles = StyleSheet.create({
   emptyText: { fontSize: 14, color: "#6B7280", marginBottom: 16 },
   loginBtn: { paddingVertical: 8, paddingHorizontal: 16, backgroundColor: "#4C8BF5", borderRadius: 8 },
   loginBtnText: { fontSize: 14, fontWeight: "600", color: "#FFFFFF" },
+  searchBarWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    height: 44,
+    backgroundColor: "#F3F4F6",
+    borderRadius: 10,
+    marginTop: 12,
+    marginBottom: 12,
+    paddingLeft: 12,
+    paddingRight: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    color: "#111827",
+    paddingVertical: 8,
+    paddingRight: 8,
+  },
+  searchClear: { padding: 4 },
+  searchButton: { padding: 4, marginLeft: 4 },
+  searchEmpty: {
+    paddingVertical: 24,
+    fontSize: 14,
+    color: "#9CA3AF",
+    textAlign: "center",
+  },
   postRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/frontend/app/(tabs)/mypage/index.tsx
+++ b/frontend/app/(tabs)/mypage/index.tsx
@@ -177,6 +177,15 @@ export default function MyPageScreen() {
             }
           />
           <MenuItem
+            icon="chatbubble-ellipses-outline"
+            label="내가 쓴 댓글"
+            onPress={() =>
+              isLoggedIn
+                ? router.push("/(tabs)/mypage/board-commented")
+                : router.push("/login")
+            }
+          />
+          <MenuItem
             icon="bookmark-outline"
             label="저장한 게시글"
             onPress={() =>

--- a/frontend/app/(tabs)/mypage/saved-posts.tsx
+++ b/frontend/app/(tabs)/mypage/saved-posts.tsx
@@ -19,6 +19,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
 import * as savedPostService from "../../../services/savedPost.service";
+import * as boardService from "../../../services/board.service";
 import { formatRelativeTime } from "../../../utils/formatDate";
 
 const DEFAULT_PROFILE_IMAGE = require("../../../assets/images/default-profile.png");
@@ -51,14 +52,38 @@ export default function SavedPostsScreen() {
     else setLoading(true);
     try {
       const data = await savedPostService.getSavedPostSummaries();
-      setList(
+      const rows: SavedRow[] =
         (data ?? []).map((p) => ({
           id: String(p.id),
           title: p.title || `게시글 #${p.id}`,
           time: p.createdAt ? formatRelativeTime(p.createdAt) : "",
-          imageUri: (p as { imageUrl?: string }).imageUrl,
-        }))
-      );
+          imageUri: p.imageUrl,
+        }));
+      setList(rows);
+
+      // 썸네일이 비어 있는 항목들은 백엔드에서 한 번 더 가져와 채운다.
+      const missing = (data ?? []).filter((p) => !p.imageUrl);
+      if (missing.length > 0) {
+        missing.forEach(async (p) => {
+          try {
+            const detail = await boardService.getPostById(p.id);
+            const first =
+              (detail.imageUrls && detail.imageUrls[0]) ||
+              (detail as any).image_urls?.[0];
+            if (!first) return;
+            // 화면 상태 업데이트
+            setList((prev) =>
+              prev.map((row) =>
+                Number(row.id) === p.id ? { ...row, imageUri: first } : row
+              )
+            );
+            // 로컬 스토리지에도 반영
+            await savedPostService.updateSavedPostThumbnail(p.id, first);
+          } catch {
+            // 개별 게시글 실패는 무시
+          }
+        });
+      }
     } finally {
       setLoading(false);
       setRefreshing(false);

--- a/frontend/app/(tabs)/mypage/saved-posts.tsx
+++ b/frontend/app/(tabs)/mypage/saved-posts.tsx
@@ -21,6 +21,8 @@ import * as Clipboard from "expo-clipboard";
 import * as savedPostService from "../../../services/savedPost.service";
 import { formatRelativeTime } from "../../../utils/formatDate";
 
+const DEFAULT_PROFILE_IMAGE = require("../../../assets/images/default-profile.png");
+
 type SavedRow = {
   id: string;
   title: string;
@@ -91,7 +93,18 @@ export default function SavedPostsScreen() {
     <Pressable style={styles.postRow} onPress={() => router.push(`/board/${item.id}`)}>
       <View style={styles.postRowBody}>
         <View style={styles.postRowTop}>
-          <Text style={styles.timeText}>{item.time || "저장한 글"}</Text>
+          <View style={styles.postAuthorAvatar}>
+            <Image
+              source={DEFAULT_PROFILE_IMAGE}
+              style={[styles.postAuthorAvatar, styles.defaultProfileImageZoom]}
+              resizeMode="cover"
+            />
+          </View>
+          <Text style={styles.author}>저장한 글</Text>
+          <View style={styles.tagBadge}>
+            <Text style={styles.tagText}>저장</Text>
+          </View>
+          <Text style={styles.timeText}>{item.time}</Text>
         </View>
         {item.title ? (
           <Text style={styles.postTitle} numberOfLines={1} ellipsizeMode="tail">
@@ -358,9 +371,37 @@ const styles = StyleSheet.create({
     gap: 6,
     marginBottom: 4,
   },
+  postAuthorAvatar: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: "#E5E7EB",
+    overflow: "hidden",
+  },
+  defaultProfileImageZoom: {
+    position: "absolute",
+    transform: [{ scale: 1.35 }],
+  },
+  author: {
+    fontSize: 14,
+    fontWeight: "400",
+    color: "#6B7280",
+  },
+  tagBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 6,
+    backgroundColor: "#F3F4FF",
+  },
+  tagText: {
+    fontSize: 11,
+    color: "#4F46E5",
+    fontWeight: "500",
+  },
   timeText: {
     fontSize: 11,
     color: "#9CA3AF",
+    marginLeft: 6,
   },
   postTitle: {
     fontSize: 14,

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -482,20 +482,11 @@ export default function PostDetailScreen() {
         }
       }
     }
-    if (!comment) {
-      console.log('[isMyComment] comment not found for id:', commentId);
-      return false;
-    }
+    if (!comment) return false;
     // snake_case와 camelCase 모두 처리
     const authorId = comment.authorId ?? comment.author_id;
-    console.log('[isMyComment] commentId:', commentId, 'authorId:', authorId, 'user.id:', user?.id);
-    if (authorId == null || user?.id == null) {
-      console.log('[isMyComment] null check failed - authorId:', authorId, 'user.id:', user?.id);
-      return false;
-    }
-    const result = Number(authorId) === Number(user.id);
-    console.log('[isMyComment] result:', result, 'Number(authorId):', Number(authorId), 'Number(user.id):', Number(user.id));
-    return result;
+    if (authorId == null || user?.id == null) return false;
+    return Number(authorId) === Number(user.id);
   };
 
   const handleDeleteComment = (commentId: string) => {
@@ -507,12 +498,25 @@ export default function PostDetailScreen() {
         style: "destructive",
         onPress: async () => {
           try {
+            console.log('[handleDeleteComment] 삭제 시도:', commentId);
             await boardService.deleteComment(commentId);
+            console.log('[handleDeleteComment] 삭제 API 성공');
+            // 로컬 상태에서 즉시 제거
             setDeletedCommentIds((prev) => new Set(prev).add(commentId));
             removeComment(commentId);
-            await refetchPost();
-          } catch {
-            Alert.alert("오류", "댓글 삭제에 실패했습니다.");
+            // 서버에서 최신 데이터 다시 불러오기
+            await Promise.all([refetchPost(), refetchComments()]);
+            console.log('[handleDeleteComment] refetch 완료');
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : "댓글 삭제에 실패했습니다.";
+            console.error('[handleDeleteComment] 삭제 실패:', msg);
+            Alert.alert("오류", msg);
+            // 삭제 실패 시 로컬 상태 롤백
+            setDeletedCommentIds((prev) => {
+              const next = new Set(prev);
+              next.delete(commentId);
+              return next;
+            });
           }
         },
       },
@@ -1094,9 +1098,13 @@ const styles = StyleSheet.create({
   commentAuthor: { fontSize: 13, fontWeight: "600", color: "#111827" },
   commentTime: { fontSize: 11, color: "#9CA3AF" },
   commentContent: { fontSize: 13, color: "#374151", lineHeight: 18 },
-  commentRight: { alignItems: "flex-end", gap: 4 },
+  commentRight: { alignItems: "flex-end", gap: 4, position: "relative", zIndex: 10 },
   commentMenuBtn: { padding: 4, marginLeft: 4 },
   commentDropdown: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    zIndex: 100,
     backgroundColor: "#FFFFFF",
     borderRadius: 8,
     borderWidth: 1,
@@ -1105,7 +1113,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 4,
-    elevation: 3,
+    elevation: 10,
     minWidth: 100,
   },
   commentDropdownItem: { paddingVertical: 10, paddingHorizontal: 14 },

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -77,8 +77,6 @@ export default function PostDetailScreen() {
   const router = useRouter();
   const { width: winWidth } = useWindowDimensions();
   const { isLoggedIn, user, logout } = useAuthContext();
-  // 디버그: user.id 확인
-  console.log('[board/[id]] user:', user?.id, 'isLoggedIn:', isLoggedIn);
   const [menuVisible, setMenuVisible] = useState(false);
   const [commentText, setCommentText] = useState("");
   const [submittingComment, setSubmittingComment] = useState(false);
@@ -497,26 +495,24 @@ export default function PostDetailScreen() {
         text: "삭제",
         style: "destructive",
         onPress: async () => {
+          // 먼저 로컬 상태에서 즉시 제거 (낙관적 업데이트)
+          setDeletedCommentIds((prev) => new Set(prev).add(commentId));
+          removeComment(commentId);
+
           try {
-            console.log('[handleDeleteComment] 삭제 시도:', commentId);
             await boardService.deleteComment(commentId);
-            console.log('[handleDeleteComment] 삭제 API 성공');
-            // 로컬 상태에서 즉시 제거
-            setDeletedCommentIds((prev) => new Set(prev).add(commentId));
-            removeComment(commentId);
-            // 서버에서 최신 데이터 다시 불러오기
-            await Promise.all([refetchPost(), refetchComments()]);
-            console.log('[handleDeleteComment] refetch 완료');
+            // 댓글 수만 업데이트 (refetchComments 제거하여 삭제된 댓글이 다시 나타나는 문제 방지)
+            await refetchPost();
           } catch (e) {
             const msg = e instanceof Error ? e.message : "댓글 삭제에 실패했습니다.";
-            console.error('[handleDeleteComment] 삭제 실패:', msg);
             Alert.alert("오류", msg);
-            // 삭제 실패 시 로컬 상태 롤백
+            // 삭제 실패 시 로컬 상태 롤백 및 댓글 목록 다시 불러오기
             setDeletedCommentIds((prev) => {
               const next = new Set(prev);
               next.delete(commentId);
               return next;
             });
+            await refetchComments();
           }
         },
       },

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -77,6 +77,8 @@ export default function PostDetailScreen() {
   const router = useRouter();
   const { width: winWidth } = useWindowDimensions();
   const { isLoggedIn, user, logout } = useAuthContext();
+  // 디버그: user.id 확인
+  console.log('[board/[id]] user:', user?.id, 'isLoggedIn:', isLoggedIn);
   const [menuVisible, setMenuVisible] = useState(false);
   const [commentText, setCommentText] = useState("");
   const [submittingComment, setSubmittingComment] = useState(false);
@@ -469,7 +471,7 @@ export default function PostDetailScreen() {
 
   const isMyComment = (commentId: string) => {
     // 최상위 댓글에서 찾기
-    let comment = apiComments.find((f) => String(f.id) === commentId);
+    let comment: Record<string, unknown> | undefined = apiComments.find((f) => String(f.id) === commentId);
     // 대댓글에서도 찾기
     if (!comment) {
       for (const c of apiComments) {
@@ -480,7 +482,20 @@ export default function PostDetailScreen() {
         }
       }
     }
-    return comment && user?.id != null && Number(comment.authorId) === Number(user.id);
+    if (!comment) {
+      console.log('[isMyComment] comment not found for id:', commentId);
+      return false;
+    }
+    // snake_case와 camelCase 모두 처리
+    const authorId = comment.authorId ?? comment.author_id;
+    console.log('[isMyComment] commentId:', commentId, 'authorId:', authorId, 'user.id:', user?.id);
+    if (authorId == null || user?.id == null) {
+      console.log('[isMyComment] null check failed - authorId:', authorId, 'user.id:', user?.id);
+      return false;
+    }
+    const result = Number(authorId) === Number(user.id);
+    console.log('[isMyComment] result:', result, 'Number(authorId):', Number(authorId), 'Number(user.id):', Number(user.id));
+    return result;
   };
 
   const handleDeleteComment = (commentId: string) => {

--- a/frontend/app/event/[id].tsx
+++ b/frontend/app/event/[id].tsx
@@ -61,10 +61,11 @@ function getEventDayLabels(startAt?: string | null, endAt?: string | null): stri
 export default function EventDetailScreen() {
   const insets = useSafeAreaInsets();
   const { isLoggedIn } = useAuth();
-  const { id, source, tab: tabParam } = useLocalSearchParams<{
+  const { id, source, tab: tabParam, thumb } = useLocalSearchParams<{
     id: string;
     source?: string;
     tab?: string;
+    thumb?: string;
   }>();
   const { detail: event, loading, error, refetch: refetchDetail } = useEventDetail(id, source ?? "detail");
   const initialTab: TabKey =
@@ -85,6 +86,26 @@ export default function EventDetailScreen() {
     }
     return event?.startAt ? formatEventDate(event.startAt) : null;
   }, [extra.timeline, event?.startAt]);
+
+  const thumbnailFromRoute = useMemo(() => {
+    if (!thumb || typeof thumb !== "string") return null;
+    const t = thumb.trim();
+    return t.length > 0 ? t : null;
+  }, [thumb]);
+
+  const eventWithThumbnail = useMemo(
+    () =>
+      event
+        ? {
+            ...event,
+            thumbnailUrl:
+              (thumbnailFromRoute as string | null | undefined) ??
+              (event as typeof event & { thumbnailUrl?: string | null }).thumbnailUrl ??
+              (event.posterUrls?.[0] ?? null),
+          }
+        : event,
+    [event, thumbnailFromRoute]
+  );
 
   const eventDayLabels = useMemo(
     () => getEventDayLabels(event?.startAt ?? null, event?.endAt ?? null),
@@ -240,7 +261,7 @@ export default function EventDetailScreen() {
       >
         <EventDetailHeader
           id={id}
-          event={event}
+          event={eventWithThumbnail}
           loading={loading}
           error={error}
           onSave={handleSave}
@@ -260,13 +281,15 @@ export default function EventDetailScreen() {
 
         <View style={styles.body}>
           {tab === "news" && (
-            <EventNewsTab
-              news={extra.news}
-              eventId={event?.id != null ? Number(event.id) : undefined}
-            />
+            <View style={styles.bodyInner}>
+              <EventNewsTab
+                news={extra.news}
+                eventId={event?.id != null ? Number(event.id) : undefined}
+              />
+            </View>
           )}
           {(tab === "timeline" || tab === "booths") && (
-            <View style={styles.timelineWrap}>
+            <View style={[styles.timelineWrap, styles.bodyInner]}>
               {tab === "timeline" && isMultiDayTimeline && (
                 <View style={styles.timelineDateNavRow}>
                   <Pressable
@@ -353,9 +376,11 @@ const styles = StyleSheet.create({
   },
   body: {
     paddingHorizontal: 16,
-    paddingTop: 10,
     paddingBottom: 20,
     minHeight: SCREEN_HEIGHT * 0.5,
+  },
+  bodyInner: {
+    paddingTop: 10,
   },
   timelineWrap: { flex: 1 },
   timelineDateNavRow: {

--- a/frontend/app/profile/[id].tsx
+++ b/frontend/app/profile/[id].tsx
@@ -20,10 +20,13 @@ import * as chatService from '../../services/chat.service';
 import * as blockService from '../../services/block.service';
 import * as reportService from '../../services/report.service';
 import * as boardService from '../../services/board.service';
+import type { MemberCommentItem } from '../../services/board.service';
 import { useAuth } from '../../hooks/useAuth';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { formatRelativeTime } from '../../utils/formatDate';
 import type { PostListItem } from '../../types/board';
+
+type TabType = 'posts' | 'comments';
 
 const DEFAULT_PROFILE_IMAGE = require('../../assets/images/default-profile.png');
 
@@ -40,12 +43,21 @@ export default function MemberProfileScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const [blockCheck, setBlockCheck] = useState<{ iBlockedThem: boolean; theyBlockedMe: boolean } | null>(null);
 
+  // 탭 상태
+  const [activeTab, setActiveTab] = useState<TabType>('posts');
+
   // 게시글 목록
   const [posts, setPosts] = useState<PostListItem[]>([]);
   const [postsLoading, setPostsLoading] = useState(false);
   const [postsPage, setPostsPage] = useState(0);
   const [hasMorePosts, setHasMorePosts] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+
+  // 댓글 목록
+  const [comments, setComments] = useState<MemberCommentItem[]>([]);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [commentsPage, setCommentsPage] = useState(0);
+  const [hasMoreComments, setHasMoreComments] = useState(true);
 
   const memberId = Number(id);
   const isMyProfile = currentUser?.id != null && Number(currentUser.id) === memberId;
@@ -108,10 +120,31 @@ export default function MemberProfileScreen() {
     }
   }, [memberId, postsLoading]);
 
-  // 프로필 로드 후 게시글 로드
+  // 댓글 로드
+  const loadComments = useCallback(async (page: number = 0, reset: boolean = false) => {
+    if (commentsLoading && !reset) return;
+    setCommentsLoading(true);
+    try {
+      const data = await boardService.getCommentsByMemberId(memberId, { page, size: 10 });
+      if (page === 0 || reset) {
+        setComments(data.content);
+      } else {
+        setComments(prev => [...prev, ...data.content]);
+      }
+      setHasMoreComments(data.content.length === 10);
+      setCommentsPage(page);
+    } catch (e) {
+      console.error('Failed to load comments:', e);
+    } finally {
+      setCommentsLoading(false);
+    }
+  }, [memberId, commentsLoading]);
+
+  // 프로필 로드 후 게시글과 댓글 로드
   useEffect(() => {
     if (profile && memberId > 0) {
       loadPosts(0, true);
+      loadComments(0, true);
     }
   }, [profile, memberId]);
 
@@ -122,11 +155,11 @@ export default function MemberProfileScreen() {
     try {
       const data = await authService.getMemberProfile(memberId);
       if (data) setProfile(data);
-      await loadPosts(0, true);
+      await Promise.all([loadPosts(0, true), loadComments(0, true)]);
     } finally {
       setRefreshing(false);
     }
-  }, [memberId, refreshing, loadPosts]);
+  }, [memberId, refreshing, loadPosts, loadComments]);
 
   // 채팅하기
   const handleSendChat = async () => {
@@ -231,9 +264,20 @@ export default function MemberProfileScreen() {
 
   // 더 불러오기
   const handleLoadMore = () => {
-    if (hasMorePosts && !postsLoading) {
-      loadPosts(postsPage + 1);
+    if (activeTab === 'posts') {
+      if (hasMorePosts && !postsLoading) {
+        loadPosts(postsPage + 1);
+      }
+    } else {
+      if (hasMoreComments && !commentsLoading) {
+        loadComments(commentsPage + 1);
+      }
     }
+  };
+
+  // 댓글 클릭 (해당 게시글로 이동)
+  const handleCommentPress = (postId: number) => {
+    router.push(`/board/${postId}`);
   };
 
   const profileImageUrl = profile?.profileImageUrl?.trim();
@@ -261,6 +305,29 @@ export default function MemberProfileScreen() {
         {hasImage && (
           <Image source={{ uri: imageUrls[0] }} style={styles.postThumbnail} />
         )}
+      </Pressable>
+    );
+  };
+
+  // 댓글 아이템 렌더링
+  const renderCommentItem = ({ item }: { item: MemberCommentItem }) => {
+    return (
+      <Pressable style={styles.commentItem} onPress={() => handleCommentPress(item.postId)}>
+        <View style={styles.commentContent}>
+          {item.postTitle && (
+            <Text style={styles.commentPostTitle} numberOfLines={1}>
+              {item.postTitle}
+            </Text>
+          )}
+          <Text style={styles.commentText} numberOfLines={2}>{item.content}</Text>
+          <View style={styles.postMeta}>
+            <Text style={styles.postTime}>{formatRelativeTime(item.createdAt)}</Text>
+            <View style={styles.postStats}>
+              <Ionicons name="heart-outline" size={12} color="#9CA3AF" />
+              <Text style={styles.postStatText}>{item.likeCount ?? 0}</Text>
+            </View>
+          </View>
+        </View>
       </Pressable>
     );
   };
@@ -308,28 +375,47 @@ export default function MemberProfileScreen() {
         <Text style={styles.chatButtonText}>채팅하기</Text>
       </Pressable>
 
-      {/* 게시글 섹션 타이틀 */}
-      <View style={styles.sectionHeader}>
-        <Text style={styles.sectionTitle}>작성 게시글</Text>
+      {/* 탭 버튼 */}
+      <View style={styles.tabContainer}>
+        <Pressable
+          style={[styles.tabButton, activeTab === 'posts' && styles.tabButtonActive]}
+          onPress={() => setActiveTab('posts')}
+        >
+          <Text style={[styles.tabButtonText, activeTab === 'posts' && styles.tabButtonTextActive]}>
+            게시물
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[styles.tabButton, activeTab === 'comments' && styles.tabButtonActive]}
+          onPress={() => setActiveTab('comments')}
+        >
+          <Text style={[styles.tabButtonText, activeTab === 'comments' && styles.tabButtonTextActive]}>
+            댓글
+          </Text>
+        </Pressable>
       </View>
     </View>
   );
 
   // 빈 목록 컴포넌트
-  const renderEmpty = () => (
-    !postsLoading ? (
+  const renderEmpty = () => {
+    const isLoading = activeTab === 'posts' ? postsLoading : commentsLoading;
+    const emptyText = activeTab === 'posts' ? '작성한 게시글이 없습니다.' : '작성한 댓글이 없습니다.';
+    return !isLoading ? (
       <View style={styles.emptyContainer}>
-        <Text style={styles.emptyText}>작성한 게시글이 없습니다.</Text>
+        <Text style={styles.emptyText}>{emptyText}</Text>
       </View>
-    ) : null
-  );
+    ) : null;
+  };
 
   // 푸터 컴포넌트
-  const renderFooter = () => (
-    postsLoading && posts.length > 0 ? (
+  const renderFooter = () => {
+    const isLoading = activeTab === 'posts' ? postsLoading : commentsLoading;
+    const dataLength = activeTab === 'posts' ? posts.length : comments.length;
+    return isLoading && dataLength > 0 ? (
       <ActivityIndicator size="small" color="#4C8BF5" style={{ paddingVertical: 16 }} />
-    ) : null
-  );
+    ) : null;
+  };
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -363,9 +449,12 @@ export default function MemberProfileScreen() {
         </View>
       ) : (
         <FlatList
-          data={posts}
-          keyExtractor={(item) => String(item.id)}
-          renderItem={renderPostItem}
+          data={activeTab === 'posts' ? posts : comments}
+          keyExtractor={(item) => `${activeTab}-${item.id}`}
+          renderItem={activeTab === 'posts'
+            ? (props) => renderPostItem(props as { item: PostListItem })
+            : (props) => renderCommentItem(props as { item: MemberCommentItem })
+          }
           ListHeaderComponent={renderHeader}
           ListEmptyComponent={renderEmpty}
           ListFooterComponent={renderFooter}
@@ -514,14 +603,31 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#FFFFFF',
   },
-  sectionHeader: {
+  tabContainer: {
+    flexDirection: 'row',
     width: '100%',
-    paddingTop: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    marginTop: 8,
   },
-  sectionTitle: {
-    fontSize: 16,
+  tabButton: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderBottomWidth: 2,
+    borderBottomColor: 'transparent',
+  },
+  tabButtonActive: {
+    borderBottomColor: '#4C8BF5',
+  },
+  tabButtonText: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: '#9CA3AF',
+  },
+  tabButtonTextActive: {
+    color: '#4C8BF5',
     fontWeight: '600',
-    color: '#111827',
   },
   postItem: {
     flexDirection: 'row',
@@ -569,6 +675,26 @@ const styles = StyleSheet.create({
     height: 64,
     borderRadius: 8,
     backgroundColor: '#F3F4F6',
+  },
+  commentItem: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  commentContent: {
+    flex: 1,
+  },
+  commentPostTitle: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 4,
+  },
+  commentText: {
+    fontSize: 15,
+    color: '#111827',
+    lineHeight: 20,
+    marginBottom: 8,
   },
   emptyContainer: {
     paddingVertical: 48,

--- a/frontend/components/detail/BoothDetailModal.tsx
+++ b/frontend/components/detail/BoothDetailModal.tsx
@@ -8,6 +8,7 @@ import {
   Pressable,
   GestureResponderEvent,
   Linking,
+  Modal,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 
@@ -32,24 +33,79 @@ export default function BoothDetailModal({
 }: Props) {
   if (!visible || !booth) return null;
 
-  return (
-    <View style={styles.overlay} pointerEvents="box-none">
-      {/* 어두운 배경 */}
-      <Pressable style={styles.backdrop} onPress={onClose} />
+  const formatPriceLabel = (raw: string): string | null => {
+    const s = raw.trim();
+    // 이미 "5천원" 같은 형태가 들어오는 경우
+    const wonThousand = s.match(/(\d+)\s*천원/i);
+    if (wonThousand) return `${wonThousand[1]}천원`;
 
-      {/* 가운데 카드 */}
-      <View style={styles.card}>
-        {/* 상단 이름 + 즐겨찾기 */}
+    const won = s.match(/([\d,]+)\s*원/i);
+    if (!won) return null;
+    const value = parseInt(won[1].replace(/,/g, ""), 10);
+    if (Number.isNaN(value)) return null;
+
+    if (value % 1000 === 0) return `${value / 1000}천원`;
+    if (value >= 1000) return `${Math.round(value / 1000)}천원`;
+    return `${value}원`;
+  };
+
+  const formatQuantityLabel = (raw: string): string | null => {
+    const s = raw.trim();
+    const asKorean = s.match(/(\d+)\s*개/i);
+    if (asKorean) return `${asKorean[1]}개`;
+
+    // admin input 예: (6pcs)
+    const asPcs = s.match(/(\d+)\s*pcs/i);
+    if (asPcs) return `${asPcs[1]}개`;
+
+    const asEa = s.match(/(\d+)\s*ea/i);
+    if (asEa) return `${asEa[1]}개`;
+
+    return null;
+  };
+
+  const formatFoodMenuLine = (line: string): string => {
+    const normalized = line.replace(/[—–]/g, "-");
+    const parts = normalized
+      .split("-")
+      .map((p) => p.trim())
+      .filter(Boolean);
+    const left = parts[0] ?? normalized;
+    const right = parts[parts.length - 1] ?? "";
+
+    const qty = formatQuantityLabel(left);
+    const price = formatPriceLabel(right);
+    if (qty && price) return `${qty} — ${price}`;
+
+    // fallback: 구분자만 화면용으로 바꿔줌
+    return line.replace(/[—–]/g, "—").replace(/\s*-\s*/g, " — ");
+  };
+
+  return (
+    <Modal visible transparent animationType="fade">
+      <View style={styles.modalRoot} pointerEvents="box-none">
+        {/* 어두운 배경 */}
+        <Pressable style={styles.backdrop} onPress={() => onClose()} />
+
+        {/* 가운데 카드 */}
+        <View style={styles.card}>
+        {/* 상단 아이콘 + 이름/운영시간 + 즐겨찾기 */}
         <View style={styles.headerRow}>
-          <View style={{ flex: 1 }}>
-            <Text style={styles.boothName}>{booth.name}</Text>
-            {!!booth.time && (
-              <Text style={styles.metaText}>운영시간: {booth.time}</Text>
-            )}
-            {!!booth.host && (
-              <Text style={styles.metaText}>주최: {booth.host}</Text>
-            )}
+          <View style={styles.headerLeft}>
+            <View style={styles.iconWrap}>
+              <Ionicons name="megaphone-outline" size={18} color="#4C8BF5" />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.boothName}>{booth.name}</Text>
+              {!!booth.time && (
+                <Text style={styles.metaText}>운영시간: {booth.time}</Text>
+              )}
+              {!!booth.host && (
+                <Text style={styles.metaText}>주최: {booth.host}</Text>
+              )}
+            </View>
           </View>
+
           {eventId != null && onToggleFavorite ? (
             <Pressable
               onPress={onToggleFavorite}
@@ -68,15 +124,18 @@ export default function BoothDetailModal({
         </View>
 
         {/* 내용 영역 */}
-        {booth.type === "food" && booth.menu && (
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>메뉴</Text>
-            {booth.menu.map((m) => (
-              <Text key={m} style={styles.bodyText}>
-                {m}
-              </Text>
-            ))}
-          </View>
+        {booth.type === "food" && booth.menu && booth.menu.length > 0 && (
+          <>
+            <View style={styles.infoDivider} />
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>메뉴</Text>
+              {booth.menu.map((m) => (
+                <View key={m} style={styles.menuCard}>
+                  <Text style={styles.menuCardText}>{formatFoodMenuLine(m)}</Text>
+                </View>
+              ))}
+            </View>
+          </>
         )}
 
         {booth.type === "experience" && (
@@ -130,14 +189,15 @@ export default function BoothDetailModal({
             </Pressable>
           </View>
         )}
+        </View>
       </View>
-    </View>
+    </Modal>
   );
 }
 
 const styles = StyleSheet.create({
-  overlay: {
-    ...StyleSheet.absoluteFillObject,
+  modalRoot: {
+    flex: 1,
     justifyContent: "center",
     alignItems: "center",
     zIndex: 20,
@@ -161,7 +221,21 @@ const styles = StyleSheet.create({
   headerRow: {
     flexDirection: "row",
     alignItems: "flex-start",
-    marginBottom: 12,
+    marginBottom: 8,
+  },
+  headerLeft: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    flex: 1,
+    gap: 10,
+  },
+  iconWrap: {
+    width: 42,
+    height: 42,
+    borderRadius: 14,
+    backgroundColor: "#FFE9C7",
+    justifyContent: "center",
+    alignItems: "center",
   },
   boothName: {
     fontSize: 16,
@@ -171,6 +245,12 @@ const styles = StyleSheet.create({
   metaText: {
     fontSize: 12,
     color: "#666",
+  },
+  infoDivider: {
+    marginTop: 10,
+    marginBottom: 10,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: "#E5E7EB",
   },
   starButton: {
     marginLeft: 8,
@@ -188,6 +268,20 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#444",
     lineHeight: 18,
+  },
+  menuCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    marginTop: 10,
+    borderWidth: 1,
+    borderColor: "#F3F4F6",
+  },
+  menuCardText: {
+    fontSize: 14,
+    color: "#111827",
+    fontWeight: "700",
   },
   linkRow: {
     flexDirection: "row",

--- a/frontend/components/detail/EventDetailHeader.tsx
+++ b/frontend/components/detail/EventDetailHeader.tsx
@@ -96,7 +96,12 @@ interface Props {
 
 export default function EventDetailHeader({ id, event, loading, error, onShare, onSave, isLiked = false, likeCount, onLike, isLoggedIn = false, isScraped = false }: Props) {
   const router = useRouter();
-  const posterUri = event?.posterUrls?.[0] ?? DEFAULT_POSTER_URI;
+  // 등록 시 선택한 대표 썸네일(thumbnailUrl)을 우선 사용하고,
+  // 없으면 상세 포스터 배열의 첫 번째 이미지를 사용
+  const posterUri =
+    (event?.thumbnailUrl as string | null | undefined)?.trim() ||
+    event?.posterUrls?.[0] ||
+    DEFAULT_POSTER_URI;
   const [clickCount, setClickCount] = useState<number | null>(null);
   const [hasReminder, setHasReminder] = useState(false);
 

--- a/frontend/services/board.service.ts
+++ b/frontend/services/board.service.ts
@@ -152,6 +152,33 @@ export async function getPostsByMemberId(
   return normalizeListImageUrls(data);
 }
 
+/** 특정 사용자의 댓글 목록 (공개 조회) */
+export type MemberCommentItem = {
+  id: number;
+  postId: number;
+  postTitle?: string;
+  content: string;
+  authorId: number;
+  authorNickname: string;
+  authorProfileImageUrl?: string;
+  likeCount: number;
+  createdAt: string;
+  updatedAt?: string;
+  deleted?: boolean;
+};
+
+export async function getCommentsByMemberId(
+  memberId: number,
+  params?: { page?: number; size?: number }
+): Promise<PageResponse<MemberCommentItem>> {
+  const page = params?.page ?? 0;
+  const size = params?.size ?? 20;
+  const url = `${API_BASE_URL}/api/members/${memberId}/comments?page=${page}&size=${size}`;
+  const res = await fetch(url, { headers: await getAuthHeaders() });
+  if (!res.ok) throw new Error(`getCommentsByMemberId failed: ${res.status}`);
+  return res.json();
+}
+
 /** 상대 경로 이미지 URL을 API 기준으로 절대 URL로 변환 */
 function toAbsoluteImageUrls(urls: string[] | undefined): string[] {
   if (!urls || !Array.isArray(urls)) return [];

--- a/frontend/services/event.service.ts
+++ b/frontend/services/event.service.ts
@@ -231,6 +231,7 @@ export async function getEventsOnMap(params: {
 type EventDetailResponseRaw = {
   id: number;
   title: string;
+  thumbnailUrl?: string | null;
   posterUrls: string[] | null;
   startAt: string | number[];
   endAt: string | number[];
@@ -264,6 +265,7 @@ export async function getEventDetail(id: string): Promise<EventDetail> {
   return {
     id: raw.id,
     title: raw.title,
+    thumbnailUrl: raw.thumbnailUrl ?? null,
     posterUrls: raw.posterUrls ?? [],
     startAt: typeof raw.startAt === 'string' ? raw.startAt : toIsoDateString(raw.startAt),
     endAt: typeof raw.endAt === 'string' ? raw.endAt : toIsoDateString(raw.endAt),

--- a/frontend/services/savedPost.service.ts
+++ b/frontend/services/savedPost.service.ts
@@ -69,3 +69,18 @@ export async function toggleSavedPost(
   await setStored(list);
   return true;
 }
+
+/** 이미 저장된 게시글의 썸네일 URL을 갱신 (백필용) */
+export async function updateSavedPostThumbnail(
+  postId: number,
+  imageUrl: string
+): Promise<void> {
+  const list = await getStored();
+  const idx = list.findIndex((p) => p.id === postId);
+  if (idx < 0) return;
+  list[idx] = {
+    ...list[idx],
+    imageUrl,
+  };
+  await setStored(list);
+}

--- a/frontend/types/event.ts
+++ b/frontend/types/event.ts
@@ -92,6 +92,8 @@ export interface EventExtra {
 export interface EventDetail {
   id: number;
   title: string;
+  /** 등록 시 선택한 대표 썸네일(포스터) — 목록/지도/상세 공통 사용 */
+  thumbnailUrl?: string | null;
   posterUrls: string[];
   startAt: string;
   endAt: string;


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->
앱 이름 한글화 적용, Refresh Token 단독 검증을 통한 토큰 재발급 로직 개선, 사용자 프로필 내 댓글 조회 기능 추가, 행사 썸네일(Thumbnail) 분리 적용 및 프론트엔드 전반의 UI/UX 버그 수정 사항을 포함합니다.

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #158
- Refs #161
- Refs #162
- Refs #163
- Refs #164

## 작업 내용
- [x] 앱 이름 변경 (app.json Dailo -> 다일로) 및 로컬 DB 포트 변경 (3307 -> 3306)
- [x] 토큰 재발급(/reissue) 시 Access Token 파라미터 제거 및 Refresh Token 단독 검증으로 로직 단순화
- [x] 카카오 소셜 로그인 시 발급된 Refresh Token DB 저장 로직 추가
- [x] JWT Principal 타입(이메일 형식 vs 카카오 숫자 ID) 호환 처리 (Block, Chat 서비스 등 예외 처리 보강)
- [x] 타 사용자 및 내가 쓴 댓글 조회를 위한 API(/api/members/{id}/comments) 추가 및 프론트엔드 연동 (마이페이지, 프로필 탭)
- [x] 행사 목록 및 지도 렌더링 성능 개선을 위해 썸네일(thumbnailUrl)과 포스터(posterUrls) 응답 데이터 분리
- [x] 행사 종료 여부에 따른 뱃지 표시, 지나간 행사 기본 숨김 처리 및 하단 탭바 여백(Bottom Inset) 이슈 해결

## 체크리스트
- [x] 빌드가 에러 없이 수행되는가?
- [x] 불필요한 로그(console.log 등)는 없는가?