### PR TITLE
fix: IPA 파일 경로 glob 미작동 수정

### DIFF
--- a/.github/workflows/ios-appstore-deploy.yml
+++ b/.github/workflows/ios-appstore-deploy.yml
@@ -197,10 +197,22 @@ jobs:
             -exportOptionsPlist "$PWD/ExportOptions.plist" \
             -exportPath "$PWD/build"
 
+      - name: Find IPA path
+        id: find-ipa
+        working-directory: ./frontend/ios
+        run: |
+          IPA_PATH=$(find "$PWD/build" -name "*.ipa" -type f | head -n 1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "No IPA file found in build directory"
+            ls -la "$PWD/build"
+            exit 1
+          fi
+          echo "ipa_path=$IPA_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Upload to TestFlight
         uses: apple-actions/upload-testflight-build@v1
         with:
-          app-path: ./frontend/ios/build/*.ipa
+          app-path: ${{ steps.find-ipa.outputs.ipa_path }}
           issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
           api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
           api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}


### PR DESCRIPTION
apple-actions/upload-testflight-build에서 glob 패턴이 전개되지 않아 IPA 파일을 못 찾는 문제 수정. find로 실제 IPA 경로를 먼저 찾도록 변경.

## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 로그인 UI 마크업 구현
- [ ] 이메일 정규식 검사 함수 추가
- [ ] 

## 체크리스트
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
