### PR TITLE
상세보기 상단여백줄임, 포스터 영역

### DIFF
--- a/frontend/app/(tabs)/map/_components/MapBottomSheet.tsx
+++ b/frontend/app/(tabs)/map/_components/MapBottomSheet.tsx
@@ -5,12 +5,10 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  ScrollView,
   ActivityIndicator,
   Alert,
-  Platform,
+  Image,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -20,11 +18,9 @@ import { formatTime, formatTimeRange } from '../../../../utils/formatTime';
 import { getEventDetail } from '../../../../services/event.service';
 import { toggleScrap } from '../../../../services/scrap.service';
 import { useAuth } from '../../../../hooks/useAuth';
-import { parseEventExtra } from '../../../../utils/eventExtra';
-import EventDetailTabs, { TabKey } from '../../../../components/detail/EventDetailTabs';
-import Timeline from '../../../../components/detail/Timeline';
-import EventNewsTab from '../../../../components/detail/EventNewsTab';
-import EventBoothTab from '../../../../components/detail/EventBoothTab';
+/** 상세 화면 EventDetailHeader와 동일 — 이미지 없을 때만 사용 */
+const DEFAULT_POSTER_URI =
+  'https://images.unsplash.com/photo-1485550409059-9afb054cada4?w=800';
 
 const CATEGORY_LABEL: Record<EventCategory, string> = {
   FESTIVAL: '축제',
@@ -67,20 +63,17 @@ export function MapBottomSheet({
   onPressCurrentLocation,
 }: Props) {
   const router = useRouter();
-  const insets = useSafeAreaInsets();
 
   const { isLoggedIn } = useAuth();
   const [detail, setDetail] = useState<EventDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
-  const [tab, setTab] = useState<TabKey>('news');
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
 
-  // expanded 모드 진입 시 상세 데이터 fetch + 탭/북마크 초기화
+  // expanded 모드 진입 시 상세 데이터 fetch + 북마크 초기화
   useEffect(() => {
     if (!visible || !event || mode !== 'expanded') return;
     setDetail(null);
-    setTab('news');
     setIsBookmarked(event.isBookmarked ?? false);
     setDetailLoading(true);
     getEventDetail(event.id)
@@ -111,7 +104,14 @@ export function MapBottomSheet({
     }
   };
 
-  const extra = useMemo(() => parseEventExtra(detail?.extraJson ?? null), [detail?.extraJson]);
+  const posterUri = useMemo(() => {
+    const fromDetail =
+      (detail?.thumbnailUrl as string | null | undefined)?.trim() ||
+      detail?.posterUrls?.[0];
+    if (fromDetail) return fromDetail;
+    const fromEvent = (event?.thumbnailUrl ?? '').trim();
+    return fromEvent.length > 0 ? fromEvent : null;
+  }, [detail?.thumbnailUrl, detail?.posterUrls, event?.thumbnailUrl]);
 
   if (!visible || !event) return null;
 
@@ -267,50 +267,18 @@ export function MapBottomSheet({
             ) : null}
           </View>
 
-          {/* 미리보기 박스 (명확히 구분된 네모 영역) */}
+          {/* 미리보기: 행사 대표 포스터(상세 화면 헤더와 동일 우선순위) */}
           <View style={styles.previewBox}>
-            {detailLoading ? (
+            {detailLoading && !posterUri ? (
               <View style={styles.loadingSection}>
                 <ActivityIndicator size="small" color="#4C8BF5" />
               </View>
             ) : (
-              <>
-                {/* 탭 바 */}
-                <EventDetailTabs value={tab} onChange={setTab} />
-
-                {/* 탭 콘텐츠 (박스 안에서만 스크롤) */}
-                <ScrollView
-                  style={styles.tabContent}
-                  contentContainerStyle={styles.tabContentInner}
-                  showsVerticalScrollIndicator={false}
-                  nestedScrollEnabled
-                >
-                  {tab === 'news' && (
-                    <EventNewsTab
-                      news={extra.news}
-                      eventId={detail?.id != null ? Number(detail.id) : undefined}
-                    />
-                  )}
-                  {tab === 'timeline' && (
-                    <Timeline
-                      dateLabel={extra.timeline?.[0]?.dateLabel ?? null}
-                      items={extra.timeline}
-                    />
-                  )}
-                  {tab === 'booths' && (
-                    <EventBoothTab
-                      eventId={detail?.id != null ? Number(detail.id) : undefined}
-                      eventTitle={event.title}
-                      foodBooths={extra.foodBooths}
-                      experienceBooths={extra.experienceBooths}
-                      eventLatitude={event.latitude}
-                      eventLongitude={event.longitude}
-                      foodArea={extra.foodArea}
-                      experienceArea={extra.experienceArea}
-                    />
-                  )}
-                </ScrollView>
-              </>
+              <Image
+                source={{ uri: posterUri ?? DEFAULT_POSTER_URI }}
+                style={styles.posterImage}
+                resizeMode="cover"
+              />
             )}
           </View>
 
@@ -548,13 +516,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9FAFB',
     overflow: 'hidden',
   },
-  tabContent: {
+  posterImage: {
+    width: '100%',
     flex: 1,
-  },
-  tabContentInner: {
-    paddingHorizontal: 16,
-    paddingTop: 8,
-    paddingBottom: 16,
+    backgroundColor: '#E5E7EB',
   },
   largeButtonRow: {
     flexDirection: 'row',

--- a/frontend/components/detail/EventDetailHeader.tsx
+++ b/frontend/components/detail/EventDetailHeader.tsx
@@ -18,6 +18,7 @@ import {
 import * as Location from "expo-location";
 import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Ionicons } from "@expo/vector-icons";
 import type { EventDetail } from "../../types/event";
@@ -96,6 +97,7 @@ interface Props {
 
 export default function EventDetailHeader({ id, event, loading, error, onShare, onSave, isLiked = false, likeCount, onLike, isLoggedIn = false, isScraped = false }: Props) {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   // 등록 시 선택한 대표 썸네일(thumbnailUrl)을 우선 사용하고,
   // 없으면 상세 포스터 배열의 첫 번째 이미지를 사용
   const posterUri =
@@ -177,7 +179,7 @@ export default function EventDetailHeader({ id, event, loading, error, onShare, 
         <View style={[styles.poster, styles.posterPlaceholder]}>
           <ActivityIndicator size="large" color="#6366F1" />
         </View>
-        <View style={styles.iconRow}>
+        <View style={[styles.iconRow, { top: insets.top + 4 }]}>
           <Pressable onPress={() => router.back()} style={styles.iconButton} hitSlop={10}>
             <Ionicons name="arrow-back" size={22} color="#111827" />
           </Pressable>
@@ -346,7 +348,7 @@ export default function EventDetailHeader({ id, event, loading, error, onShare, 
     <View style={styles.container}>
       <Image source={{ uri: posterUri }} style={styles.poster} resizeMode="cover" />
 
-      <View style={styles.iconRow}>
+      <View style={[styles.iconRow, { top: insets.top + 4 }]}>
         <Pressable onPress={() => router.back()} style={styles.iconButton} hitSlop={10}>
           <Ionicons name="arrow-back" size={22} color="#111827" />
         </Pressable>
@@ -441,7 +443,6 @@ const styles = StyleSheet.create({
   /* 🔹 상단 버튼 레이아웃 */
   iconRow: {
     position: "absolute",
-    top: 40,
     left: 16,
     right: 16,
     flexDirection: "row",


### PR DESCRIPTION
## 개요
지도 행사 확장 카드에서 포스터 영역에 소식/타임테이블/축제부스 탭이 나오던 문제를 수정하고, 행사 상세 화면 상단(뒤로가기·좋아요·북마크)과 상태바 사이 여백을 줄였습니다.

## 관련 이슈
- Refs #(이슈 번호가 있으면 입력)

## 작업 내용
- [x] `MapBottomSheet`: 미리보기 영역을 탭 UI 대신 행사 대표 이미지(썸네일 → posterUrls[0] → 지도 목록 썸네일 → 기본 이미지)로 표시
- [x] `EventDetailHeader`: 상단 아이콘 행 `top` 고정값(40) 제거, `useSafeAreaInsets()` 기준 `insets.top + 4`로 조정 (로딩 스켈레톤 동일 적용)

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가? (로컬에서 `npx tsc` / 앱 실행으로 확인 권장)
- [x] 불필요한 로그(console.log 등)는 없는가? (해당 변경 파일에 디버그 로그 추가 없음)