### PR TITLE
버그 수정 및 UX 개선 (조회수 중복, 채팅 날짜 구분선, 탭바, 채팅 버튼)

### DIFF
--- a/frontend/app/(tabs)/board/index.tsx
+++ b/frontend/app/(tabs)/board/index.tsx
@@ -421,13 +421,11 @@ export default function BoardScreen() {
         {/* 헤더 */}
         <View style={styles.header}>
           <Text style={styles.headerTitle}>게시판</Text>
-          {/* 채팅하기 아이콘 주석 처리
           <View style={styles.headerRight}>
             <Pressable onPress={() => router.push("/board/chat")} style={styles.headerIconBtn}>
               <Ionicons name="chatbubble-outline" size={22} color="#111827" />
             </Pressable>
           </View>
-          */}
         </View>
 
         <ScrollView

--- a/frontend/hooks/useEvent.ts
+++ b/frontend/hooks/useEvent.ts
@@ -115,10 +115,11 @@ export function useEventDetail(id: string | undefined, source?: string) {
     try {
       const data = await eventService.getEventDetail(id);
       setDetail(data);
-      const eventIdNum = Number(id);
-      if (Number.isFinite(eventIdNum) && (source ?? 'detail')) {
-        logService.logClick({ eventId: eventIdNum, source: source ?? 'detail' }).catch(() => {});
-      }
+      // logClick은 EventDetailHeader에서 처리 (중복 호출 방지)
+      // const eventIdNum = Number(id);
+      // if (Number.isFinite(eventIdNum) && (source ?? 'detail')) {
+      //   logService.logClick({ eventId: eventIdNum, source: source ?? 'detail' }).catch(() => {});
+      // }
     } catch (e) {
       setError(e instanceof Error ? e : new Error(String(e)));
       setDetail(null);


### PR DESCRIPTION
## 개요
버그 수정 및 UX 개선 (조회수 중복, 채팅 날짜 구분선, 탭바, 채팅 버튼)

## 관련 이슈
- Refs #

## 작업 내용
- [ ] 채팅 날짜 구분선 하드코딩 "오늘" → `createdAt` 기반 동적 표시로 교체
- [ ] 행사 상세 진입 시 조회수 중복 카운트 제거 (`useEventDetail` 훅에서 `logClick` 호출 제거)
- [ ] 게시판 상단 채팅 목록 진입 버튼 활성화

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
