### PR TITLE
축제완료 칩

### DIFF
--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -1146,7 +1146,11 @@ export default function MapScreen() {
       } else if (!inZone) {
         clearFestivalParticipation().then(() => refreshFestivalParticipation());
       }
-      const elapsedSec = entry ? Math.floor((Date.now() - entry.enteredAt) / 1000) : 0;
+      const elapsedSec = entry
+        ? entry.participationCompletedToday
+          ? 30 * 60
+          : Math.floor((Date.now() - entry.enteredAt) / 1000)
+        : 0;
       const statusLabel = elapsedSec >= 30 * 60 ? '축제 참여 완료' : '축제 참여중';
       const msg =
         inZone && entry

--- a/frontend/hooks/useFestivalParticipation.ts
+++ b/frontend/hooks/useFestivalParticipation.ts
@@ -1,7 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   getFestivalParticipation,
   formatElapsed,
+  hasParticipationCompletedToday,
+  markParticipationCompletedToday,
   type FestivalParticipation,
 } from '../services/festivalParticipationStorage';
 
@@ -13,15 +15,25 @@ export function useFestivalParticipation() {
   const [entry, setEntry] = useState<FestivalParticipation | null>(null);
   const [elapsedFormatted, setElapsedFormatted] = useState('00:00:00');
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const markedCompleteForSessionRef = useRef(false);
 
   const refresh = useCallback(async () => {
     const value = await getFestivalParticipation();
-    setEntry(value);
+    if (!value) {
+      setEntry(null);
+      return;
+    }
+    const completedToday = await hasParticipationCompletedToday(value.eventId);
+    setEntry({ ...value, participationCompletedToday: completedToday });
   }, []);
 
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    markedCompleteForSessionRef.current = false;
+  }, [entry?.eventId, entry?.enteredAt]);
 
   useEffect(() => {
     if (!entry) {
@@ -30,9 +42,29 @@ export function useFestivalParticipation() {
       return;
     }
     const update = () => {
-      const sec = Math.floor((Date.now() - entry.enteredAt) / 1000);
-      setElapsedSeconds(sec);
-      setElapsedFormatted(formatElapsed(sec));
+      if (entry.participationCompletedToday) {
+        setElapsedSeconds(PARTICIPATION_COMPLETE_SECONDS);
+        setElapsedFormatted(formatElapsed(PARTICIPATION_COMPLETE_SECONDS));
+        return;
+      }
+      const sessionSec = Math.floor((Date.now() - entry.enteredAt) / 1000);
+      if (sessionSec >= PARTICIPATION_COMPLETE_SECONDS) {
+        if (!markedCompleteForSessionRef.current) {
+          markedCompleteForSessionRef.current = true;
+          void markParticipationCompletedToday(entry.eventId).then(() => {
+            setEntry((prev) =>
+              prev && String(prev.eventId) === String(entry.eventId)
+                ? { ...prev, participationCompletedToday: true }
+                : prev
+            );
+          });
+        }
+        setElapsedSeconds(PARTICIPATION_COMPLETE_SECONDS);
+        setElapsedFormatted(formatElapsed(PARTICIPATION_COMPLETE_SECONDS));
+        return;
+      }
+      setElapsedSeconds(sessionSec);
+      setElapsedFormatted(formatElapsed(sessionSec));
     };
     update();
     const interval = setInterval(update, 1000);
@@ -43,7 +75,8 @@ export function useFestivalParticipation() {
     };
   }, [entry, refresh]);
 
-  const isCompleted = elapsedSeconds >= PARTICIPATION_COMPLETE_SECONDS;
+  const isCompleted =
+    !!entry?.participationCompletedToday || elapsedSeconds >= PARTICIPATION_COMPLETE_SECONDS;
 
   return { entry, elapsedFormatted, elapsedSeconds, isCompleted, refresh };
 }

--- a/frontend/services/festivalParticipationStorage.ts
+++ b/frontend/services/festivalParticipationStorage.ts
@@ -1,6 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const FESTIVAL_PARTICIPATION_KEY = '@dailo/festival_participation';
+/** 행사별로 "오늘 로컬일 기준 30분 참여 완료" 표시용 (구역 이탈 후 재진입 시 칩·메뉴 유지) */
+const FESTIVAL_PARTICIPATION_COMPLETED_DAY_KEY = '@dailo/festival_participation_completed_day';
 
 export type FestivalParticipation = {
   enteredAt: number;
@@ -9,7 +11,44 @@ export type FestivalParticipation = {
   /** 참여 중인 행사 좌표 (이탈 판정용, 없으면 구버전 데이터) */
   eventLat?: number | null;
   eventLng?: number | null;
+  /**
+   * AsyncStorage에는 저장하지 않음. 훅에서만 병합:
+   * 오늘 해당 행사에서 이미 30분 참여 완료(또는 완료 플래그 조회) 시 true.
+   */
+  participationCompletedToday?: boolean;
 };
+
+function localDayKey(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** 오늘(로컬) 해당 행사에서 30분 참여 완료로 기록된 경우 */
+export async function hasParticipationCompletedToday(eventId: string): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(FESTIVAL_PARTICIPATION_COMPLETED_DAY_KEY);
+    if (!raw) return false;
+    const map = JSON.parse(raw) as Record<string, string>;
+    return map[String(eventId)] === localDayKey();
+  } catch {
+    return false;
+  }
+}
+
+/** 30분 달성 시 호출 — 구역을 나갔다 들어와도 오늘 한도 내 참여완료 표시에 사용 */
+export async function markParticipationCompletedToday(eventId: string): Promise<void> {
+  try {
+    const raw = await AsyncStorage.getItem(FESTIVAL_PARTICIPATION_COMPLETED_DAY_KEY);
+    const map: Record<string, string> = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    map[String(eventId)] = localDayKey();
+    await AsyncStorage.setItem(FESTIVAL_PARTICIPATION_COMPLETED_DAY_KEY, JSON.stringify(map));
+  } catch {
+    // ignore
+  }
+}
 
 export async function getFestivalParticipation(): Promise<FestivalParticipation | null> {
   try {


### PR DESCRIPTION
## 개요
축제 구역에서 30분 참여를 한 번이라도 완료한 뒤 구역을 나갔다가 다시 들어와도, 같은 날·같은 행사에 한해 상단 칩·사이드 메뉴·마이페이지에서 「축제 참여 완료」와 00:30:00이 유지되도록 로컬에 완료 일자를 기록합니다. 재진입 시 타이머만 이어지는 것처럼 보이거나, 완료 후에도 참여중으로 보이는 문제를 줄입니다.

## 관련 이슈
- Refs #(이슈 번호)

## 작업 내용
- [x] AsyncStorage에 행사별·로컬일 기준 30분 참여 완료 여부 저장 (`hasParticipationCompletedToday` / `markParticipationCompletedToday`)
- [x] `useFestivalParticipation`에서 완료일 병합, 완료 시 타이머 00:30:00 고정 및 완료 시 플래그 저장
- [x] 지도 「위치·행사 새로고침」알림 문구에서도 완료일 반영
- [x] `FestivalParticipation` 타입에 런타임 전용 `participationCompletedToday` 필드 정의

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [x] 불필요한 로그(console.log 등)는 없는가?