### PR TITLE
fix: ExportOptions.plist에 provisioningProfiles 매핑 추가

### DIFF
--- a/.github/workflows/ios-appstore-deploy.yml
+++ b/.github/workflows/ios-appstore-deploy.yml
@@ -168,14 +168,23 @@ jobs:
 
       - name: Export IPA
         working-directory: ./frontend/ios
+        env:
+          IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+          IOS_PROFILE_NAME: ${{ secrets.IOS_PROFILE_NAME }}
         run: |
-          cat > ExportOptions.plist <<'PLIST'
+          cat > ExportOptions.plist <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
           <dict>
-            <key>method</key><string>app-store</string>
+            <key>method</key><string>app-store-connect</string>
             <key>signingStyle</key><string>manual</string>
+            <key>teamID</key><string>${IOS_TEAM_ID}</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.knut.dailo</key>
+              <string>${IOS_PROFILE_NAME}</string>
+            </dict>
             <key>stripSwiftSymbols</key><true/>
             <key>compileBitcode</key><false/>
             <key>manageAppVersionAndBuildNumber</key><false/>


### PR DESCRIPTION
export 단계에서 Push Notifications entitlement 포함된 프로파일을 찾지 못하는 문제 수정. teamID, provisioningProfiles 딕셔너리 추가하고 method를 app-store-connect로 변경.

## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 로그인 UI 마크업 구현
- [ ] 이메일 정규식 검사 함수 추가
- [ ] 

## 체크리스트
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
