### PR TITLE
feat: 관리자 웹 대시보드 추가 및 role 기반 인증 개선

### DIFF
--- a/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/dailo/backend/config/SecurityConfig.java
@@ -67,6 +67,8 @@ public class SecurityConfig {
 
                         .requestMatchers("/", "/login/**", "/oauth2/**", "/error").permitAll()
 
+                        .requestMatchers("/api/admin/web/**").permitAll()
+
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
 
                         .requestMatchers("/health", "/actuator/health").permitAll()

--- a/backend/src/main/java/com/dailo/backend/dto/auth/MemberResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/auth/MemberResponseDto.java
@@ -15,6 +15,7 @@ public class MemberResponseDto {
     private String email;
     private String nickname;
     private String profileImageUrl;
+    private String role;
 
     public static MemberResponseDto of(Member member, String resolvedProfileImageUrl) {
         return MemberResponseDto.builder()
@@ -22,6 +23,7 @@ public class MemberResponseDto {
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .profileImageUrl(resolvedProfileImageUrl)
+                .role(member.getRole() != null ? member.getRole().name() : null)
                 .build();
     }
 }

--- a/backend/src/main/resources/static/api/admin/web/css/style.css
+++ b/backend/src/main/resources/static/api/admin/web/css/style.css
@@ -1,0 +1,80 @@
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--pri:#2563eb;--pri-d:#1d4ed8;--bg:#f1f5f9;--sb:#1e293b;--sb-t:#94a3b8;--card:#fff;--txt:#1e293b;--muted:#64748b;--border:#e2e8f0;--danger:#ef4444;--success:#22c55e;--warn:#f59e0b}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--txt)}
+
+/* Login */
+.login-wrap{display:flex;align-items:center;justify-content:center;min-height:100vh;background:linear-gradient(135deg,#1e293b,#334155)}
+.login-box{background:var(--card);padding:48px 40px;border-radius:16px;box-shadow:0 20px 60px rgba(0,0,0,.3);width:400px;max-width:90vw}
+.login-box h1{font-size:24px;text-align:center;margin-bottom:8px}
+.login-box .sub{color:var(--muted);text-align:center;margin-bottom:32px;font-size:14px}
+.fg{margin-bottom:20px}
+.fg label{display:block;font-size:13px;font-weight:600;margin-bottom:6px;color:var(--muted)}
+.fg input,.fg select,.fg textarea{width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-size:14px;outline:none}
+.fg input:focus,.fg select:focus,.fg textarea:focus{border-color:var(--pri)}
+.fg textarea{resize:vertical;min-height:80px}
+.btn{display:inline-block;padding:10px 20px;border:none;border-radius:8px;font-size:13px;font-weight:600;cursor:pointer;transition:background .2s}
+.btn-p{background:var(--pri);color:#fff;width:100%}.btn-p:hover{background:var(--pri-d)}
+.btn-d{background:var(--danger);color:#fff}.btn-d:hover{background:#dc2626}
+.btn-s{background:var(--success);color:#fff}
+.btn-w{background:var(--warn);color:#fff}
+.btn-g{background:var(--bg);color:var(--txt);border:1px solid var(--border)}.btn-g:hover{background:var(--border)}
+.btn-sm{padding:6px 14px;font-size:12px}
+.err{color:var(--danger);font-size:13px;margin-top:12px;text-align:center;display:none}
+
+/* Layout */
+.layout{display:flex;min-height:100vh}
+.sidebar{width:220px;background:var(--sb);position:fixed;height:100vh;overflow-y:auto;padding:20px 0;z-index:10}
+.sb-logo{color:#fff;font-size:18px;font-weight:700;padding:0 20px;margin-bottom:28px}.sb-logo span{color:var(--pri)}
+.sb-sec{font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--sb-t);padding:16px 20px 6px;opacity:.6}
+.sidebar a{display:block;padding:10px 20px;color:var(--sb-t);text-decoration:none;font-size:13px;border-left:3px solid transparent;transition:all .15s}
+.sidebar a:hover{color:#fff;background:rgba(255,255,255,.05)}
+.sidebar a.active{color:#fff;background:rgba(255,255,255,.1);border-left-color:var(--pri)}
+.sb-bottom{position:absolute;bottom:16px;left:0;right:0;padding:0 20px}
+.sb-bottom button{width:100%;background:rgba(255,255,255,.05);color:var(--sb-t);border:1px solid rgba(255,255,255,.1);padding:8px;border-radius:8px;cursor:pointer;font-size:12px}
+.sb-bottom button:hover{background:rgba(239,68,68,.2);color:var(--danger)}
+
+.main{flex:1;margin-left:220px;padding:28px 32px}
+.ph h2{font-size:20px;font-weight:700}.ph p{color:var(--muted);font-size:13px;margin-top:2px}
+.ph{margin-bottom:24px;display:flex;justify-content:space-between;align-items:center}
+
+/* Cards / Stats */
+.stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:16px;margin-bottom:28px}
+.stat{background:var(--card);border-radius:12px;padding:20px;box-shadow:0 1px 3px rgba(0,0,0,.06);border:1px solid var(--border)}
+.stat .l{font-size:12px;color:var(--muted);margin-bottom:6px}.stat .v{font-size:26px;font-weight:700}
+.card{background:var(--card);border-radius:12px;padding:20px;box-shadow:0 1px 3px rgba(0,0,0,.06);border:1px solid var(--border);margin-bottom:20px}
+.card h3{font-size:15px;font-weight:600;margin-bottom:14px}
+
+/* Table */
+table{width:100%;border-collapse:collapse}
+th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--border);font-size:13px}
+th{color:var(--muted);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.5px}
+tr:last-child td{border-bottom:none}
+tr:hover td{background:#f8fafc}
+.badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600}
+.b-admin{background:#dbeafe;color:#1d4ed8}
+.b-user{background:#f1f5f9;color:#64748b}
+.b-active{background:#dcfce7;color:#166534}
+.b-del{background:#fee2e2;color:#991b1b}
+.b-pending{background:#fef3c7;color:#92400e}
+.b-answered{background:#dbeafe;color:#1d4ed8}
+.b-closed{background:#f1f5f9;color:#64748b}
+.b-visible{background:#dcfce7;color:#166534}
+.b-hidden{background:#fef3c7;color:#92400e}
+
+/* Pagination */
+.paging{display:flex;gap:6px;justify-content:center;margin-top:14px}
+.paging button{padding:5px 12px;border:1px solid var(--border);background:var(--card);border-radius:6px;cursor:pointer;font-size:12px}
+.paging button.cur{background:var(--pri);color:#fff;border-color:var(--pri)}
+
+/* Modal */
+.modal-bg{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.5);z-index:100;align-items:center;justify-content:center}
+.modal-bg.show{display:flex}
+.modal{background:#fff;border-radius:12px;padding:28px;width:480px;max-width:90vw;max-height:85vh;overflow-y:auto}
+.modal h3{margin-bottom:14px}
+.modal-actions{display:flex;gap:10px;justify-content:flex-end;margin-top:18px}
+
+/* Misc */
+.loading{text-align:center;padding:32px;color:var(--muted)}
+.flex-gap{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.hidden{display:none!important}
+.page{display:none}.page.active{display:block}

--- a/backend/src/main/resources/static/api/admin/web/index.html
+++ b/backend/src/main/resources/static/api/admin/web/index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dailo Admin</title>
+  <link rel="stylesheet" href="/api/admin/web/css/style.css">
+</head>
+<body>
+
+<!-- ===== LOGIN ===== -->
+<div id="loginView" class="login-wrap">
+  <div class="login-box">
+    <h1>Dailo Admin</h1>
+    <p class="sub">관리자 계정으로 로그인하세요</p>
+    <form id="loginForm">
+      <div class="fg"><label>이메일</label><input type="email" id="loginEmail" required></div>
+      <div class="fg"><label>비밀번호</label><input type="password" id="loginPw" required></div>
+      <button type="submit" class="btn btn-p">로그인</button>
+      <p class="err" id="loginErr"></p>
+    </form>
+  </div>
+</div>
+
+<!-- ===== APP ===== -->
+<div id="appView" class="layout hidden">
+  <aside class="sidebar">
+    <div class="sb-logo">Dailo <span>Admin</span></div>
+    <div class="sb-sec">Overview</div>
+    <a href="#" data-page="dashboard" class="active">Dashboard</a>
+    <div class="sb-sec">관리</div>
+    <a href="#" data-page="members">회원 목록</a>
+    <a href="#" data-page="events">행사 관리</a>
+    <a href="#" data-page="posts">게시글 관리</a>
+    <a href="#" data-page="comments">댓글 관리</a>
+    <a href="#" data-page="notices">공지사항</a>
+    <a href="#" data-page="faq">FAQ</a>
+    <a href="#" data-page="banners">배너</a>
+    <a href="#" data-page="reports">신고 관리</a>
+    <a href="#" data-page="blocks">차단 관리</a>
+    <a href="#" data-page="inquiries">문의</a>
+    <a href="#" data-page="push">푸시 알림</a>
+    <div class="sb-sec">시스템</div>
+    <a href="#" data-page="appversions">앱 버전</a>
+    <a href="#" data-page="logs">활동 로그</a>
+    <div class="sb-bottom"><button onclick="logout()">로그아웃</button></div>
+  </aside>
+  <main class="main">
+
+    <!-- Dashboard -->
+    <div id="pg-dashboard" class="page active">
+      <div class="ph"><div><h2>Dashboard</h2><p>서비스 현황</p></div></div>
+      <div class="stats" id="dashStats"></div>
+    </div>
+
+    <!-- Members -->
+    <div id="pg-members" class="page">
+      <div class="ph"><div><h2>회원 목록</h2><p>회원 관리</p></div></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>이메일</th><th>닉네임</th><th>Role</th><th>상태</th><th>가입일</th><th>액션</th></tr></thead><tbody id="tMembers"></tbody></table><div class="paging" id="pgMembers"></div></div>
+    </div>
+
+    <!-- Events -->
+    <div id="pg-events" class="page">
+      <div class="ph"><div><h2>행사 관리</h2><p>행사 목록</p></div></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>제목</th><th>장소</th><th>시작일</th><th>종료일</th><th>상태</th><th>액션</th></tr></thead><tbody id="tEvents"></tbody></table><div class="paging" id="pgEvents"></div></div>
+    </div>
+
+    <!-- Posts -->
+    <div id="pg-posts" class="page">
+      <div class="ph"><div><h2>게시글 관리</h2><p>신고된 게시글 포함</p></div></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>제목</th><th>작성자</th><th>신고수</th><th>작성일</th><th>액션</th></tr></thead><tbody id="tPosts"></tbody></table><div class="paging" id="pgPosts"></div></div>
+    </div>
+
+    <!-- Comments -->
+    <div id="pg-comments" class="page">
+      <div class="ph"><div><h2>댓글 관리</h2><p>댓글 숨김/복원/삭제</p></div></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>게시글</th><th>작성자</th><th>내용</th><th>상태</th><th>신고</th><th>액션</th></tr></thead><tbody id="tComments"></tbody></table><div class="paging" id="pgComments"></div></div>
+    </div>
+
+    <!-- Notices -->
+    <div id="pg-notices" class="page">
+      <div class="ph"><div><h2>공지사항 관리</h2></div><button class="btn btn-p btn-sm" onclick="openNoticeModal()">+ 작성</button></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>제목</th><th>작성일</th><th>액션</th></tr></thead><tbody id="tNotices"></tbody></table></div>
+    </div>
+
+    <!-- FAQ -->
+    <div id="pg-faq" class="page">
+      <div class="ph"><div><h2>FAQ 관리</h2></div><button class="btn btn-p btn-sm" onclick="openFaqModal()">+ 추가</button></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>카테고리</th><th>질문</th><th>활성</th><th>순서</th><th>액션</th></tr></thead><tbody id="tFaq"></tbody></table></div>
+    </div>
+
+    <!-- Banners -->
+    <div id="pg-banners" class="page">
+      <div class="ph"><div><h2>배너 관리</h2></div><button class="btn btn-p btn-sm" onclick="openBannerModal()">+ 추가</button></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>제목</th><th>활성</th><th>순서</th><th>기간</th><th>액션</th></tr></thead><tbody id="tBanners"></tbody></table></div>
+    </div>
+
+    <!-- Reports -->
+    <div id="pg-reports" class="page">
+      <div class="ph"><div><h2>신고 관리</h2><p>게시글별 신고 기록</p></div></div>
+      <div class="card"><table><thead><tr><th>게시글ID</th><th>제목</th><th>작성자</th><th>신고수</th></tr></thead><tbody id="tReports"></tbody></table></div>
+    </div>
+
+    <!-- Blocks -->
+    <div id="pg-blocks" class="page">
+      <div class="ph"><div><h2>차단 관리</h2><p>5회 이상 차단된 회원</p></div></div>
+      <div class="card"><table><thead><tr><th>회원ID</th><th>이메일</th><th>닉네임</th><th>차단수</th><th>정지만료</th><th>액션</th></tr></thead><tbody id="tBlocks"></tbody></table></div>
+    </div>
+
+    <!-- Inquiries -->
+    <div id="pg-inquiries" class="page">
+      <div class="ph"><div><h2>문의 관리</h2></div></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>이메일</th><th>제목</th><th>상태</th><th>작성일</th><th>액션</th></tr></thead><tbody id="tInquiries"></tbody></table><div class="paging" id="pgInquiries"></div></div>
+    </div>
+
+    <!-- Push -->
+    <div id="pg-push" class="page">
+      <div class="ph"><div><h2>푸시 알림 발송</h2></div></div>
+      <div class="card">
+        <div class="fg"><label>제목</label><input type="text" id="pushTitle"></div>
+        <div class="fg"><label>내용</label><textarea id="pushBody"></textarea></div>
+        <button class="btn btn-p" onclick="sendPush()">전체 발송</button>
+        <p id="pushResult" style="margin-top:12px;font-size:13px;"></p>
+      </div>
+    </div>
+
+    <!-- App Versions -->
+    <div id="pg-appversions" class="page">
+      <div class="ph"><div><h2>앱 버전 관리</h2></div><button class="btn btn-p btn-sm" onclick="openVersionModal()">+ 추가</button></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>플랫폼</th><th>최소</th><th>최신</th><th>강제업데이트</th><th>액션</th></tr></thead><tbody id="tVersions"></tbody></table></div>
+    </div>
+
+    <!-- Logs -->
+    <div id="pg-logs" class="page">
+      <div class="ph"><div><h2>활동 로그</h2></div></div>
+      <div class="card"><table><thead><tr><th>ID</th><th>관리자</th><th>액션</th><th>대상</th><th>설명</th><th>일시</th></tr></thead><tbody id="tLogs"></tbody></table><div class="paging" id="pgLogs"></div></div>
+    </div>
+
+  </main>
+</div>
+
+<!-- ===== MODALS ===== -->
+<div class="modal-bg" id="suspendModal"><div class="modal">
+  <h3>회원 정지</h3>
+  <p id="suspendInfo" style="font-size:13px;color:var(--muted);margin-bottom:12px"></p>
+  <div class="fg"><select id="suspendType"><option value="2W">2주</option><option value="1M">1개월</option><option value="1Y">1년</option><option value="PERMANENT">영구</option><option value="NONE">정지 해제</option></select></div>
+  <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('suspendModal')">취소</button><button class="btn btn-d btn-sm" onclick="confirmSuspend()">확인</button></div>
+</div></div>
+
+<div class="modal-bg" id="noticeModal"><div class="modal">
+  <h3 id="noticeModalTitle">공지사항 작성</h3>
+  <input type="hidden" id="noticeEditId">
+  <div class="fg"><label>제목</label><input type="text" id="noticeTitle"></div>
+  <div class="fg"><label>내용</label><textarea id="noticeContent" style="min-height:120px"></textarea></div>
+  <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('noticeModal')">취소</button><button class="btn btn-p btn-sm" onclick="saveNotice()">저장</button></div>
+</div></div>
+
+<div class="modal-bg" id="faqModal"><div class="modal">
+  <h3 id="faqModalTitle">FAQ 추가</h3>
+  <input type="hidden" id="faqEditId">
+  <div class="fg"><label>카테고리</label><input type="text" id="faqCategory" placeholder="일반, 계정, 행사 등"></div>
+  <div class="fg"><label>질문</label><input type="text" id="faqQuestion"></div>
+  <div class="fg"><label>답변</label><textarea id="faqAnswer"></textarea></div>
+  <div class="fg"><label>순서</label><input type="number" id="faqOrder" value="0"></div>
+  <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('faqModal')">취소</button><button class="btn btn-p btn-sm" onclick="saveFaq()">저장</button></div>
+</div></div>
+
+<div class="modal-bg" id="bannerModal"><div class="modal">
+  <h3 id="bannerModalTitle">배너 추가</h3>
+  <input type="hidden" id="bannerEditId">
+  <div class="fg"><label>제목</label><input type="text" id="bannerTitle"></div>
+  <div class="fg"><label>이미지 URL</label><input type="text" id="bannerImageUrl"></div>
+  <div class="fg"><label>링크 URL</label><input type="text" id="bannerLinkUrl"></div>
+  <div class="fg"><label>링크 타입</label><select id="bannerLinkType"><option value="NONE">없음</option><option value="INTERNAL">내부</option><option value="EXTERNAL">외부</option></select></div>
+  <div class="fg"><label>순서</label><input type="number" id="bannerOrder" value="0"></div>
+  <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('bannerModal')">취소</button><button class="btn btn-p btn-sm" onclick="saveBanner()">저장</button></div>
+</div></div>
+
+<div class="modal-bg" id="versionModal"><div class="modal">
+  <h3 id="versionModalTitle">앱 버전 추가</h3>
+  <input type="hidden" id="versionEditId">
+  <div class="fg"><label>플랫폼</label><select id="versionPlatform"><option value="IOS">iOS</option><option value="ANDROID">Android</option></select></div>
+  <div class="fg"><label>최소 버전</label><input type="text" id="versionMin" placeholder="1.0.0"></div>
+  <div class="fg"><label>최신 버전</label><input type="text" id="versionLatest" placeholder="1.0.0"></div>
+  <div class="fg"><label><input type="checkbox" id="versionForce"> 강제 업데이트</label></div>
+  <div class="fg"><label>스토어 URL</label><input type="text" id="versionStoreUrl"></div>
+  <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('versionModal')">취소</button><button class="btn btn-p btn-sm" onclick="saveVersion()">저장</button></div>
+</div></div>
+
+<div class="modal-bg" id="inquiryModal"><div class="modal">
+  <h3>문의 상세</h3>
+  <div id="inquiryDetail"></div>
+  <div class="fg" style="margin-top:12px"><label>답변</label><textarea id="inquiryAnswer"></textarea></div>
+  <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('inquiryModal')">닫기</button><button class="btn btn-p btn-sm" onclick="saveInquiryAnswer()">답변 저장</button></div>
+</div></div>
+
+<script src="/api/admin/web/js/auth.js"></script>
+<script src="/api/admin/web/js/app.js"></script>
+</body>
+</html>

--- a/backend/src/main/resources/static/api/admin/web/js/app.js
+++ b/backend/src/main/resources/static/api/admin/web/js/app.js
@@ -1,0 +1,448 @@
+// ===== Init =====
+(function init() {
+  if (getToken() && getRole() === 'ADMIN') {
+    showApp();
+  } else {
+    document.getElementById('loginView').classList.remove('hidden');
+  }
+})();
+
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const err = document.getElementById('loginErr');
+  err.style.display = 'none';
+  try {
+    const email = document.getElementById('loginEmail').value;
+    const pw = document.getElementById('loginPw').value;
+    const r = await fetch('/api/auth/login', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password: pw }),
+    });
+    if (!r.ok) throw new Error('이메일 또는 비밀번호가 올바르지 않습니다.');
+    const t = await r.json();
+    const token = t.accessToken || t.access_token;
+    if (!token) throw new Error('토큰 없음');
+    const me = await fetch('/api/members/me', { headers: { Authorization: 'Bearer ' + token } });
+    if (!me.ok) throw new Error('사용자 정보 조회 실패');
+    const u = await me.json();
+    if (u.role !== 'ADMIN') throw new Error('관리자 권한이 없습니다.');
+    localStorage.setItem('admin_token', token);
+    localStorage.setItem('admin_role', u.role);
+    localStorage.setItem('admin_email', u.email);
+    showApp();
+  } catch (ex) {
+    err.textContent = ex.message; err.style.display = 'block';
+  }
+});
+
+function showApp() {
+  document.getElementById('loginView').classList.add('hidden');
+  document.getElementById('appView').classList.remove('hidden');
+  loadDashboard();
+}
+
+// ===== Navigation =====
+document.querySelectorAll('.sidebar a[data-page]').forEach(a => {
+  a.addEventListener('click', (e) => {
+    e.preventDefault();
+    const pg = a.dataset.page;
+    document.querySelectorAll('.sidebar a').forEach(x => x.classList.remove('active'));
+    a.classList.add('active');
+    document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+    document.getElementById('pg-' + pg).classList.add('active');
+    loaders[pg]?.();
+  });
+});
+
+const loaders = {
+  dashboard: loadDashboard,
+  members: () => loadMembers(0),
+  events: () => loadEvents(0),
+  posts: () => loadPosts(0),
+  comments: () => loadComments(0),
+  notices: loadNotices,
+  faq: loadFaq,
+  banners: loadBanners,
+  reports: loadReports,
+  blocks: loadBlocks,
+  inquiries: () => loadInquiries(0),
+  push: () => {},
+  appversions: loadVersions,
+  logs: () => loadLogs(0),
+};
+
+// ===== Helpers =====
+function esc(s) { const d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+function fmtDate(s) { return s ? new Date(s).toLocaleDateString('ko') : '-'; }
+function fmtDateTime(s) { return s ? new Date(s).toLocaleString('ko') : '-'; }
+function badge(text, cls) { return `<span class="badge ${cls}">${esc(text)}</span>`; }
+function roleBadge(r) { return badge(r || 'USER', r === 'ADMIN' ? 'b-admin' : 'b-user'); }
+function statusBadge(s) { return badge(s || '-', s === 'ACTIVE' ? 'b-active' : s === 'DELETED' ? 'b-del' : 'b-pending'); }
+function closeModal(id) { document.getElementById(id).classList.remove('show'); }
+function openModal(id) { document.getElementById(id).classList.add('show'); }
+
+function pagingHtml(id, page, totalPages, fn) {
+  let h = '';
+  const start = Math.max(0, page - 4);
+  const end = Math.min(totalPages, start + 10);
+  for (let i = start; i < end; i++) {
+    h += `<button class="${i === page ? 'cur' : ''}" onclick="${fn}(${i})">${i + 1}</button>`;
+  }
+  document.getElementById(id).innerHTML = h;
+}
+
+// ===== Dashboard =====
+async function loadDashboard() {
+  try {
+    const d = await apiJson('/api/admin/dashboard');
+    const ms = d.memberStats || d;
+    const es = d.eventStats || d;
+    const ps = d.postStats || d;
+    const rs = d.reportStats || d;
+    const is = d.inquiryStats || d;
+    document.getElementById('dashStats').innerHTML = `
+      <div class="stat"><div class="l">전체 회원</div><div class="v">${ms.totalMembers ?? '-'}</div></div>
+      <div class="stat"><div class="l">오늘 가입</div><div class="v">${ms.todaySignups ?? '-'}</div></div>
+      <div class="stat"><div class="l">전체 행사</div><div class="v">${es.totalEvents ?? '-'}</div></div>
+      <div class="stat"><div class="l">전체 게시글</div><div class="v">${ps.totalPosts ?? '-'}</div></div>
+      <div class="stat"><div class="l">미처리 신고</div><div class="v">${rs.pendingReports ?? '-'}</div></div>
+      <div class="stat"><div class="l">미처리 문의</div><div class="v">${is.pendingInquiries ?? '-'}</div></div>
+    `;
+  } catch (e) {
+    document.getElementById('dashStats').innerHTML = '<div class="stat"><div class="l">로드 실패</div></div>';
+  }
+}
+
+// ===== Members =====
+let _suspendId = null;
+async function loadMembers(page) {
+  try {
+    const d = await apiJson(`/api/admin/members?page=${page}&size=20`);
+    const rows = (d.content || []).map(m => `<tr>
+      <td>${m.id}</td><td>${esc(m.email)}</td><td>${esc(m.nickname)}</td>
+      <td>${roleBadge(m.role)}</td><td>${statusBadge(m.status)}</td><td>${fmtDate(m.createdAt)}</td>
+      <td><button class="btn btn-d btn-sm" onclick="openSuspend(${m.id},'${esc(m.email)}')">정지</button></td>
+    </tr>`).join('');
+    document.getElementById('tMembers').innerHTML = rows || '<tr><td colspan="7" class="loading">없음</td></tr>';
+    pagingHtml('pgMembers', d.number || 0, d.totalPages || 1, 'loadMembers');
+  } catch (e) { document.getElementById('tMembers').innerHTML = '<tr><td colspan="7" class="loading">로드 실패</td></tr>'; }
+}
+function openSuspend(id, email) { _suspendId = id; document.getElementById('suspendInfo').textContent = `${email} (ID: ${id})`; openModal('suspendModal'); }
+async function confirmSuspend() {
+  if (!_suspendId) return;
+  try {
+    await api(`/api/admin/members/${_suspendId}/suspend`, { method: 'PATCH', body: JSON.stringify({ type: document.getElementById('suspendType').value }) });
+    closeModal('suspendModal'); loadMembers(0);
+  } catch (e) { alert('실패: ' + e.message); }
+}
+
+// ===== Events =====
+async function loadEvents(page) {
+  try {
+    const d = await apiJson(`/api/admin/events?page=${page}&size=20`);
+    const rows = (d.content || []).map(e => `<tr>
+      <td>${e.id}</td><td>${esc(e.title)}</td><td>${esc(e.placeName)}</td>
+      <td>${fmtDate(e.startAt)}</td><td>${fmtDate(e.endAt)}</td>
+      <td>${statusBadge(e.status)}</td>
+      <td><button class="btn btn-d btn-sm" onclick="deleteEvent(${e.id})">삭제</button></td>
+    </tr>`).join('');
+    document.getElementById('tEvents').innerHTML = rows || '<tr><td colspan="7" class="loading">없음</td></tr>';
+    pagingHtml('pgEvents', d.number || 0, d.totalPages || 1, 'loadEvents');
+  } catch (e) { document.getElementById('tEvents').innerHTML = '<tr><td colspan="7" class="loading">로드 실패</td></tr>'; }
+}
+async function deleteEvent(id) {
+  if (!confirm('정말 삭제하시겠습니까?')) return;
+  try { await api(`/api/admin/events/${id}`, { method: 'DELETE' }); loadEvents(0); } catch (e) { alert(e.message); }
+}
+
+// ===== Posts =====
+async function loadPosts(page) {
+  try {
+    const d = await apiJson('/api/admin/reports/record/by-post');
+    const rows = (d || []).map(p => `<tr>
+      <td>${p.postId}</td><td>${esc(p.title)}</td><td>${esc(p.authorNickname)} (${p.authorId})</td>
+      <td>${p.reportCount}</td><td>-</td>
+      <td><button class="btn btn-d btn-sm" onclick="deletePost(${p.postId})">삭제</button></td>
+    </tr>`).join('');
+    document.getElementById('tPosts').innerHTML = rows || '<tr><td colspan="6" class="loading">없음</td></tr>';
+  } catch (e) { document.getElementById('tPosts').innerHTML = '<tr><td colspan="6" class="loading">로드 실패</td></tr>'; }
+}
+async function deletePost(id) {
+  if (!confirm('게시글을 삭제하시겠습니까?')) return;
+  try { await api(`/api/admin/posts/${id}`, { method: 'DELETE' }); loadPosts(0); } catch (e) { alert(e.message); }
+}
+
+// ===== Comments =====
+async function loadComments(page) {
+  try {
+    const d = await apiJson(`/api/admin/comments?page=${page}&size=20`);
+    const rows = (d.content || []).map(c => `<tr>
+      <td>${c.id}</td><td>${esc(c.postTitle)} (${c.postId})</td><td>${esc(c.authorNickname)}</td>
+      <td>${esc(c.content?.substring(0, 40))}</td>
+      <td>${badge(c.status, c.status === 'VISIBLE' ? 'b-visible' : c.status === 'HIDDEN' ? 'b-hidden' : 'b-del')}</td>
+      <td>${c.reportCount || 0}</td>
+      <td class="flex-gap">
+        <button class="btn btn-w btn-sm" onclick="hideComment(${c.id})">숨김</button>
+        <button class="btn btn-s btn-sm" onclick="restoreComment(${c.id})">복원</button>
+        <button class="btn btn-d btn-sm" onclick="delComment(${c.id})">삭제</button>
+      </td>
+    </tr>`).join('');
+    document.getElementById('tComments').innerHTML = rows || '<tr><td colspan="7" class="loading">없음</td></tr>';
+    pagingHtml('pgComments', d.number || 0, d.totalPages || 1, 'loadComments');
+  } catch (e) { document.getElementById('tComments').innerHTML = '<tr><td colspan="7" class="loading">로드 실패</td></tr>'; }
+}
+async function hideComment(id) { try { await api(`/api/admin/comments/${id}/hide`, { method: 'PATCH' }); loadComments(0); } catch (e) { alert(e.message); } }
+async function restoreComment(id) { try { await api(`/api/admin/comments/${id}/restore`, { method: 'PATCH' }); loadComments(0); } catch (e) { alert(e.message); } }
+async function delComment(id) { if (!confirm('삭제?')) return; try { await api(`/api/admin/comments/${id}`, { method: 'DELETE' }); loadComments(0); } catch (e) { alert(e.message); } }
+
+// ===== Notices =====
+async function loadNotices() {
+  try {
+    const d = await apiJson('/api/admin/notices?page=0&size=100');
+    const list = d.content || d || [];
+    const rows = list.map(n => `<tr>
+      <td>${n.id}</td><td>${esc(n.title)}</td><td>${fmtDate(n.createdAt)}</td>
+      <td class="flex-gap">
+        <button class="btn btn-g btn-sm" onclick="editNotice(${n.id})">수정</button>
+        <button class="btn btn-d btn-sm" onclick="delNotice(${n.id})">삭제</button>
+      </td>
+    </tr>`).join('');
+    document.getElementById('tNotices').innerHTML = rows || '<tr><td colspan="4" class="loading">없음</td></tr>';
+  } catch (e) { document.getElementById('tNotices').innerHTML = '<tr><td colspan="4" class="loading">로드 실패</td></tr>'; }
+}
+function openNoticeModal(id, title, content) {
+  document.getElementById('noticeEditId').value = id || '';
+  document.getElementById('noticeTitle').value = title || '';
+  document.getElementById('noticeContent').value = content || '';
+  document.getElementById('noticeModalTitle').textContent = id ? '공지사항 수정' : '공지사항 작성';
+  openModal('noticeModal');
+}
+async function editNotice(id) {
+  try {
+    const list = await apiJson('/api/admin/notices?page=0&size=100');
+    const n = (list.content || list || []).find(x => x.id === id);
+    if (n) openNoticeModal(n.id, n.title, n.content);
+  } catch (e) { alert(e.message); }
+}
+async function saveNotice() {
+  const id = document.getElementById('noticeEditId').value;
+  const body = { title: document.getElementById('noticeTitle').value, content: document.getElementById('noticeContent').value };
+  try {
+    if (id) await api(`/api/admin/notices/${id}`, { method: 'PUT', body: JSON.stringify(body) });
+    else await api('/api/admin/notices', { method: 'POST', body: JSON.stringify(body) });
+    closeModal('noticeModal'); loadNotices();
+  } catch (e) { alert(e.message); }
+}
+async function delNotice(id) { if (!confirm('삭제?')) return; try { await api(`/api/admin/notices/${id}`, { method: 'DELETE' }); loadNotices(); } catch (e) { alert(e.message); } }
+
+// ===== FAQ =====
+async function loadFaq() {
+  try {
+    const d = await apiJson('/api/admin/faq?page=0&size=100');
+    const list = d.content || d || [];
+    const rows = list.map(f => `<tr>
+      <td>${f.id}</td><td>${esc(f.category)}</td><td>${esc(f.question)}</td>
+      <td>${f.isActive ? badge('ON', 'b-active') : badge('OFF', 'b-del')}</td><td>${f.displayOrder}</td>
+      <td class="flex-gap">
+        <button class="btn btn-g btn-sm" onclick="editFaq(${f.id})">수정</button>
+        <button class="btn btn-w btn-sm" onclick="toggleFaq(${f.id})">토글</button>
+        <button class="btn btn-d btn-sm" onclick="delFaq(${f.id})">삭제</button>
+      </td>
+    </tr>`).join('');
+    document.getElementById('tFaq').innerHTML = rows || '<tr><td colspan="6" class="loading">없음</td></tr>';
+  } catch (e) { document.getElementById('tFaq').innerHTML = '<tr><td colspan="6" class="loading">로드 실패</td></tr>'; }
+}
+function openFaqModal(id, cat, q, a, order) {
+  document.getElementById('faqEditId').value = id || '';
+  document.getElementById('faqCategory').value = cat || '';
+  document.getElementById('faqQuestion').value = q || '';
+  document.getElementById('faqAnswer').value = a || '';
+  document.getElementById('faqOrder').value = order || 0;
+  document.getElementById('faqModalTitle').textContent = id ? 'FAQ 수정' : 'FAQ 추가';
+  openModal('faqModal');
+}
+async function editFaq(id) {
+  try { const f = await apiJson(`/api/admin/faq/${id}`); openFaqModal(f.id, f.category, f.question, f.answer, f.displayOrder); } catch (e) { alert(e.message); }
+}
+async function saveFaq() {
+  const id = document.getElementById('faqEditId').value;
+  const body = { category: document.getElementById('faqCategory').value, question: document.getElementById('faqQuestion').value, answer: document.getElementById('faqAnswer').value, displayOrder: Number(document.getElementById('faqOrder').value) };
+  try {
+    if (id) await api(`/api/admin/faq/${id}`, { method: 'PUT', body: JSON.stringify(body) });
+    else await api('/api/admin/faq', { method: 'POST', body: JSON.stringify(body) });
+    closeModal('faqModal'); loadFaq();
+  } catch (e) { alert(e.message); }
+}
+async function toggleFaq(id) { try { await api(`/api/admin/faq/${id}/toggle`, { method: 'PATCH' }); loadFaq(); } catch (e) { alert(e.message); } }
+async function delFaq(id) { if (!confirm('삭제?')) return; try { await api(`/api/admin/faq/${id}`, { method: 'DELETE' }); loadFaq(); } catch (e) { alert(e.message); } }
+
+// ===== Banners =====
+async function loadBanners() {
+  try {
+    const d = await apiJson('/api/admin/banners?page=0&size=100');
+    const list = d.content || d || [];
+    const rows = list.map(b => `<tr>
+      <td>${b.id}</td><td>${esc(b.title)}</td>
+      <td>${b.isActive ? badge('ON', 'b-active') : badge('OFF', 'b-del')}</td><td>${b.displayOrder}</td>
+      <td>${fmtDate(b.startAt)} ~ ${fmtDate(b.endAt)}</td>
+      <td class="flex-gap">
+        <button class="btn btn-g btn-sm" onclick="editBanner(${b.id})">수정</button>
+        <button class="btn btn-w btn-sm" onclick="toggleBanner(${b.id})">토글</button>
+        <button class="btn btn-d btn-sm" onclick="delBanner(${b.id})">삭제</button>
+      </td>
+    </tr>`).join('');
+    document.getElementById('tBanners').innerHTML = rows || '<tr><td colspan="6" class="loading">없음</td></tr>';
+  } catch (e) { document.getElementById('tBanners').innerHTML = '<tr><td colspan="6" class="loading">로드 실패</td></tr>'; }
+}
+function openBannerModal(id, title, imgUrl, linkUrl, linkType, order) {
+  document.getElementById('bannerEditId').value = id || '';
+  document.getElementById('bannerTitle').value = title || '';
+  document.getElementById('bannerImageUrl').value = imgUrl || '';
+  document.getElementById('bannerLinkUrl').value = linkUrl || '';
+  document.getElementById('bannerLinkType').value = linkType || 'NONE';
+  document.getElementById('bannerOrder').value = order || 0;
+  document.getElementById('bannerModalTitle').textContent = id ? '배너 수정' : '배너 추가';
+  openModal('bannerModal');
+}
+async function editBanner(id) {
+  try { const b = await apiJson(`/api/admin/banners/${id}`); openBannerModal(b.id, b.title, b.imageUrl, b.linkUrl, b.linkType, b.displayOrder); } catch (e) { alert(e.message); }
+}
+async function saveBanner() {
+  const id = document.getElementById('bannerEditId').value;
+  const body = { title: document.getElementById('bannerTitle').value, imageUrl: document.getElementById('bannerImageUrl').value, linkUrl: document.getElementById('bannerLinkUrl').value || null, linkType: document.getElementById('bannerLinkType').value, displayOrder: Number(document.getElementById('bannerOrder').value) };
+  try {
+    if (id) await api(`/api/admin/banners/${id}`, { method: 'PUT', body: JSON.stringify(body) });
+    else await api('/api/admin/banners', { method: 'POST', body: JSON.stringify(body) });
+    closeModal('bannerModal'); loadBanners();
+  } catch (e) { alert(e.message); }
+}
+async function toggleBanner(id) { try { await api(`/api/admin/banners/${id}/toggle`, { method: 'PATCH' }); loadBanners(); } catch (e) { alert(e.message); } }
+async function delBanner(id) { if (!confirm('삭제?')) return; try { await api(`/api/admin/banners/${id}`, { method: 'DELETE' }); loadBanners(); } catch (e) { alert(e.message); } }
+
+// ===== Reports =====
+async function loadReports() {
+  try {
+    const d = await apiJson('/api/admin/reports/record/by-post');
+    const rows = (d || []).map(r => `<tr>
+      <td>${r.postId}</td><td>${esc(r.title)}</td><td>${esc(r.authorNickname)} (${r.authorId})</td><td>${r.reportCount}</td>
+    </tr>`).join('');
+    document.getElementById('tReports').innerHTML = rows || '<tr><td colspan="4" class="loading">없음</td></tr>';
+  } catch (e) { document.getElementById('tReports').innerHTML = '<tr><td colspan="4" class="loading">로드 실패</td></tr>'; }
+}
+
+// ===== Blocks =====
+async function loadBlocks() {
+  try {
+    const d = await apiJson('/api/admin/blocks/heavy-blocked');
+    const rows = (d || []).map(b => `<tr>
+      <td>${b.memberId}</td><td>${esc(b.email)}</td><td>${esc(b.nickname)}</td><td>${b.blockCount}</td>
+      <td>${fmtDateTime(b.suspendedUntil)}</td>
+      <td><button class="btn btn-d btn-sm" onclick="openSuspend(${b.memberId},'${esc(b.email)}')">정지</button></td>
+    </tr>`).join('');
+    document.getElementById('tBlocks').innerHTML = rows || '<tr><td colspan="6" class="loading">없음</td></tr>';
+  } catch (e) { document.getElementById('tBlocks').innerHTML = '<tr><td colspan="6" class="loading">로드 실패</td></tr>'; }
+}
+
+// ===== Inquiries =====
+let _inquiryId = null;
+async function loadInquiries(page) {
+  try {
+    const d = await apiJson(`/api/admin/inquiries?page=${page}&size=20`);
+    const rows = (d.content || []).map(i => `<tr>
+      <td>${i.id}</td><td>${esc(i.email)}</td><td>${esc(i.title)}</td>
+      <td>${badge(i.status, i.status === 'PENDING' ? 'b-pending' : i.status === 'ANSWERED' ? 'b-answered' : 'b-closed')}</td>
+      <td>${fmtDate(i.createdAt)}</td>
+      <td><button class="btn btn-g btn-sm" onclick="openInquiry(${i.id})">상세</button></td>
+    </tr>`).join('');
+    document.getElementById('tInquiries').innerHTML = rows || '<tr><td colspan="6" class="loading">없음</td></tr>';
+    pagingHtml('pgInquiries', d.number || 0, d.totalPages || 1, 'loadInquiries');
+  } catch (e) { document.getElementById('tInquiries').innerHTML = '<tr><td colspan="6" class="loading">로드 실패</td></tr>'; }
+}
+async function openInquiry(id) {
+  _inquiryId = id;
+  try {
+    const d = await apiJson(`/api/admin/inquiries/${id}`);
+    document.getElementById('inquiryDetail').innerHTML = `
+      <p><b>이메일:</b> ${esc(d.email)}</p>
+      <p><b>제목:</b> ${esc(d.title)}</p>
+      <p><b>내용:</b> ${esc(d.content)}</p>
+      <p><b>상태:</b> ${d.status}</p>
+      <p><b>기존 답변:</b> ${esc(d.answer) || '없음'}</p>
+    `;
+    document.getElementById('inquiryAnswer').value = d.answer || '';
+    openModal('inquiryModal');
+  } catch (e) { alert(e.message); }
+}
+async function saveInquiryAnswer() {
+  if (!_inquiryId) return;
+  try {
+    await api(`/api/admin/inquiries/${_inquiryId}/answer`, { method: 'PUT', body: JSON.stringify({ answer: document.getElementById('inquiryAnswer').value }) });
+    closeModal('inquiryModal'); loadInquiries(0);
+  } catch (e) { alert(e.message); }
+}
+
+// ===== Push =====
+async function sendPush() {
+  const title = document.getElementById('pushTitle').value;
+  const body = document.getElementById('pushBody').value;
+  if (!title || !body) { alert('제목과 내용을 입력하세요.'); return; }
+  if (!confirm('전체 사용자에게 푸시를 발송하시겠습니까?')) return;
+  try {
+    const r = await apiJson('/api/admin/notifications/send-all', { method: 'POST', body: JSON.stringify({ title, body }) });
+    document.getElementById('pushResult').textContent = `발송 완료 - 성공: ${r.sentCount}, 실패: ${r.failedCount}`;
+  } catch (e) { document.getElementById('pushResult').textContent = '발송 실패: ' + e.message; }
+}
+
+// ===== App Versions =====
+async function loadVersions() {
+  try {
+    const d = await apiJson('/api/admin/app-version');
+    const list = Array.isArray(d) ? d : (d.content || []);
+    const rows = list.map(v => `<tr>
+      <td>${v.id}</td><td>${v.platform}</td><td>${v.minimumVersion}</td><td>${v.latestVersion}</td>
+      <td>${v.forceUpdate ? badge('YES', 'b-del') : badge('NO', 'b-active')}</td>
+      <td class="flex-gap">
+        <button class="btn btn-g btn-sm" onclick="editVersion(${v.id})">수정</button>
+        <button class="btn btn-d btn-sm" onclick="delVersion(${v.id})">삭제</button>
+      </td>
+    </tr>`).join('');
+    document.getElementById('tVersions').innerHTML = rows || '<tr><td colspan="6" class="loading">없음</td></tr>';
+  } catch (e) { document.getElementById('tVersions').innerHTML = '<tr><td colspan="6" class="loading">로드 실패</td></tr>'; }
+}
+function openVersionModal(id, platform, min, latest, force, storeUrl) {
+  document.getElementById('versionEditId').value = id || '';
+  document.getElementById('versionPlatform').value = platform || 'IOS';
+  document.getElementById('versionMin').value = min || '';
+  document.getElementById('versionLatest').value = latest || '';
+  document.getElementById('versionForce').checked = !!force;
+  document.getElementById('versionStoreUrl').value = storeUrl || '';
+  document.getElementById('versionModalTitle').textContent = id ? '앱 버전 수정' : '앱 버전 추가';
+  openModal('versionModal');
+}
+async function editVersion(id) {
+  try { const v = await apiJson(`/api/admin/app-version/${id}`); openVersionModal(v.id, v.platform, v.minimumVersion, v.latestVersion, v.forceUpdate, v.storeUrl); } catch (e) { alert(e.message); }
+}
+async function saveVersion() {
+  const id = document.getElementById('versionEditId').value;
+  const body = { platform: document.getElementById('versionPlatform').value, minimumVersion: document.getElementById('versionMin').value, latestVersion: document.getElementById('versionLatest').value, forceUpdate: document.getElementById('versionForce').checked, storeUrl: document.getElementById('versionStoreUrl').value || null };
+  try {
+    if (id) await api(`/api/admin/app-version/${id}`, { method: 'PUT', body: JSON.stringify(body) });
+    else await api('/api/admin/app-version', { method: 'POST', body: JSON.stringify(body) });
+    closeModal('versionModal'); loadVersions();
+  } catch (e) { alert(e.message); }
+}
+async function delVersion(id) { if (!confirm('삭제?')) return; try { await api(`/api/admin/app-version/${id}`, { method: 'DELETE' }); loadVersions(); } catch (e) { alert(e.message); } }
+
+// ===== Logs =====
+async function loadLogs(page) {
+  try {
+    const d = await apiJson(`/api/admin/logs?page=${page}&size=20`);
+    const rows = (d.content || []).map(l => `<tr>
+      <td>${l.id}</td><td>${esc(l.adminEmail)}</td><td>${esc(l.action)}</td>
+      <td>${esc(l.targetType)}${l.targetId ? ' #' + l.targetId : ''}</td>
+      <td>${esc(l.description?.substring(0, 50))}</td><td>${fmtDateTime(l.createdAt)}</td>
+    </tr>`).join('');
+    document.getElementById('tLogs').innerHTML = rows || '<tr><td colspan="6" class="loading">없음</td></tr>';
+    pagingHtml('pgLogs', d.number || 0, d.totalPages || 1, 'loadLogs');
+  } catch (e) { document.getElementById('tLogs').innerHTML = '<tr><td colspan="6" class="loading">로드 실패</td></tr>'; }
+}

--- a/backend/src/main/resources/static/api/admin/web/js/auth.js
+++ b/backend/src/main/resources/static/api/admin/web/js/auth.js
@@ -1,0 +1,43 @@
+function getToken() { return localStorage.getItem('admin_token'); }
+function getRole() { return localStorage.getItem('admin_role'); }
+
+function requireAuth() {
+  if (!getToken() || getRole() !== 'ADMIN') {
+    location.href = '/api/admin/web/';
+    return false;
+  }
+  return true;
+}
+
+function logout() {
+  localStorage.removeItem('admin_token');
+  localStorage.removeItem('admin_role');
+  localStorage.removeItem('admin_email');
+  location.href = '/api/admin/web/';
+}
+
+function apiHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer ' + getToken(),
+  };
+}
+
+async function api(path, options = {}) {
+  const res = await fetch(path, {
+    ...options,
+    headers: { ...apiHeaders(), ...(options.headers || {}) },
+  });
+  if (res.status === 401 || res.status === 403) {
+    logout();
+    throw new Error('인증 만료');
+  }
+  return res;
+}
+
+async function apiJson(path, options) {
+  const res = await api(path, options);
+  if (!res.ok) throw new Error(await res.text() || `Error ${res.status}`);
+  const text = await res.text();
+  return text ? JSON.parse(text) : null;
+}

--- a/frontend/app/(tabs)/mypage/index.tsx
+++ b/frontend/app/(tabs)/mypage/index.tsx
@@ -14,7 +14,6 @@ import { router } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAuth } from "../../../hooks/useAuth";
 import { useFestivalParticipation } from "../../../hooks/useFestivalParticipation";
-import { ADMIN_EMAIL } from "../../../services/auth.service";
 import { API_BASE_URL } from "../../../constants/api";
 
 export default function MyPageScreen() {
@@ -229,8 +228,8 @@ export default function MyPageScreen() {
           />
         </Section>
 
-        {/* 섹션: 관리자 (yunajo5858@gmail.com 로그인 시에만 표시, getMe 실패 시에도 이메일로 판별) */}
-        {isLoggedIn && (user?.role === "ADMIN" || user?.email === ADMIN_EMAIL) && (
+        {/* 섹션: 관리자 (DB role=ADMIN 일 때만 표시) */}
+        {isLoggedIn && user?.role === "ADMIN" && (
           <Section title="관리자">
             <MenuItem
               icon="shield-checkmark-outline"

--- a/frontend/services/auth.service.ts
+++ b/frontend/services/auth.service.ts
@@ -8,9 +8,6 @@ const USER_EMAIL_KEY = '@dailo/userEmail';
 const USER_ID_KEY = '@dailo/userId';
 const NICKNAME_MAP_KEY = '@dailo/emailToNickname';
 
-/** 이 이메일로 로그인한 경우 마이페이지에 관리자 메뉴 표시 (백엔드 app.admin.emails와 동일하게) */
-export const ADMIN_EMAIL = 'yunajo5858@gmail.com';
-
 /** 백엔드 TokenDto */
 export type TokenDto = {
   grantType: string;


### PR DESCRIPTION
- 관리자 웹 페이지를 /api/admin/web/에 추가 (Spring Boot 정적 파일)
- MemberResponseDto에 role 필드 추가하여 프론트에서 ADMIN 판별 가능
- ADMIN_EMAIL 하드코딩 제거, DB role=ADMIN으로만 관리자 판별
- SecurityConfig에 /api/admin/web/** permitAll 추가


