### PR TITLE
축제구역, 이탈 표시

### DIFF
--- a/backend/src/main/java/com/dailo/backend/service/LocationService.java
+++ b/backend/src/main/java/com/dailo/backend/service/LocationService.java
@@ -11,6 +11,7 @@ import com.dailo.backend.repository.MemberRepository;
 import com.dailo.backend.repository.StaySessionRepository;
 import com.dailo.backend.util.GeometryUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,10 +19,12 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 public class LocationService {
@@ -210,7 +213,8 @@ public class LocationService {
         List<StaySession> sessions = staySessionRepository
                 .findByMemberIdAndStatusOrderByEndTimeDesc(memberId, StayStatus.COMPLETED);
         return sessions.stream()
-                .map(this::toResponseDto)
+                .map(this::toResponseDtoSafe)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 
@@ -221,7 +225,8 @@ public class LocationService {
         List<StaySession> sessions = staySessionRepository
                 .findByMemberIdAndStatusOrderByEndTimeDesc(memberId, StayStatus.COMPLETED);
         return sessions.stream()
-                .map(this::toResponseDto)
+                .map(this::toResponseDtoSafe)
+                .filter(Objects::nonNull)
                 .filter(dto -> dto.getDurationMinutes() >= 30L)
                 .collect(Collectors.toList());
     }
@@ -254,5 +259,17 @@ public class LocationService {
                 .endTime(s.getEndTime())
                 .durationMinutes(minutes)
                 .build();
+    }
+
+    /**
+     * 연관 Event 로딩 실패(삭제/불일치 등)가 있어도 목록 API 전체가 500으로 깨지지 않게 방어.
+     */
+    private StaySessionResponseDto toResponseDtoSafe(StaySession s) {
+        try {
+            return toResponseDto(s);
+        } catch (RuntimeException ex) {
+            log.warn("체류 세션 DTO 변환 실패: sessionId={}, memberId={}", s.getId(), s.getMember() != null ? s.getMember().getId() : null, ex);
+            return null;
+        }
     }
 }

--- a/frontend/app/(tabs)/map/_components/FilterModals.tsx
+++ b/frontend/app/(tabs)/map/_components/FilterModals.tsx
@@ -418,7 +418,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: 12,
+    marginBottom: 2,
   },
   monthText: {
     marginHorizontal: 32,
@@ -430,7 +430,7 @@ const styles = StyleSheet.create({
   // 요일 / 날짜 정렬
   weekRow: {
     flexDirection: 'row',
-    marginBottom: 4,
+    marginBottom: 2,
   },
   weekDayText: {
     width: '14.2857%', // 100 / 7

--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -1391,6 +1391,7 @@ export default function MapScreen() {
               <View
                 style={[
                   styles.activeChip,
+                  styles.activeChipExitBanner,
                   {
                     top: row1Top,
                     left: SPACING.base,
@@ -1403,10 +1404,10 @@ export default function MapScreen() {
                   <View style={styles.activeChipIconCircle}>
                     <Text style={styles.activeChipEmoji}>✓</Text>
                   </View>
-                  <View style={styles.activeChipTextCol}>
+                  <View style={[styles.activeChipTextCol, styles.activeChipTextColExitBanner]}>
                     <Text style={styles.activeChipLabel}>행사 참여 완료</Text>
                     <Text style={styles.activeChipTimer} numberOfLines={1}>
-                      구역 이탈 · {participationExitBanner.eventTitle || '참여 반영'}
+                      구역 이탈 · 참여 반영
                     </Text>
                   </View>
                 </View>
@@ -2334,6 +2335,17 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.16,
     shadowOffset: { width: 0, height: 3 },
     shadowRadius: 10,
+  },
+  /** 구역 이탈 안내 칩: 기본 칩(123)보다 넓게 */
+  activeChipExitBanner: {
+    width: 228,
+    minWidth: 200,
+    maxWidth: '88%',
+    paddingHorizontal: 12,
+  },
+  activeChipTextColExitBanner: {
+    flex: 1,
+    minWidth: 0,
   },
   activeChipLeft: {
     flexDirection: 'row',


### PR DESCRIPTION
## 개요
지도·탭·체류 기록 관련 UX와 안정성을 다듬었습니다. 날짜 필터 모달·하단 탭 여백을 조정하고, 체류 완료 목록 API 500 방어 로직을 넣었으며, 구역 이탈 칩 레이아웃(너비·문구)을 정리했습니다.

## 관련 이슈
- Refs #(번호)

## 작업 내용
- [x] 날짜 필터 바텀시트: 월 헤더·요일 행과 캘린더 사이 세로 간격 축소
- [x] 하단 탭: Android에서 강제 최소 하단 inset(24) 제거, 실제 safe area만 반영
- [x] 백엔드 `GET /api/location/stay-sessions/completed`(및 미션 목록): 연관 행사 로딩 실패 시에도 목록 전체가 500 나지 않도록 DTO 변환 방어 + 경고 로그
- [x] 지도 구역 이탈 칩: 축제명 제거, 구역 이탈 전용 더 넓은 칩 스타일 적용

## 체크리스트
- [x] 빌드가 에러 없이 수행되는가? (백엔드 `compileJava` 확인)
- [x] 불필요한 로그(console.log 등)는 없는가?