### PR TITLE
Fix/bin

### DIFF
--- a/backend/src/main/java/com/dailo/backend/dto/CommentResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/CommentResponseDto.java
@@ -28,6 +28,8 @@ public class CommentResponseDto {
     private String authorProfileImageUrl;
     private String content;
     private Integer likeCount;
+    /** 현재 로그인 사용자가 이 댓글에 좋아요를 눌렀는지 */
+    private Boolean isLiked;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     /** 삭제된 댓글 여부 */
@@ -84,12 +86,26 @@ public class CommentResponseDto {
     public static CommentResponseDto fromWithReplies(Comment comment, List<Comment> replies,
                                                      java.util.Map<Long, String> authorNicknameMap,
                                                      java.util.Map<Long, String> authorProfileImageUrlMap) {
+        return fromWithReplies(comment, replies, authorNicknameMap, authorProfileImageUrlMap, java.util.Collections.emptySet());
+    }
+
+    public static CommentResponseDto fromWithReplies(Comment comment, List<Comment> replies,
+                                                     java.util.Map<Long, String> authorNicknameMap,
+                                                     java.util.Map<Long, String> authorProfileImageUrlMap,
+                                                     java.util.Set<Long> likedIds) {
         String fromMap = authorNicknameMap != null ? authorNicknameMap.get(comment.getAuthorId()) : null;
         String profileUrl = authorProfileImageUrlMap != null ? authorProfileImageUrlMap.get(comment.getAuthorId()) : null;
         CommentResponseDto dto = from(comment, fromMap, profileUrl);
+        dto.isLiked = likedIds.contains(comment.getId());
         if (replies != null && !replies.isEmpty()) {
             dto.getReplies().addAll(replies.stream()
-                    .map(r -> from(r, authorNicknameMap != null ? authorNicknameMap.get(r.getAuthorId()) : null, authorProfileImageUrlMap != null ? authorProfileImageUrlMap.get(r.getAuthorId()) : null))
+                    .map(r -> {
+                        CommentResponseDto replyDto = from(r,
+                                authorNicknameMap != null ? authorNicknameMap.get(r.getAuthorId()) : null,
+                                authorProfileImageUrlMap != null ? authorProfileImageUrlMap.get(r.getAuthorId()) : null);
+                        replyDto.isLiked = likedIds.contains(r.getId());
+                        return replyDto;
+                    })
                     .toList());
         }
         return dto;

--- a/backend/src/main/java/com/dailo/backend/dto/PostListResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/PostListResponseDto.java
@@ -67,6 +67,10 @@ public class PostListResponseDto {
     }
 
     public static PostListResponseDto from(Post post, String authorNickname, Boolean liked, String eventTitle, String authorProfileImageUrl) {
+        return from(post, authorNickname, liked, eventTitle, authorProfileImageUrl, null);
+    }
+
+    public static PostListResponseDto from(Post post, String authorNickname, Boolean liked, String eventTitle, String authorProfileImageUrl, Integer commentCount) {
         return PostListResponseDto.builder()
                 .id(post.getId())
                 .authorId(post.getAuthorId())
@@ -79,7 +83,7 @@ public class PostListResponseDto {
                 .imageUrls(parseImageUrls(post.getImageUrlsJson()))
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())
-                .commentCount(post.getCommentCount())
+                .commentCount(commentCount != null ? commentCount : post.getCommentCount())
                 .createdAt(post.getCreatedAt())
                 .liked(liked)
                 .build();

--- a/backend/src/main/java/com/dailo/backend/entity/Comment.java
+++ b/backend/src/main/java/com/dailo/backend/entity/Comment.java
@@ -57,17 +57,13 @@ public class Comment {
         this.updatedAt = LocalDateTime.now();
     }
 
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
     // 비즈니스 메서드
     public void update(String content) {
         if (content == null || content.trim().isEmpty()) {
             throw new IllegalArgumentException("Content cannot be empty");
         }
         this.content = content;
+        this.updatedAt = LocalDateTime.now();
     }
 
     public void increaseLikeCount() {

--- a/backend/src/main/java/com/dailo/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/CommentRepository.java
@@ -75,4 +75,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 보여줄 수 있는 대댓글 수 (삭제되지 않은 대댓글만 카운트)
     @Query("SELECT COUNT(c) FROM Comment c WHERE c.parentComment = :parentComment AND c.deletedAt IS NULL")
     long countVisibleReplies(@Param("parentComment") Comment parentComment);
+
+    // 여러 게시글의 삭제되지 않은 댓글 수 (대댓글 포함) 배치 조회
+    @Query("SELECT c.post.id, COUNT(c) FROM Comment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL GROUP BY c.post.id")
+    List<Object[]> countNonDeletedCommentsByPostIds(@Param("postIds") java.util.Collection<Long> postIds);
 }

--- a/backend/src/main/java/com/dailo/backend/service/CommentService.java
+++ b/backend/src/main/java/com/dailo/backend/service/CommentService.java
@@ -106,10 +106,20 @@ public class CommentService {
                     }
                 }));
 
+        // 현재 유저가 좋아요 누른 댓글 ID 조회 (한 번의 쿼리로)
+        Set<Long> allCommentIds = new java.util.HashSet<>();
+        for (Comment c : topList) {
+            allCommentIds.add(c.getId());
+            getReplies(c, invisibleIds).forEach(r -> allCommentIds.add(r.getId()));
+        }
+        Set<Long> likedCommentIds = (userId != null && !allCommentIds.isEmpty())
+                ? commentLikeRepository.findLikedCommentIds(userId, allCommentIds)
+                : Collections.emptySet();
+
         List<CommentResponseDto> dtos = topList.stream()
                 .map(comment -> {
                     List<Comment> replies = getReplies(comment, invisibleIds);
-                    return CommentResponseDto.fromWithReplies(comment, replies, authorNicknameMap, authorProfileImageUrlMap);
+                    return CommentResponseDto.fromWithReplies(comment, replies, authorNicknameMap, authorProfileImageUrlMap, likedCommentIds);
                 })
                 .toList();
         return new PageImpl<>(dtos, pageable, (long) topList.size());

--- a/backend/src/main/java/com/dailo/backend/service/PostService.java
+++ b/backend/src/main/java/com/dailo/backend/service/PostService.java
@@ -83,6 +83,17 @@ public class PostService {
         return events.stream().collect(Collectors.toMap(Event::getId, Event::getTitle, (a, b) -> a));
     }
 
+    /** postId -> 실제 삭제되지 않은 댓글 수 (대댓글 포함) 배치 조회 */
+    private Map<Long, Integer> getCommentCountMap(List<Post> posts) {
+        Set<Long> postIds = posts.stream().map(Post::getId).collect(Collectors.toSet());
+        if (postIds.isEmpty()) return Map.of();
+        return commentRepository.countNonDeletedCommentsByPostIds(postIds).stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).longValue(),
+                        row -> ((Number) row[1]).intValue()
+                ));
+    }
+
     /** 내가 쓴 글 목록 (마이페이지 게시판 기록) */
     public Page<PostListResponseDto> getMyPosts(String email, Pageable pageable) {
         Long authorId = resolveMemberId(email);
@@ -90,7 +101,8 @@ public class PostService {
         List<Post> posts = page.getContent();
         var authorMaps = getAuthorNicknameAndProfileMaps(posts);
         Map<Long, String> eventTitleMap = getEventTitleMap(posts);
-        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), null, post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId())));
+        Map<Long, Integer> commentCountMap = getCommentCountMap(posts);
+        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), null, post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()), commentCountMap.getOrDefault(post.getId(), 0)));
     }
 
     public Page<PostListResponseDto> getAllPosts(String email, Pageable pageable) {
@@ -107,8 +119,9 @@ public class PostService {
         List<Post> posts = page.getContent();
         var authorMaps = getAuthorNicknameAndProfileMaps(posts);
         Map<Long, String> eventTitleMap = getEventTitleMap(posts);
+        Map<Long, Integer> commentCountMap = getCommentCountMap(posts);
         Set<Long> likedPostIds = (userId != null) ? postLikeRepository.findPostIdsByMemberId(userId) : Set.of();
-        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId())));
+        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()), commentCountMap.getOrDefault(post.getId(), 0)));
     }
 
     @Transactional
@@ -200,8 +213,9 @@ public class PostService {
         List<Post> posts = page.getContent();
         var authorMaps = getAuthorNicknameAndProfileMaps(posts);
         Map<Long, String> eventTitleMap = getEventTitleMap(posts);
+        Map<Long, Integer> commentCountMap = getCommentCountMap(posts);
         Set<Long> likedPostIds = (userId != null) ? postLikeRepository.findPostIdsByMemberId(userId) : Set.of();
-        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId())));
+        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()), commentCountMap.getOrDefault(post.getId(), 0)));
     }
 
     /** 내가 댓글 단 글 목록 (마이페이지) - 인증 필요 */
@@ -217,9 +231,10 @@ public class PostService {
         List<Post> ordered = postIds.stream().map(postMap::get).filter(p -> p != null).toList();
         var authorMaps = getAuthorNicknameAndProfileMaps(ordered);
         Map<Long, String> eventTitleMap = getEventTitleMap(ordered);
+        Map<Long, Integer> commentCountMap = getCommentCountMap(ordered);
         Set<Long> likedPostIds = postLikeRepository.findPostIdsByMemberId(userId);
         List<PostListResponseDto> content = ordered.stream()
-                .map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId())))
+                .map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()), commentCountMap.getOrDefault(post.getId(), 0)))
                 .toList();
         return new PageImpl<>(content, pageable, total);
     }
@@ -231,10 +246,11 @@ public class PostService {
         List<Post> posts = likePage.getContent().stream().map(PostLike::getPost).toList();
         var authorMaps = getAuthorNicknameAndProfileMaps(posts);
         Map<Long, String> eventTitleMap = getEventTitleMap(posts);
+        Map<Long, Integer> commentCountMap = getCommentCountMap(posts);
         List<PostListResponseDto> content = likePage.getContent().stream()
                 .map(pl -> {
                     Post p = pl.getPost();
-                    return PostListResponseDto.from(p, authorMaps.getFirst().get(p.getAuthorId()), true, p.getEventId() != null ? eventTitleMap.get(p.getEventId()) : null, authorMaps.getSecond().get(p.getAuthorId()));
+                    return PostListResponseDto.from(p, authorMaps.getFirst().get(p.getAuthorId()), true, p.getEventId() != null ? eventTitleMap.get(p.getEventId()) : null, authorMaps.getSecond().get(p.getAuthorId()), commentCountMap.getOrDefault(p.getId(), 0));
                 })
                 .toList();
         return new PageImpl<>(content, likePage.getPageable(), likePage.getTotalElements());
@@ -282,8 +298,9 @@ public class PostService {
         List<Post> posts = page.getContent();
         var authorMaps = getAuthorNicknameAndProfileMaps(posts);
         Map<Long, String> eventTitleMap = getEventTitleMap(posts);
+        Map<Long, Integer> commentCountMap = getCommentCountMap(posts);
         Set<Long> likedPostIds = (userId != null) ? postLikeRepository.findPostIdsByMemberId(userId) : Set.of();
-        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId())));
+        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()), commentCountMap.getOrDefault(post.getId(), 0)));
     }
 
     public Page<PostListResponseDto> searchPosts(String keyword, String email, Pageable pageable) {
@@ -301,8 +318,9 @@ public class PostService {
                             List<Post> one = List.of(post);
                             var authorMaps = getAuthorNicknameAndProfileMaps(one);
                             Map<Long, String> eventTitleMap = getEventTitleMap(one);
+                            Map<Long, Integer> commentCountMap = getCommentCountMap(one);
                             Set<Long> likedPostIds = (userId != null) ? postLikeRepository.findPostIdsByMemberId(userId) : Set.of();
-                            PostListResponseDto dto = PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()));
+                            PostListResponseDto dto = PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()), commentCountMap.getOrDefault(post.getId(), 0));
                             return new PageImpl<>(List.of(dto), pageable, 1);
                         })
                         .orElseGet(() -> searchPostsByTitle(keyword, userId, pageable));
@@ -326,8 +344,9 @@ public class PostService {
         List<Post> posts = page.getContent();
         var authorMaps = getAuthorNicknameAndProfileMaps(posts);
         Map<Long, String> eventTitleMap = getEventTitleMap(posts);
+        Map<Long, Integer> commentCountMap = getCommentCountMap(posts);
         Set<Long> likedPostIds = (userId != null) ? postLikeRepository.findPostIdsByMemberId(userId) : Set.of();
-        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId())));
+        return page.map(post -> PostListResponseDto.from(post, authorMaps.getFirst().get(post.getAuthorId()), likedPostIds.contains(post.getId()), post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null, authorMaps.getSecond().get(post.getAuthorId()), commentCountMap.getOrDefault(post.getId(), 0)));
     }
 
     /** 게시글 좋아요 토글. 반환값: 좋아요 누른 상태(true) / 취소(false) */
@@ -375,6 +394,7 @@ public class PostService {
         List<Post> posts = page.getContent();
         var authorMaps = getAuthorNicknameAndProfileMaps(posts);
         Map<Long, String> eventTitleMap = getEventTitleMap(posts);
+        Map<Long, Integer> commentCountMap = getCommentCountMap(posts);
         Set<Long> likedPostIds = (viewerId != null) ? postLikeRepository.findPostIdsByMemberId(viewerId) : Set.of();
 
         return page.map(post -> PostListResponseDto.from(
@@ -382,7 +402,8 @@ public class PostService {
                 authorMaps.getFirst().get(post.getAuthorId()),
                 likedPostIds.contains(post.getId()),
                 post.getEventId() != null ? eventTitleMap.get(post.getEventId()) : null,
-                authorMaps.getSecond().get(post.getAuthorId())
+                authorMaps.getSecond().get(post.getAuthorId()),
+                commentCountMap.getOrDefault(post.getId(), 0)
         ));
     }
 }

--- a/frontend/app/(tabs)/map/_components/NaverMap.tsx
+++ b/frontend/app/(tabs)/map/_components/NaverMap.tsx
@@ -56,7 +56,7 @@ type Props = {
   events: Event[];
   onMarkerPress: (event: Event) => void;
   /** 카메라 이동이 끝났을 때(드래그/줌 후) 호출. region 동기화용 (latitude/longitude는 남서쪽, center 아님) */
-  onCameraIdle?: (params: { region: { latitude: number; longitude: number; latitudeDelta: number; longitudeDelta: number } }) => void;
+  onCameraIdle?: (params: { region: { latitude: number; longitude: number; latitudeDelta: number; longitudeDelta: number }; zoom?: number }) => void;
   /** 현재 위치 버튼을 눌렀을 때 표시할 파란 동그라미 위치 */
   currentLocation?: { latitude: number; longitude: number } | null;
   /** 동그라미 표시용 좌표(실제 위치 못 받을 때 fallback 등). 있으면 이걸 우선 사용 */

--- a/frontend/app/(tabs)/map/_components/SideMenu.tsx
+++ b/frontend/app/(tabs)/map/_components/SideMenu.tsx
@@ -220,7 +220,7 @@ export function SideMenu({
               onPress={() => {
                 onClose();
                 if (onPressGuide) onPressGuide();
-                else router.push('/(tabs)/mypage/guide');
+                else router.push({ pathname: '/(tabs)/mypage/guide', params: { from: 'map' } });
               }}
             />
             <MenuRow

--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -1087,7 +1087,7 @@ export default function MapScreen() {
       ]);
       return;
     }
-    router.push('/(tabs)/mypage/saved-festivals');
+    router.push({ pathname: '/(tabs)/mypage/saved-festivals', params: { from: 'map' } });
   };
 
   const handlePressActiveFestivalFromMenu = () => {
@@ -1743,11 +1743,11 @@ export default function MapScreen() {
             ]);
             return;
           }
-          router.push('/(tabs)/mypage/saved-festivals');
+          router.push({ pathname: '/(tabs)/mypage/saved-festivals', params: { from: 'map' } });
         }}
         onPressMyActivities={() => {
           setIsMenuOpen(false);
-          router.push('/(tabs)/mypage/participated-festivals');
+          router.push({ pathname: '/(tabs)/mypage/participated-festivals', params: { from: 'map' } });
         }}
         onPressDirection={() => {
           setIsMenuOpen(false);
@@ -1759,7 +1759,7 @@ export default function MapScreen() {
         }}
         onPressSettings={() => {
           setIsMenuOpen(false);
-          router.push('/(tabs)/mypage/settings');
+          router.push({ pathname: '/(tabs)/mypage/settings', params: { from: 'map' } });
         }}
         onPressRefreshLocationAndCheck={handleRefreshLocationAndCheckZone}
       />

--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -1202,6 +1202,19 @@ export default function MapScreen() {
     closeEventListSheet();
     handleMarkerPress(event);
     setSheetMode('collapsed');
+    if (
+      mapRef.current &&
+      event.latitude != null &&
+      event.longitude != null &&
+      Number.isFinite(event.latitude) &&
+      Number.isFinite(event.longitude)
+    ) {
+      mapRef.current.animateCameraTo({
+        latitude: event.latitude,
+        longitude: event.longitude,
+        zoom: 15,
+      });
+    }
   };
 
   // 행사 참여 칩: 왼쪽 상단 (필터 칩 아래 10dp). 규모·북마크: 칩이 있으면 칩 아래에 배치.

--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -1328,7 +1328,9 @@ export default function MapScreen() {
                   if (!r || !Number.isFinite(r.latitude) || !Number.isFinite(r.longitude)) return;
                   const centerLat = r.latitude + r.latitudeDelta / 2;
                   const centerLng = r.longitude + r.longitudeDelta / 2;
-                  const zoom = 14 - Math.round(Math.log2(r.latitudeDelta / 0.01));
+                  const zoom = params.zoom != null
+                    ? Math.round(params.zoom)
+                    : 14 - Math.round(Math.log2(r.latitudeDelta / 0.01));
                   lastCameraRef.current = {
                     latitude: centerLat,
                     longitude: centerLng,
@@ -1541,11 +1543,7 @@ export default function MapScreen() {
                       const centerLng = lastCameraRef.current?.longitude ?? (region ? region.longitude + region.longitudeDelta / 2 : DEFAULT_CAMERA.longitude);
                       const currentZoom = lastCameraRef.current?.zoom ?? naverMapCamera.zoom;
                       if (!mapRef.current) return;
-                      /** 확대 1회 누르면 기본 배율(16)로, 그 이상이면 1단계씩 */
-                      const DEFAULT_ZOOM_LEVEL = 16;
-                      const newZoom = currentZoom < DEFAULT_ZOOM_LEVEL
-                        ? DEFAULT_ZOOM_LEVEL
-                        : Math.min(18, currentZoom + 1);
+                      const newZoom = Math.min(18, currentZoom + 1);
                       lastCameraRef.current = { latitude: centerLat, longitude: centerLng, zoom: newZoom };
                       mapRef.current.animateCameraTo({
                         latitude: centerLat,

--- a/frontend/app/(tabs)/mypage/guide.tsx
+++ b/frontend/app/(tabs)/mypage/guide.tsx
@@ -10,7 +10,8 @@ import {
   Pressable,
   RefreshControl,
 } from 'react-native';
-import { Stack, router } from 'expo-router';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
+import { useNavigation, TabActions, StackActions } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as contentService from '../../../services/content.service';
@@ -40,6 +41,16 @@ function renderLine(line: string, index: number): React.ReactNode {
 }
 
 export default function GuideScreen() {
+  const { from } = useLocalSearchParams<{ from?: string }>();
+  const navigation = useNavigation();
+  const goBack = () => {
+    if (from === 'map') {
+      navigation.dispatch(StackActions.popToTop());
+      navigation.dispatch(TabActions.jumpTo('map/index'));
+    } else {
+      router.replace('/(tabs)/mypage');
+    }
+  };
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -75,7 +86,7 @@ export default function GuideScreen() {
           headerTitleAlign: 'center',
           headerLeft: () => (
             <Pressable
-              onPress={() => router.replace('/(tabs)/mypage')}
+              onPress={goBack}
               hitSlop={8}
               style={{ paddingHorizontal: 4 }}
             >

--- a/frontend/app/(tabs)/mypage/guide.tsx
+++ b/frontend/app/(tabs)/mypage/guide.tsx
@@ -11,7 +11,6 @@ import {
   RefreshControl,
 } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
-import { useNavigation, TabActions, StackActions } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as contentService from '../../../services/content.service';
@@ -42,11 +41,10 @@ function renderLine(line: string, index: number): React.ReactNode {
 
 export default function GuideScreen() {
   const { from } = useLocalSearchParams<{ from?: string }>();
-  const navigation = useNavigation();
   const goBack = () => {
     if (from === 'map') {
-      navigation.dispatch(StackActions.popToTop());
-      navigation.dispatch(TabActions.jumpTo('map/index'));
+      router.replace('/(tabs)/mypage');
+      router.replace('/(tabs)/map');
     } else {
       router.replace('/(tabs)/mypage');
     }

--- a/frontend/app/(tabs)/mypage/participated-festivals.tsx
+++ b/frontend/app/(tabs)/mypage/participated-festivals.tsx
@@ -11,7 +11,8 @@ import {
   TouchableOpacity,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
+import { useNavigation, TabActions, StackActions } from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useFocusEffect } from "@react-navigation/native";
 import { getCompletedStaySessions, type StaySessionResponseDto } from "../../../services/location.service";
@@ -24,6 +25,16 @@ import {
 } from "../../../utils/staySessionFormat";
 
 export default function ParticipatedFestivalsScreen() {
+  const { from } = useLocalSearchParams<{ from?: string }>();
+  const navigation = useNavigation();
+  const goBack = () => {
+    if (from === 'map') {
+      navigation.dispatch(StackActions.popToTop());
+      navigation.dispatch(TabActions.jumpTo('map/index'));
+    } else {
+      router.back();
+    }
+  };
   const [list, setList] = useState<StaySessionResponseDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -64,7 +75,7 @@ export default function ParticipatedFestivalsScreen() {
     <SafeAreaView style={styles.safeArea} edges={["top", "left", "right", "bottom"]}>
       <View style={styles.container}>
         <View style={styles.header}>
-          <Pressable style={styles.headerBack} onPress={() => router.back()}>
+          <Pressable style={styles.headerBack} onPress={goBack}>
             <Ionicons name="arrow-back" size={22} color="#111827" />
           </Pressable>
           <View style={styles.headerTitleWrap} pointerEvents="box-none">

--- a/frontend/app/(tabs)/mypage/participated-festivals.tsx
+++ b/frontend/app/(tabs)/mypage/participated-festivals.tsx
@@ -12,7 +12,6 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
-import { useNavigation, TabActions, StackActions } from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useFocusEffect } from "@react-navigation/native";
 import { getCompletedStaySessions, type StaySessionResponseDto } from "../../../services/location.service";
@@ -26,11 +25,10 @@ import {
 
 export default function ParticipatedFestivalsScreen() {
   const { from } = useLocalSearchParams<{ from?: string }>();
-  const navigation = useNavigation();
   const goBack = () => {
     if (from === 'map') {
-      navigation.dispatch(StackActions.popToTop());
-      navigation.dispatch(TabActions.jumpTo('map/index'));
+      router.replace('/(tabs)/mypage');
+      router.replace('/(tabs)/map');
     } else {
       router.back();
     }

--- a/frontend/app/(tabs)/mypage/saved-festivals.tsx
+++ b/frontend/app/(tabs)/mypage/saved-festivals.tsx
@@ -13,7 +13,6 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
-import { useNavigation, TabActions, StackActions } from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import * as scrapService from "../../../services/scrap.service";
 
@@ -45,11 +44,10 @@ function formatTimeRange(startIso: string, endIso?: string): string {
 
 export default function SavedFestivalsScreen() {
   const { from } = useLocalSearchParams<{ from?: string }>();
-  const navigation = useNavigation();
   const goBack = () => {
     if (from === 'map') {
-      navigation.dispatch(StackActions.popToTop());
-      navigation.dispatch(TabActions.jumpTo('map/index'));
+      router.replace('/(tabs)/mypage');
+      router.replace('/(tabs)/map');
     } else {
       router.replace('/(tabs)/mypage');
     }

--- a/frontend/app/(tabs)/mypage/saved-festivals.tsx
+++ b/frontend/app/(tabs)/mypage/saved-festivals.tsx
@@ -12,7 +12,8 @@ import {
   Image,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { router, useFocusEffect } from "expo-router";
+import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
+import { useNavigation, TabActions, StackActions } from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import * as scrapService from "../../../services/scrap.service";
 
@@ -43,6 +44,16 @@ function formatTimeRange(startIso: string, endIso?: string): string {
 }
 
 export default function SavedFestivalsScreen() {
+  const { from } = useLocalSearchParams<{ from?: string }>();
+  const navigation = useNavigation();
+  const goBack = () => {
+    if (from === 'map') {
+      navigation.dispatch(StackActions.popToTop());
+      navigation.dispatch(TabActions.jumpTo('map/index'));
+    } else {
+      router.replace('/(tabs)/mypage');
+    }
+  };
   const [list, setList] = useState<scrapService.ScrapEventItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -119,7 +130,7 @@ export default function SavedFestivalsScreen() {
     return (
       <SafeAreaView style={styles.safeArea} edges={["top", "left", "right", "bottom"]}>
         <View style={styles.header}>
-          <Pressable style={styles.headerBack} onPress={() => router.replace("/(tabs)/mypage")}>
+          <Pressable style={styles.headerBack} onPress={() => goBack()}>
             <Ionicons name="arrow-back" size={22} color="#111827" />
           </Pressable>
           <View style={styles.headerTitleWrap} pointerEvents="box-none">
@@ -137,7 +148,7 @@ export default function SavedFestivalsScreen() {
   return (
     <SafeAreaView style={styles.safeArea} edges={["top", "left", "right", "bottom"]}>
       <View style={styles.header}>
-        <Pressable style={styles.headerBack} onPress={() => router.replace("/(tabs)/mypage")}>
+        <Pressable style={styles.headerBack} onPress={() => goBack()}>
           <Ionicons name="arrow-back" size={22} color="#111827" />
         </Pressable>
         <View style={styles.headerTitleWrap} pointerEvents="box-none">

--- a/frontend/app/(tabs)/mypage/settings.tsx
+++ b/frontend/app/(tabs)/mypage/settings.tsx
@@ -6,18 +6,16 @@ import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../../../hooks/useAuth';
 import { useSafeBack } from '../../../hooks/useSafeBack';
-import { useNavigation, TabActions, StackActions } from '@react-navigation/native';
 import * as authService from '../../../services/auth.service';
 
 export default function MyPageSettingsScreen() {
   const { isLoggedIn, logout } = useAuth();
   const safeBack = useSafeBack();
-  const navigation = useNavigation();
   const { from } = useLocalSearchParams<{ from?: string }>();
   const goBack = () => {
     if (from === 'map') {
-      navigation.dispatch(StackActions.popToTop());
-      navigation.dispatch(TabActions.jumpTo('map/index'));
+      router.replace('/(tabs)/mypage');
+      router.replace('/(tabs)/map');
     } else {
       safeBack();
     }

--- a/frontend/app/(tabs)/mypage/settings.tsx
+++ b/frontend/app/(tabs)/mypage/settings.tsx
@@ -1,16 +1,27 @@
 // app/(tabs)/mypage/settings.tsx
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Pressable, Alert, ActivityIndicator } from 'react-native';
-import { Stack, router } from 'expo-router';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../../../hooks/useAuth';
 import { useSafeBack } from '../../../hooks/useSafeBack';
+import { useNavigation, TabActions, StackActions } from '@react-navigation/native';
 import * as authService from '../../../services/auth.service';
 
 export default function MyPageSettingsScreen() {
   const { isLoggedIn, logout } = useAuth();
   const safeBack = useSafeBack();
+  const navigation = useNavigation();
+  const { from } = useLocalSearchParams<{ from?: string }>();
+  const goBack = () => {
+    if (from === 'map') {
+      navigation.dispatch(StackActions.popToTop());
+      navigation.dispatch(TabActions.jumpTo('map/index'));
+    } else {
+      safeBack();
+    }
+  };
   const [withdrawing, setWithdrawing] = useState(false);
 
   const handleWithdraw = () => {
@@ -59,7 +70,7 @@ export default function MyPageSettingsScreen() {
           headerTitleAlign: 'center',
           headerLeft: () => (
             <Pressable
-              onPress={safeBack}
+              onPress={goBack}
               hitSlop={8}
               style={styles.headerBackButton}
             >

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -15,6 +15,7 @@ import {
   Image,
   useWindowDimensions,
   RefreshControl,
+  Animated,
 } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -93,6 +94,14 @@ export default function PostDetailScreen() {
   const scrollViewRef = useRef<ScrollView>(null);
   const commentSectionY = useRef(0);
   const [refreshing, setRefreshing] = useState(false);
+  const postLikeAnim = useRef(new Animated.Value(1)).current;
+  const commentLikeAnims = useRef<Map<string, Animated.Value>>(new Map());
+  const getCommentLikeAnim = useCallback((commentId: string) => {
+    if (!commentLikeAnims.current.has(commentId)) {
+      commentLikeAnims.current.set(commentId, new Animated.Value(1));
+    }
+    return commentLikeAnims.current.get(commentId)!;
+  }, []);
   const [imageViewerVisible, setImageViewerVisible] = useState(false);
   const [imageViewerIndex, setImageViewerIndex] = useState(0);
 
@@ -160,10 +169,12 @@ export default function PostDetailScreen() {
     [apiComments, deletedCommentIds]
   );
   const comments = useMemo(() => filteredApiComments.map(toCommentDisplay), [filteredApiComments]);
-  const likeCount = post ? (post.likeCount ?? 0) : 0;
+  const [localLikeCount, setLocalLikeCount] = useState<number | null>(null);
+  const likeCount = localLikeCount ?? (post ? (post.likeCount ?? 0) : 0);
 
   useEffect(() => {
     setLiked(post?.isLiked ?? false);
+    setLocalLikeCount(null);
   }, [post?.id, post?.isLiked]);
 
   useEffect(() => {
@@ -426,6 +437,13 @@ export default function PostDetailScreen() {
     router.push(`/profile/${authorId}`);
   };
 
+  const runLikeAnim = useCallback((anim: Animated.Value) => {
+    Animated.sequence([
+      Animated.spring(anim, { toValue: 1.5, useNativeDriver: true, speed: 30, bounciness: 12 }),
+      Animated.spring(anim, { toValue: 1, useNativeDriver: true, speed: 20, bounciness: 4 }),
+    ]).start();
+  }, []);
+
   const toggleLike = async () => {
     if (!isLoggedIn) {
       Alert.alert("로그인 필요", "좋아요를 누르려면 로그인해 주세요.", [
@@ -438,8 +456,9 @@ export default function PostDetailScreen() {
     try {
       const userId = user?.id != null ? Number(user.id) : undefined;
       const res = await boardService.togglePostLike(id, userId);
+      if (res.liked) runLikeAnim(postLikeAnim);
       setLiked(res.liked);
-      await refetchPost();
+      setLocalLikeCount(res.likeCount ?? (likeCount + (res.liked ? 1 : -1)));
     } catch (e) {
       const msg = e instanceof Error ? e.message : "좋아요 처리에 실패했습니다.";
       const isAuthError = msg.includes("로그인이 만료");
@@ -461,6 +480,7 @@ export default function PostDetailScreen() {
     }
     try {
       const result = await boardService.toggleCommentLike(commentId);
+      if (result.liked) runLikeAnim(getCommentLikeAnim(commentId));
       updateCommentLike(commentId, result.liked, result.likeCount);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "좋아요 처리에 실패했습니다.";
@@ -662,7 +682,9 @@ export default function PostDetailScreen() {
                 <Text style={styles.postContent}>{post.content}</Text>
                 <View style={styles.postFooter}>
                   <Pressable style={styles.footerItem} onPress={toggleLike}>
-                    <Ionicons name={liked ? "heart" : "heart-outline"} size={18} color={liked ? "#EF4444" : "#4B5563"} />
+                    <Animated.View style={{ transform: [{ scale: postLikeAnim }] }}>
+                      <Ionicons name={liked ? "heart" : "heart-outline"} size={18} color={liked ? "#EF4444" : "#4B5563"} />
+                    </Animated.View>
                     <Text style={[styles.footerText, liked && styles.footerTextLiked]}>{likeCount}</Text>
                   </Pressable>
                   <Pressable
@@ -795,11 +817,13 @@ export default function PostDetailScreen() {
                           </View>
                         )}
                         <Pressable style={styles.commentLikeWrap} onPress={() => toggleCommentLike(c.id)}>
-                          <Ionicons
-                            name={commentLiked ? "heart" : "heart-outline"}
-                            size={16}
-                            color={commentLiked ? "#EF4444" : "#9CA3AF"}
-                          />
+                          <Animated.View style={{ transform: [{ scale: getCommentLikeAnim(c.id) }] }}>
+                            <Ionicons
+                              name={commentLiked ? "heart" : "heart-outline"}
+                              size={16}
+                              color={commentLiked ? "#EF4444" : "#9CA3AF"}
+                            />
+                          </Animated.View>
                           <Text style={[styles.commentLikeCount, commentLiked && styles.commentLikeCountLiked]}>
                             {commentLikeCount}
                           </Text>
@@ -906,11 +930,13 @@ export default function PostDetailScreen() {
                               </View>
                             )}
                             <Pressable style={styles.commentLikeWrap} onPress={() => toggleCommentLike(reply.id)}>
-                              <Ionicons
-                                name={replyLiked ? "heart" : "heart-outline"}
-                                size={16}
-                                color={replyLiked ? "#EF4444" : "#9CA3AF"}
-                              />
+                              <Animated.View style={{ transform: [{ scale: getCommentLikeAnim(reply.id) }] }}>
+                                <Ionicons
+                                  name={replyLiked ? "heart" : "heart-outline"}
+                                  size={16}
+                                  color={replyLiked ? "#EF4444" : "#9CA3AF"}
+                                />
+                              </Animated.View>
                               <Text style={[styles.commentLikeCount, replyLiked && styles.commentLikeCountLiked]}>
                                 {replyLikeCount}
                               </Text>

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -97,10 +97,10 @@ export default function PostDetailScreen() {
   const [imageViewerIndex, setImageViewerIndex] = useState(0);
 
   const { post, loading: postLoading, error: postError, refetch: refetchPost } = usePostDetail(id);
-  const { comments: apiComments, loading: commentsLoading, refetch: refetchComments, removeComment } = useComments(id);
+  const { comments: apiComments, loading: commentsLoading, refetch: refetchComments, removeComment, updateCommentLike } = useComments(id);
 
   const onRefresh = useCallback(async () => {
-    if (refreshing) return; // 중복 새로고침 방지
+    if (refreshing) return;
     setRefreshing(true);
     try {
       await Promise.all([refetchPost(), refetchComments()]);
@@ -459,24 +459,10 @@ export default function PostDetailScreen() {
       ]);
       return;
     }
-    // 낙관적 업데이트
-    setLikedCommentIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(commentId)) next.delete(commentId);
-      else next.add(commentId);
-      return next;
-    });
     try {
-      await boardService.toggleCommentLike(commentId);
-      refetchComments();
+      const result = await boardService.toggleCommentLike(commentId);
+      updateCommentLike(commentId, result.liked, result.likeCount);
     } catch (e) {
-      // 실패 시 롤백
-      setLikedCommentIds((prev) => {
-        const next = new Set(prev);
-        if (next.has(commentId)) next.delete(commentId);
-        else next.add(commentId);
-        return next;
-      });
       const msg = e instanceof Error ? e.message : "좋아요 처리에 실패했습니다.";
       Alert.alert("오류", msg);
     }
@@ -690,7 +676,7 @@ export default function PostDetailScreen() {
                   >
                     <Ionicons name="chatbubble-ellipses-outline" size={18} color="#4B5563" />
                     <Text style={styles.footerText}>
-                      {commentsLoading ? (post.commentCount ?? 0) : comments.length}
+                      {commentsLoading ? (post.commentCount ?? 0) : comments.reduce((acc, c) => acc + 1 + (c.replies?.length ?? 0), 0)}
                     </Text>
                   </Pressable>
                   {/* 종이비행기(공유/채팅) 아이콘 비노출 처리

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -166,6 +166,18 @@ export default function PostDetailScreen() {
     setLiked(post?.isLiked ?? false);
   }, [post?.id, post?.isLiked]);
 
+  useEffect(() => {
+    if (!apiComments.length) return;
+    const ids = new Set<string>();
+    apiComments.forEach((c) => {
+      if (c.isLiked) ids.add(String(c.id));
+      (c.replies ?? []).forEach((r) => {
+        if (r.isLiked) ids.add(String(r.id));
+      });
+    });
+    setLikedCommentIds(ids);
+  }, [apiComments]);
+
   const handleSavePost = async () => {
     setMenuVisible(false);
     if (!isLoggedIn) {
@@ -702,7 +714,7 @@ export default function PostDetailScreen() {
                 ) : (
                   comments.map((c) => {
               const commentLiked = likedCommentIds.has(c.id);
-              const commentLikeCount = c.likes + (commentLiked ? 1 : 0);
+              const commentLikeCount = c.likes;
               const isMine = !c.deleted && isMyComment(c.id);
               const hasCommentPhoto = !c.deleted && c.authorProfileImageUrl?.trim();
               const isEdited = !c.deleted && new Date(c.updatedAt) > new Date(c.createdAt);
@@ -812,7 +824,7 @@ export default function PostDetailScreen() {
                   {/* 대댓글 렌더링 */}
                   {c.replies.map((reply) => {
                     const replyLiked = likedCommentIds.has(reply.id);
-                    const replyLikeCount = reply.likes + (replyLiked ? 1 : 0);
+                    const replyLikeCount = reply.likes;
                     const isMyReply = !reply.deleted && isMyComment(reply.id);
                     const hasReplyPhoto = !reply.deleted && reply.authorProfileImageUrl?.trim();
                     const isReplyEdited = !reply.deleted && new Date(reply.updatedAt) > new Date(reply.createdAt);

--- a/frontend/hooks/useBoard.ts
+++ b/frontend/hooks/useBoard.ts
@@ -358,9 +358,25 @@ export function useComments(postId: string | undefined) {
     );
   }, []);
 
+  /** 댓글/대댓글 좋아요 상태와 카운트를 로컬에서 즉시 업데이트 */
+  const updateCommentLike = useCallback((commentId: number | string, liked: boolean, likeCount: number) => {
+    const idStr = String(commentId);
+    setComments((prev) =>
+      prev.map((c) => {
+        if (String(c.id) === idStr) return { ...c, isLiked: liked, likeCount };
+        return {
+          ...c,
+          replies: (c.replies ?? []).map((r) =>
+            String(r.id) === idStr ? { ...r, isLiked: liked, likeCount } : r
+          ),
+        };
+      })
+    );
+  }, []);
+
   useEffect(() => {
     fetchComments();
   }, [fetchComments]);
 
-  return { comments, loading, error, refetch: fetchComments, removeComment };
+  return { comments, loading, error, refetch: fetchComments, removeComment, updateCommentLike };
 }

--- a/frontend/types/board.ts
+++ b/frontend/types/board.ts
@@ -62,6 +62,7 @@ export type CommentItem = {
   authorProfileImageUrl?: string | null;
   content: string;
   likeCount: number;
+  isLiked?: boolean;
   createdAt: string;
   updatedAt: string;
   replies: CommentItem[];


### PR DESCRIPTION
## 개요
지도 사이드메뉴 네비게이션 개선, 게시글·댓글 좋아요 개선, 축제 구역 이탈 처리, 지도 UX 버그 수정

## 작업 내용
**지도**
- [ ] 사이드메뉴 항목 진입 후 뒤로가기 시 지도 탭으로 복귀 (from=map 파라미터 활용)
- [ ] 뒤로가기 후 마이페이지 탭에 이전 스택이 남는 문제 수정
- [ ] 축제 목록에서 항목 선택 시 해당 위치로 지도 포커스 이동
- [ ] 지도 확대(+) 버튼 단계별 동작 수정
- [ ] 축제 구역 이탈 및 일정 종료 시 참여 완료 처리 (서버 동기화 재시도 포함)

**게시글·댓글**
- [ ] 게시글·댓글·대댓글 좋아요 하트 spring 애니메이션 추가
- [ ] 좋아요 낙관적 업데이트 적용 (화면 리로드 제거)
- [ ] 페이지 재진입 시 댓글 좋아요 상태(빨간색) 유지
- [ ] 댓글 좋아요 카운트 중복 증가 버그 수정
- [ ] 좋아요 시 댓글에 (수정됨) 표시되는 버그 수정
- [ ] 게시글 목록 댓글 수를 대댓글 포함 실제 DB 카운트로 수정

## 체크리스트
- [o] 빌드가 에러 없이 수행되는가?
- [o] 불필요한 로그(console.log 등)는 없는가?