### PR TITLE
fix: 채팅 나가기·알림뱃지·이름 표시 개선

### DIFF
--- a/backend/src/main/java/com/dailo/backend/dto/ChatMemberDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/ChatMemberDto.java
@@ -16,6 +16,8 @@ public class ChatMemberDto {
     private String nickname;
     private LocalDateTime joinedAt;
     private LocalDateTime lastReadAt;
+    /** 채팅방 나가기 시각 (null이면 아직 참여 중) */
+    private LocalDateTime leftAt;
 
     public static ChatMemberDto from(ChatMember member) {
         return ChatMemberDto.builder()
@@ -24,6 +26,7 @@ public class ChatMemberDto {
                 .nickname(null)
                 .joinedAt(member.getJoinedAt())
                 .lastReadAt(member.getLastReadAt())
+                .leftAt(member.getLeftAt())
                 .build();
     }
 
@@ -35,6 +38,7 @@ public class ChatMemberDto {
                 .nickname(nickname)
                 .joinedAt(member.getJoinedAt())
                 .lastReadAt(member.getLastReadAt())
+                .leftAt(member.getLeftAt())
                 .build();
     }
 }

--- a/backend/src/main/java/com/dailo/backend/dto/ChatRoomResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/ChatRoomResponseDto.java
@@ -28,7 +28,6 @@ public class ChatRoomResponseDto {
 
     public static ChatRoomResponseDto from(ChatRoom room) {
         List<ChatMemberDto> activeMembers = room.getMembers().stream()
-                .filter(m -> m.getLeftAt() == null)
                 .map(ChatMemberDto::from)
                 .collect(Collectors.toList());
         return ChatRoomResponseDto.builder()
@@ -49,7 +48,6 @@ public class ChatRoomResponseDto {
     public static ChatRoomResponseDto from(ChatRoom room, Map<Long, String> nicknameByUserId, Integer unreadCount,
                                           String lastMessageContent, LocalDateTime lastMessageAt) {
         List<ChatMemberDto> activeMembers = room.getMembers().stream()
-                .filter(m -> m.getLeftAt() == null)
                 .map(m -> ChatMemberDto.from(m, nicknameByUserId.getOrDefault(m.getUserId(), null)))
                 .collect(Collectors.toList());
         return ChatRoomResponseDto.builder()

--- a/backend/src/main/java/com/dailo/backend/entity/ChatMember.java
+++ b/backend/src/main/java/com/dailo/backend/entity/ChatMember.java
@@ -50,7 +50,6 @@ public class ChatMember {
 
     public void rejoin() {
         this.leftAt = null;
-        // joinedAt은 최초 입장 시간이므로 유지
     }
 
     public boolean isActive() {

--- a/backend/src/main/java/com/dailo/backend/entity/ChatRoom.java
+++ b/backend/src/main/java/com/dailo/backend/entity/ChatRoom.java
@@ -56,4 +56,9 @@ public class ChatRoom {
     public void updateTimestamp() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    // 나가기 시 재사용 방지 (재채팅 시 새 방 생성)
+    public void clearDirectRoomKey() {
+        this.directRoomKey = null;
+    }
 }

--- a/backend/src/main/java/com/dailo/backend/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/ChatMessageRepository.java
@@ -15,6 +15,10 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     Page<ChatMessage> findByRoomOrderByCreatedAtDesc(ChatRoom room, Pageable pageable);
     Page<ChatMessage> findByRoomOrderByCreatedAtAsc(ChatRoom room, Pageable pageable);
 
-    /** lastReadAt 이후 메시지 수 (미읽음 개수) */
-    long countByRoomAndCreatedAtAfter(ChatRoom room, LocalDateTime after);
+    /** lastReadAt 이후 메시지 수 (미읽음 개수) - 내가 보낸 메시지 제외 */
+    long countByRoomAndCreatedAtAfterAndSenderIdNot(ChatRoom room, LocalDateTime after, Long senderId);
+
+    /** 방의 모든 메시지 삭제 */
+    void deleteByRoom(ChatRoom room);
+
 }

--- a/backend/src/main/java/com/dailo/backend/service/ChatMessageService.java
+++ b/backend/src/main/java/com/dailo/backend/service/ChatMessageService.java
@@ -94,7 +94,7 @@ public class ChatMessageService {
                 .orElseThrow(() -> new RuntimeException("Room not found: " + roomId));
 
         // 멤버 여부 확인
-        ChatMember member = chatMemberRepository.findByRoomAndUserId(room, userId)
+        chatMemberRepository.findByRoomAndUserId(room, userId)
                 .orElseThrow(() -> new RuntimeException("You are not a member of this room"));
 
         return chatMessageRepository.findByRoomOrderByCreatedAtDesc(room, pageable)

--- a/backend/src/main/java/com/dailo/backend/service/ChatRoomService.java
+++ b/backend/src/main/java/com/dailo/backend/service/ChatRoomService.java
@@ -127,7 +127,7 @@ public class ChatRoomService {
                 .map(ChatMember::getLastReadAt)
                 .orElse(LocalDateTime.of(1970, 1, 1, 0, 0, 0));
 
-        int unread = (int) chatMessageRepository.countByRoomAndCreatedAtAfter(room, lastRead);
+        int unread = (int) chatMessageRepository.countByRoomAndCreatedAtAfterAndSenderIdNot(room, lastRead, myUserId);
 
         Optional<ChatMessage> lastMsg = chatMessageRepository
                 .findByRoomOrderByCreatedAtDesc(room, PageRequest.of(0, 1))
@@ -173,7 +173,7 @@ public class ChatRoomService {
             LocalDateTime lastRead = chatMemberRepository.findByRoomAndUserId(room, userId)
                     .map(ChatMember::getLastReadAt)
                     .orElse(LocalDateTime.of(1970, 1, 1, 0, 0, 0));
-            int unread = (int) chatMessageRepository.countByRoomAndCreatedAtAfter(room, lastRead);
+            int unread = (int) chatMessageRepository.countByRoomAndCreatedAtAfterAndSenderIdNot(room, lastRead, userId);
             Optional<ChatMessage> lastMsg = chatMessageRepository
                     .findByRoomOrderByCreatedAtDesc(room, PageRequest.of(0, 1))
                     .stream().findFirst();
@@ -211,6 +211,16 @@ public class ChatRoomService {
         }
 
         member.leave();
+        // 재채팅 시 새 방이 생성되도록 key 초기화
+        room.clearDirectRoomKey();
+
+        // 모든 멤버가 나갔으면 방·메시지 영구 삭제
+        boolean allLeft = room.getMembers().stream().allMatch(m -> !m.isActive());
+        if (allLeft) {
+            chatMessageRepository.deleteByRoom(room);
+            chatMemberRepository.deleteAll(room.getMembers());
+            chatRoomRepository.delete(room);
+        }
     }
 
     public ChatRoomResponseDto getRoom(Long roomId, String email) {

--- a/frontend/app/board/chat/[id].tsx
+++ b/frontend/app/board/chat/[id].tsx
@@ -69,7 +69,8 @@ export default function ChatRoomScreen() {
 
   const partner = room?.members?.find((m) => m.userId !== myUserId);
   const partnerNick = partner ? ((partner as { nickname?: string; nick_name?: string }).nickname ?? (partner as { nick_name?: string }).nick_name ?? "").trim() : "";
-  const partnerName = partner ? (partnerNick || `user_${partner.userId}`) : "대화 상대";
+  const partnerLeft = !!partner?.leftAt;
+  const partnerName = partner ? (partnerLeft ? "알 수 없음" : (partnerNick || `user_${partner.userId}`)) : "대화 상대";
   const partnerUserId = partner?.userId ?? 0;
 
   useEffect(() => {
@@ -313,34 +314,40 @@ export default function ChatRoomScreen() {
         )}
 
         {/* 입력 영역 */}
-        <View style={styles.inputRow}>
-          <Pressable style={styles.inputIcon}>
-            <Ionicons name="image-outline" size={24} color="#4C8BF5" />
-          </Pressable>
-          <TextInput
-            style={styles.input}
-            placeholder="메시지 보내기.."
-            placeholderTextColor="#9CA3AF"
-            value={input}
-            onChangeText={setInput}
-            multiline
-            maxLength={500}
-          />
-          <Pressable style={styles.inputIcon}>
-            <Ionicons name="mic-outline" size={22} color="#6B7280" />
-          </Pressable>
-          <Pressable
-            onPress={handleSend}
-            style={[styles.sendBtn, !input.trim() && styles.sendBtnDisabled]}
-            disabled={!input.trim()}
-          >
-            <Ionicons
-              name="send"
-              size={20}
-              color={input.trim() ? "#4C8BF5" : "#9CA3AF"}
+        {partnerLeft ? (
+          <View style={styles.partnerLeftBanner}>
+            <Text style={styles.partnerLeftText}>상대방이 채팅방을 나갔습니다.</Text>
+          </View>
+        ) : (
+          <View style={styles.inputRow}>
+            <Pressable style={styles.inputIcon}>
+              <Ionicons name="image-outline" size={24} color="#4C8BF5" />
+            </Pressable>
+            <TextInput
+              style={styles.input}
+              placeholder="메시지 보내기.."
+              placeholderTextColor="#9CA3AF"
+              value={input}
+              onChangeText={setInput}
+              multiline
+              maxLength={500}
             />
-          </Pressable>
-        </View>
+            <Pressable style={styles.inputIcon}>
+              <Ionicons name="mic-outline" size={22} color="#6B7280" />
+            </Pressable>
+            <Pressable
+              onPress={handleSend}
+              style={[styles.sendBtn, !input.trim() && styles.sendBtnDisabled]}
+              disabled={!input.trim()}
+            >
+              <Ionicons
+                name="send"
+                size={20}
+                color={input.trim() ? "#4C8BF5" : "#9CA3AF"}
+              />
+            </Pressable>
+          </View>
+        )}
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
@@ -455,4 +462,12 @@ const styles = StyleSheet.create({
   menuItemDanger: { borderTopWidth: 1, borderTopColor: "#F3F4F6" },
   menuItemTextDanger: { fontSize: 15, color: "#DC2626", fontWeight: "500" },
   loadingWrap: { flex: 1, justifyContent: "center", alignItems: "center", paddingVertical: 48 },
+  partnerLeftBanner: {
+    paddingVertical: 14,
+    alignItems: "center",
+    borderTopWidth: 1,
+    borderTopColor: "#E5E7EB",
+    backgroundColor: "#F9FAFB",
+  },
+  partnerLeftText: { fontSize: 14, color: "#6B7280" },
 });

--- a/frontend/app/board/chat/index.tsx
+++ b/frontend/app/board/chat/index.tsx
@@ -88,8 +88,9 @@ export default function ChatListScreen() {
   const getPartner = (room: chatService.ChatRoomResponse) => {
     const other = room.members?.find((m) => m.userId !== myUserId);
     if (!other) return "알 수 없음";
+    if (other.leftAt) return "알 수 없음";
     const raw = other as Record<string, unknown>;
-    const nick = (other.nickname ?? raw.nick_name ?? "").trim();
+    const nick = String(other.nickname ?? raw.nick_name ?? "").trim();
     return nick || `user_${other.userId}`;
   };
 

--- a/frontend/services/chat.service.ts
+++ b/frontend/services/chat.service.ts
@@ -20,6 +20,8 @@ export type ChatMember = {
   nickname?: string | null;
   joinedAt: string;
   lastReadAt?: string;
+  /** 채팅방 나가기 시각 (null이면 아직 참여 중) */
+  leftAt?: string | null;
 };
 
 export type ChatRoomResponse = {


### PR DESCRIPTION
## 개요
채팅 나가기·알림뱃지·이름 표시 개선

## 관련 이슈
- Refs #

## 작업 내용
- [ ] 나가기 시 directRoomKey 초기화로 재채팅 시 새 방 생성 보장
- [ ] 둘 다 나갔을 때 방·메시지 영구 삭제
- [ ] 미읽음 카운트에서 내가 보낸 메시지 제외
- [ ] 나간 멤버 leftAt 응답 포함, 상대방 나감 감지
- [ ] 상대방 나갔을 때 입력창 대신 안내 문구 및 이름 "알 수 없음" 표시

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
