### PR TITLE
버스 정류장 마커 표시, 실시간 도착 정보 바텀시트, 노선-정류장 DB 동기화 기능 추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,7 @@ COPY src ./src
 RUN ./gradlew clean build -x test --no-daemon
 
 # 2단계: 실행 단계
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre-jammy
 
 # 작업 디렉토리
 WORKDIR /app

--- a/backend/src/main/java/com/dailo/backend/dto/BusArrivalResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/BusArrivalResponse.java
@@ -11,6 +11,7 @@ public class BusArrivalResponse {
 
     private String stopName;
     private String cityCode;
+    private Long cachedAt;
     private List<ArrivalItem> arrivals;
 
     @Getter
@@ -19,6 +20,7 @@ public class BusArrivalResponse {
         private String routeId;
         private String routeNo;
         private String destination;
+        private Integer arrivalSec;
         private Integer arrivalMin;
         private String arrivalMessage;
         private Integer remainingStops;

--- a/backend/src/main/java/com/dailo/backend/entity/BusStop.java
+++ b/backend/src/main/java/com/dailo/backend/entity/BusStop.java
@@ -38,6 +38,9 @@ public class BusStop {
     @Column(name = "city_code", length = 10)
     private String cityCode;
 
+    @Column(name = "has_routes")
+    private Boolean hasRoutes;
+
     @UpdateTimestamp
     @Column(name = "synced_at")
     private LocalDateTime syncedAt;

--- a/backend/src/main/java/com/dailo/backend/entity/BusStopRoute.java
+++ b/backend/src/main/java/com/dailo/backend/entity/BusStopRoute.java
@@ -1,0 +1,33 @@
+package com.dailo.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "bus_stop_routes", indexes = {
+        @Index(name = "idx_bus_stop_route_stop_id", columnList = "stop_id")
+}, uniqueConstraints = {
+        @UniqueConstraint(name = "uk_bus_stop_route", columnNames = {"stop_id", "route_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BusStopRoute {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "stop_id", nullable = false, length = 30)
+    private String stopId;
+
+    @Column(name = "route_id", nullable = false, length = 30)
+    private String routeId;
+
+    @Column(name = "route_no", length = 20)
+    private String routeNo;
+
+    @Column(name = "end_node_name", length = 50)
+    private String endNodeName;
+}

--- a/backend/src/main/java/com/dailo/backend/repository/BusStopRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/BusStopRepository.java
@@ -1,8 +1,10 @@
 package com.dailo.backend.repository;
 
 import com.dailo.backend.entity.BusStop;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,7 +21,8 @@ public interface BusStopRepository extends JpaRepository<BusStop, Long> {
 
     @Query("SELECT b FROM BusStop b WHERE " +
             "b.latitude BETWEEN :minLat AND :maxLat AND " +
-            "b.longitude BETWEEN :minLng AND :maxLng")
+            "b.longitude BETWEEN :minLng AND :maxLng AND " +
+            "(b.hasRoutes IS NULL OR b.hasRoutes = true)")
     List<BusStop> findByBounds(
             @Param("minLat") double minLat,
             @Param("maxLat") double maxLat,
@@ -27,4 +30,9 @@ public interface BusStopRepository extends JpaRepository<BusStop, Long> {
             @Param("maxLng") double maxLng,
             Pageable pageable
     );
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE BusStop b SET b.hasRoutes = :hasRoutes WHERE b.stopId = :stopId")
+    void updateHasRoutes(@Param("stopId") String stopId, @Param("hasRoutes") Boolean hasRoutes);
 }

--- a/backend/src/main/java/com/dailo/backend/repository/BusStopRouteRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/BusStopRouteRepository.java
@@ -1,0 +1,22 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.BusStopRoute;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BusStopRouteRepository extends JpaRepository<BusStopRoute, Long> {
+
+    List<BusStopRoute> findByStopId(String stopId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM BusStopRoute r WHERE r.stopId IN :stopIds")
+    void deleteByStopIdIn(@Param("stopIds") List<String> stopIds);
+}

--- a/backend/src/main/java/com/dailo/backend/service/BusApiService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BusApiService.java
@@ -92,6 +92,7 @@ public class BusApiService {
                 .routeId(item.path("routeid").asText(""))
                 .routeNo(item.path("routeno").asText(""))
                 .destination(item.path("nodenm").asText("")) // 현재 버스 위치 정류장명 (행선지 방면 표시용)
+                .arrivalSec(arrivalSec >= 0 ? arrivalSec : null)
                 .arrivalMin(arrivalMin)
                 .arrivalMessage(arrivalMessage)
                 .remainingStops(remainingStops >= 0 ? remainingStops : null)
@@ -99,41 +100,52 @@ public class BusApiService {
     }
 
     /**
-     * 정류장 경유 노선 목록 조회
-     * BusRouteInfoInqireService/getRouteBySttn
+     * 도시 전체 노선 목록 조회 (routeId + routeNo)
+     * BusRouteInfoInqireService/getRouteNoList
      */
-    public List<BusRouteInfoResponse> getRoutesByStop(String cityCode, String stopId) {
-        URI uri = UriComponentsBuilder
-                .fromHttpUrl(baseUrl + "/BusRouteInfoInqireService/getRouteBySttn")
-                .queryParam("serviceKey", apiKey)
-                .queryParam("cityCode", cityCode)
-                .queryParam("nodeId", stopId)
-                .queryParam("numOfRows", 30)
-                .queryParam("pageNo", 1)
-                .queryParam("_type", "json")
-                .build(true)
-                .toUri();
-
+    public List<BusRouteInfoResponse> getRoutes(String cityCode) {
         List<BusRouteInfoResponse> result = new ArrayList<>();
-        try {
-            String response = restTemplate.getForObject(uri, String.class);
-            JsonNode items = objectMapper.readTree(response)
-                    .path("response").path("body").path("items").path("item");
+        int page = 1;
+        final int perPage = 100;
 
-            if (items.isMissingNode() || items.isNull()) return result;
+        while (true) {
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(baseUrl + "/BusRouteInfoInqireService/getRouteNoList")
+                    .queryParam("serviceKey", apiKey)
+                    .queryParam("cityCode", cityCode)
+                    .queryParam("numOfRows", perPage)
+                    .queryParam("pageNo", page)
+                    .queryParam("_type", "json")
+                    .build(true).toUri();
 
-            Iterable<JsonNode> rows = items.isArray() ? items : List.of(items);
-            for (JsonNode item : rows) {
-                result.add(BusRouteInfoResponse.builder()
-                        .routeId(item.path("routeid").asText(""))
-                        .routeNo(item.path("routeno").asText(""))
+            try {
+                String response = restTemplate.getForObject(uri, String.class);
+                JsonNode body = objectMapper.readTree(response).path("response").path("body");
+                JsonNode items = body.path("items").path("item");
 
-                        .endNodeName(item.path("endnodenm").asText(""))
-                        .build());
+                if (items.isMissingNode() || items.isNull()) break;
+
+                Iterable<JsonNode> rows = items.isArray() ? items : List.of(items);
+                for (JsonNode item : rows) {
+                    String routeId = item.path("routeid").asText("");
+                    if (!routeId.isEmpty()) {
+                        result.add(BusRouteInfoResponse.builder()
+                                .routeId(routeId)
+                                .routeNo(item.path("routeno").asText(""))
+                                .endNodeName(item.path("endnodenm").asText(""))
+                                .build());
+                    }
+                }
+
+                int totalCount = body.path("totalCount").asInt(0);
+                if ((long) page * perPage >= totalCount) break;
+                page++;
+            } catch (Exception e) {
+                log.error("노선 목록 조회 실패 - cityCode: {}, error: {}", cityCode, e.getMessage());
+                break;
             }
-        } catch (Exception e) {
-            log.error("정류장 경유 노선 조회 실패 - stopId: {}, error: {}", stopId, e.getMessage());
         }
+
         return result;
     }
 

--- a/backend/src/main/java/com/dailo/backend/service/BusService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BusService.java
@@ -7,6 +7,7 @@ import com.dailo.backend.dto.BusRouteStopResponse;
 import com.dailo.backend.dto.BusStopResponse;
 import com.dailo.backend.entity.BusStop;
 import com.dailo.backend.repository.BusStopRepository;
+import com.dailo.backend.repository.BusStopRouteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
@@ -15,7 +16,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,6 +27,7 @@ public class BusService {
     private static final String DEFAULT_CITY_CODE = "33020";
 
     private final BusStopRepository busStopRepository;
+    private final BusStopRouteRepository busStopRouteRepository;
     private final BusApiService busApiService;
 
     // @Cacheable 메서드 간 호출 시 프록시를 통해야 캐시가 동작하므로 자기주입 사용
@@ -52,7 +53,7 @@ public class BusService {
      * 지도 bounds 내 정류장 조회
      */
     public List<BusStopResponse> getStopsInBounds(double swLat, double swLng, double neLat, double neLng) {
-        return busStopRepository.findByBounds(swLat, neLat, swLng, neLng, PageRequest.of(0, 15))
+        return busStopRepository.findByBounds(swLat, neLat, swLng, neLng, PageRequest.of(0, 200))
                 .stream().map(BusStopResponse::from).collect(Collectors.toList());
     }
 
@@ -74,6 +75,7 @@ public class BusService {
         return BusArrivalResponse.builder()
                 .stopName(stop.getStopName())
                 .cityCode(cityCode)
+                .cachedAt(System.currentTimeMillis())
                 .arrivals(corrected)
                 .build();
     }
@@ -108,6 +110,7 @@ public class BusService {
                     .routeId(item.getRouteId())
                     .routeNo(item.getRouteNo())
                     .destination(item.getDestination())
+                    .arrivalSec(item.getArrivalSec())
                     .arrivalMin(item.getArrivalMin())
                     .arrivalMessage(item.getArrivalMessage())
                     .remainingStops(currentNodeOrder - closestNodeOrder)
@@ -118,13 +121,16 @@ public class BusService {
     }
 
     /**
-     * 정류장 경유 노선 목록 조회
+     * 정류장 경유 노선 목록 조회 (DB)
      */
     public List<BusRouteInfoResponse> getRoutesByStop(String stopId) {
-        BusStop stop = busStopRepository.findByStopId(stopId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "STOP_NOT_FOUND"));
-        String cityCode = stop.getCityCode() != null ? stop.getCityCode() : DEFAULT_CITY_CODE;
-        return busApiService.getRoutesByStop(cityCode, stopId);
+        return busStopRouteRepository.findByStopId(stopId).stream()
+                .map(r -> BusRouteInfoResponse.builder()
+                        .routeId(r.getRouteId())
+                        .routeNo(r.getRouteNo())
+                        .endNodeName(r.getEndNodeName() != null ? r.getEndNodeName() : "")
+                        .build())
+                .collect(Collectors.toList());
     }
 
     /**

--- a/backend/src/main/java/com/dailo/backend/service/BusStopSyncService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BusStopSyncService.java
@@ -1,7 +1,11 @@
 package com.dailo.backend.service;
 
+import com.dailo.backend.dto.BusRouteInfoResponse;
+import com.dailo.backend.dto.BusRouteStopResponse;
 import com.dailo.backend.entity.BusStop;
+import com.dailo.backend.entity.BusStopRoute;
 import com.dailo.backend.repository.BusStopRepository;
+import com.dailo.backend.repository.BusStopRouteRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +20,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -31,10 +37,67 @@ public class BusStopSyncService {
     private String baseUrl;
 
     private final BusStopRepository busStopRepository;
+    private final BusStopRouteRepository busStopRouteRepository;
+    private final BusApiService busApiService;
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
     private static final int PER_PAGE = 100;
+
+    /**
+     * 노선 목록 → 경유 정류장 역방향으로 (stopId → List<route>) 매핑 구성 후 DB 저장
+     * 동시에 노선 보유 정류장 ID Set 반환
+     */
+    private Set<String> buildAndSaveRouteMapping(String cityCode) {
+        List<BusRouteInfoResponse> routes = busApiService.getRoutes(cityCode);
+        log.info("노선 수: {}개 - cityCode: {}", routes.size(), cityCode);
+
+        // (stopId, routeId) 중복 방지용 Set + stopId → list of BusStopRoute
+        Map<String, List<BusStopRoute>> stopRouteMap = new HashMap<>();
+        Set<String> seen = new HashSet<>(); // "stopId:routeId"
+
+        for (BusRouteInfoResponse route : routes) {
+            try {
+                List<BusRouteStopResponse> stops = busApiService.getRouteStops(cityCode, route.getRouteId());
+                for (BusRouteStopResponse stop : stops) {
+                    String stopId = stop.getNodeId();
+                    if (stopId == null || stopId.isEmpty()) continue;
+                    String key = stopId + ":" + route.getRouteId();
+                    if (!seen.add(key)) continue; // 이미 추가된 조합은 건너뜀
+                    stopRouteMap.computeIfAbsent(stopId, k -> new ArrayList<>())
+                            .add(BusStopRoute.builder()
+                                    .stopId(stopId)
+                                    .routeId(route.getRouteId())
+                                    .routeNo(route.getRouteNo())
+                                    .endNodeName(route.getEndNodeName())
+                                    .build());
+                }
+            } catch (Exception e) {
+                log.warn("노선 경유 정류장 조회 실패 - routeId: {}", route.getRouteId());
+            }
+        }
+
+        Set<String> stopsWithRoutes = stopRouteMap.keySet();
+        log.info("노선 보유 정류장 수: {}개", stopsWithRoutes.size());
+
+        // 기존 데이터 삭제 후 새로 저장 (배치)
+        List<String> stopIds = new ArrayList<>(stopsWithRoutes);
+        for (int i = 0; i < stopIds.size(); i += 500) {
+            List<String> batch = stopIds.subList(i, Math.min(i + 500, stopIds.size()));
+            busStopRouteRepository.deleteByStopIdIn(batch);
+        }
+
+        List<BusStopRoute> allRoutes = new ArrayList<>();
+        for (List<BusStopRoute> routeList : stopRouteMap.values()) {
+            allRoutes.addAll(routeList);
+        }
+        for (int i = 0; i < allRoutes.size(); i += 500) {
+            busStopRouteRepository.saveAll(allRoutes.subList(i, Math.min(i + 500, allRoutes.size())));
+        }
+
+        log.info("노선-정류장 매핑 저장 완료: {}건", allRoutes.size());
+        return new HashSet<>(stopsWithRoutes);
+    }
 
     /**
      * TAGO BusSttnInfoInqireService → 전체 도시코드 목록 조회
@@ -68,6 +131,9 @@ public class BusStopSyncService {
      */
     @Async
     public void syncByCity(String cityCode, String cityName) {
+        log.info("노선 보유 정류장 목록 구성 시작 - {}", cityName);
+        Set<String> stopsWithRoutes = buildAndSaveRouteMapping(cityCode);
+
         int page = 1;
         int totalSaved = 0;
 
@@ -93,7 +159,15 @@ public class BusStopSyncService {
 
                 for (JsonNode item : rows) {
                     String stopId = item.path("nodeid").asText();
-                    if (busStopRepository.existsByStopId(stopId)) continue;
+                    boolean hasRoutes = stopsWithRoutes.contains(stopId);
+                    boolean exists = busStopRepository.existsByStopId(stopId);
+
+                    if (exists) {
+                        busStopRepository.updateHasRoutes(stopId, hasRoutes);
+                        continue;
+                    }
+
+                    if (!hasRoutes) continue;
 
                     try {
                         toSave.add(BusStop.builder()
@@ -103,6 +177,7 @@ public class BusStopSyncService {
                                 .longitude(item.path("gpslong").asDouble())
                                 .regionName(cityName)
                                 .cityCode(cityCode)
+                                .hasRoutes(true)
                                 .build());
                     } catch (Exception e) {
                         log.warn("정류장 파싱 실패 - stopId: {}", stopId);

--- a/frontend/app/(tabs)/map/_components/BusStopBottomSheet.tsx
+++ b/frontend/app/(tabs)/map/_components/BusStopBottomSheet.tsx
@@ -31,6 +31,7 @@ type MergedItem = {
   routeNo: string;
   endNodeName: string; // 종점 (노선 기본 정보)
   destination: string | null; // 도착 정보의 행선지
+  arrivalSec: number | null;
   arrivalMin: number | null;
   arrivalMessage: string | null;
   remainingStops: number | null;
@@ -50,6 +51,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState(false);
+  const [cachedAt, setCachedAt] = useState<number | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [tick, setTick] = useState(0);
   const [cooldown, setCooldown] = useState(0);
@@ -118,7 +120,11 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
 
         if (arrivalsRes) {
           setStopName(arrivalsRes.stopName);
-          setCityCode(arrivalsRes.cityCode);
+          setCityCode(arrivalsRes.cityCode || stop?.cityCode || '');
+          setCachedAt(arrivalsRes.cachedAt ?? Date.now());
+        } else {
+          setCityCode(stop?.cityCode || '');
+          setCachedAt(Date.now());
         }
 
         const arrivals = arrivalsRes?.arrivals ?? [];
@@ -138,6 +144,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
             routeNo: route.routeNo,
             endNodeName: route.endNodeName,
             destination: arrival?.destination ?? null,
+            arrivalSec: arrival?.arrivalSec ?? null,
             arrivalMin: arrival?.arrivalMin ?? null,
             arrivalMessage: arrival?.arrivalMessage ?? null,
             remainingStops: arrival?.remainingStops ?? null,
@@ -151,6 +158,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
             routeNo: a.routeNo,
             endNodeName: a.destination ?? "",
             destination: a.destination,
+            arrivalSec: a.arrivalSec,
             arrivalMin: a.arrivalMin,
             arrivalMessage: a.arrivalMessage,
             remainingStops: a.remainingStops,
@@ -175,7 +183,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
         stopSpin();
       }
     },
-    [startSpin, stopSpin, startCooldown, cooldown],
+    [startSpin, stopSpin, startCooldown, cooldown, stop],
   );
 
   useEffect(() => {
@@ -183,14 +191,19 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
     fetchData(stop.stopId);
   }, [stop?.stopId]);
 
-  const getCountdown = (arrivalMin: number | null, arrivalMessage: string | null) => {
-    if (arrivalMin == null || !lastUpdated) return arrivalMessage;
-    const elapsedSec = Math.floor((Date.now() - lastUpdated.getTime()) / 1000);
-    const remainingSec = arrivalMin * 60 - elapsedSec;
+  const getCountdown = (arrivalSec: number | null, arrivalMessage: string | null) => {
+    if (arrivalSec == null || !cachedAt) return arrivalMessage;
+    const elapsedSec = Math.floor((Date.now() - cachedAt) / 1000);
+    const remainingSec = arrivalSec - elapsedSec;
     if (remainingSec <= 0) return "곧 도착";
     const min = Math.floor(remainingSec / 60);
     const sec = remainingSec % 60;
     if (min === 0) return `${sec}초 후 도착`;
+    if (min >= 60) {
+      const hour = Math.floor(min / 60);
+      const remMin = min % 60;
+      return remMin > 0 ? `${hour}시간 ${remMin}분 후 도착` : `${hour}시간 후 도착`;
+    }
     return `${min}분 ${sec < 10 ? `0${sec}` : sec}초 후 도착`;
   };
 
@@ -266,7 +279,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
           </View>
         ) : items.length === 0 ? (
           <View style={styles.center}>
-            <Text style={styles.emptyText}>운행중인 버스가 없습니다.</Text>
+            <Text style={styles.emptyText}>이 정류장의 노선 정보가 없습니다.</Text>
           </View>
         ) : (
           <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
@@ -309,7 +322,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
                           styles.arrivalTimeSoon,
                       ]}
                     >
-                      {getCountdown(item.arrivalMin, item.arrivalMessage)}
+                      {getCountdown(item.arrivalSec, item.arrivalMessage)}
                     </Text>
                   ) : (
                     <Text style={styles.noArrival}>운행 정보 없음</Text>

--- a/frontend/app/(tabs)/map/_components/NaverMap.tsx
+++ b/frontend/app/(tabs)/map/_components/NaverMap.tsx
@@ -60,7 +60,7 @@ type Props = {
   events: Event[];
   onMarkerPress: (event: Event) => void;
   /** 카메라 이동이 끝났을 때(드래그/줌 후) 호출. region 동기화용 (latitude/longitude는 남서쪽, center 아님) */
-  onCameraIdle?: (params: { region: { latitude: number; longitude: number; latitudeDelta: number; longitudeDelta: number }; zoom?: number }) => void;
+  onCameraIdle?: (params: { latitude?: number; longitude?: number; zoom?: number; region: { latitude: number; longitude: number; latitudeDelta: number; longitudeDelta: number } }) => void;
   /** 현재 위치 버튼을 눌렀을 때 표시할 파란 동그라미 위치 */
   currentLocation?: { latitude: number; longitude: number } | null;
   /** 동그라미 표시용 좌표(실제 위치 못 받을 때 fallback 등). 있으면 이걸 우선 사용 */
@@ -77,6 +77,8 @@ type Props = {
   busStops?: BusStop[];
   /** 버스 정류장 마커 탭 콜백 */
   onBusStopPress?: (stop: BusStop) => void;
+  /** 버스 정류장 쿼리 중심 (원형 필터 기준점) */
+  busQueryCenter?: { latitude: number; longitude: number } | null;
 };
 
 // 현재 위치 점: 화면 상에서 항상 일정한 크기의 점으로 표시 (줌 레벨과 무관)
@@ -117,8 +119,47 @@ const DISTANCE_FILTER_CIRCLE_COLOR = 'rgba(59, 130, 246, 0.15)';
 const DISTANCE_FILTER_CIRCLE_OUTLINE_WIDTH = 2;
 const DISTANCE_FILTER_CIRCLE_OUTLINE_COLOR = 'rgba(59, 130, 246, 0.5)';
 
+const CLUSTER_CELL_SIZES = [0.001, 0.002, 0.003, 0.005, 0.007, 0.01, 0.015, 0.02, 0.03, 0.05, 0.1];
+const CLUSTER_TARGET = 15;
+
+function clusterBusStops(stops: BusStop[], zoom: number, centerLat: number, centerLng: number): BusStop[] {
+  if (stops.length === 0) return stops;
+
+  // 원형 필터: 직사각형 bounds 모서리 제거
+  const cosLat = Math.cos(centerLat * Math.PI / 180);
+  const radiusDeg = 0.05 * Math.pow(2, Math.max(0, 14 - zoom));
+  const circular = stops.filter(s => {
+    const dLat = s.latitude - centerLat;
+    const dLng = (s.longitude - centerLng) * cosLat;
+    return dLat * dLat + dLng * dLng <= radiusDeg * radiusDeg;
+  });
+  const candidates = circular.length >= 5 ? circular : stops;
+
+  if (zoom >= 16 || candidates.length <= CLUSTER_TARGET) return candidates;
+
+  // 각 셀에서 셀 중심에 가장 가까운 정류장을 대표로 선택 (DB 정렬 순서 의존 제거)
+  for (const cellSize of CLUSTER_CELL_SIZES) {
+    const cells = new Map<string, { stop: BusStop; dist: number }>();
+    for (const stop of candidates) {
+      const row = Math.floor(stop.latitude / cellSize);
+      const col = Math.floor(stop.longitude / cellSize);
+      const key = `${row}_${col}`;
+      const cellCenterLat = (row + 0.5) * cellSize;
+      const cellCenterLng = (col + 0.5) * cellSize;
+      const dist = Math.hypot(stop.latitude - cellCenterLat, stop.longitude - cellCenterLng);
+      const existing = cells.get(key);
+      if (!existing || dist < existing.dist) cells.set(key, { stop, dist });
+    }
+    if (cells.size <= CLUSTER_TARGET) {
+      return Array.from(cells.values()).map(v => v.stop);
+    }
+  }
+
+  return candidates.slice(0, CLUSTER_TARGET);
+}
+
 export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
-  { style, camera, events, onMarkerPress, onCameraIdle, currentLocation, circleCoords, showMyLocationCircle, selectedEvent, distanceFilterRadiusM, distanceFilterCenter, busStops, onBusStopPress },
+  { style, camera, events, onMarkerPress, onCameraIdle, currentLocation, circleCoords, showMyLocationCircle, selectedEvent, distanceFilterRadiusM, distanceFilterCenter, busStops, onBusStopPress, busQueryCenter },
   ref
 ) {
   const myLocationCoords = circleCoords ?? currentLocation ?? null;
@@ -145,6 +186,12 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
       ),
     [events]
   );
+
+  const clusteredBusStops = useMemo(() => {
+    const filterLat = busQueryCenter?.latitude ?? effectiveCamera.latitude;
+    const filterLng = busQueryCenter?.longitude ?? effectiveCamera.longitude;
+    return clusterBusStops(busStops ?? [], effectiveCamera.zoom, filterLat, filterLng);
+  }, [busStops, effectiveCamera.zoom, effectiveCamera.latitude, effectiveCamera.longitude, busQueryCenter]);
 
   return (
     <NaverMapView
@@ -271,7 +318,7 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
             />
           </NaverMapMarkerOverlay>
         )}
-      {busStops?.map((stop) => (
+      {clusteredBusStops.map((stop) => (
         <NaverMapMarkerOverlay
           key={`bus-stop-${stop.stopId}`}
           latitude={stop.latitude}
@@ -279,16 +326,10 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
           width={BUS_STOP_SIZE}
           height={BUS_STOP_SIZE}
           anchor={{ x: 0.5, y: 0.5 }}
+          image={BUS_STOP_MARKER}
           onTap={() => onBusStopPress?.(stop)}
           globalZIndex={180000}
-          isHideCollidedMarkers
-        >
-          <Image
-            source={BUS_STOP_MARKER}
-            style={{ width: BUS_STOP_SIZE, height: BUS_STOP_SIZE }}
-            resizeMode="contain"
-          />
-        </NaverMapMarkerOverlay>
+        />
       ))}
       {distanceFilterRadiusM != null &&
         distanceFilterRadiusM > 0 &&

--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -705,6 +705,7 @@ export default function MapScreen() {
   const [showBusStops, setShowBusStops] = useState(false);
   const [busStops, setBusStops] = useState<BusStop[]>([]);
   const [selectedBusStop, setSelectedBusStop] = useState<BusStop | null>(null);
+  const [busQueryCenter, setBusQueryCenter] = useState<{ latitude: number; longitude: number } | null>(null);
   const busStopFetchRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastBoundsRef = useRef<{ swLat: number; swLng: number; neLat: number; neLng: number; zoom: number } | null>(null);
 
@@ -1348,8 +1349,11 @@ export default function MapScreen() {
                 onCameraIdle={(params) => {
                   const r = params.region;
                   if (!r || !Number.isFinite(r.latitude) || !Number.isFinite(r.longitude)) return;
-                  const centerLat = r.latitude + r.latitudeDelta / 2;
-                  const centerLng = r.longitude + r.longitudeDelta / 2;
+                  // params.latitude/longitude = 카메라 중심 (탭바 뒤 포함 전체 뷰 기준)
+                  // r.latitude = SW 모서리이나 탭바 영역만큼 남쪽으로 밀려 있어,
+                  // 중심 기준으로 delta 절반씩 잡아 정확한 가시 범위를 계산
+                  const centerLat = Number.isFinite(params.latitude) ? (params.latitude as number) : r.latitude + r.latitudeDelta / 2;
+                  const centerLng = Number.isFinite(params.longitude) ? (params.longitude as number) : r.longitude + r.longitudeDelta / 2;
                   const zoom = params.zoom != null
                     ? Math.round(params.zoom)
                     : 14 - Math.round(Math.log2(r.latitudeDelta / 0.01));
@@ -1366,16 +1370,19 @@ export default function MapScreen() {
                   }, 600);
 
                   // 버스 정류장: 줌 13 이상일 때만 현재 화면 bounds로 조회
+                  // 카메라 중심 기준으로 delta 절반씩 잡아 가시 영역에 정확히 맞춤
                   const currentZoom = params.zoom ?? 14;
-                  const swLat = r.latitude;
-                  const swLng = r.longitude;
-                  const neLat = r.latitude + r.latitudeDelta;
-                  const neLng = r.longitude + r.longitudeDelta;
+                  const busCenter = centerLat + r.latitudeDelta * 0.30;
+                  const swLat = busCenter - r.latitudeDelta / 2;
+                  const swLng = centerLng - r.longitudeDelta / 2;
+                  const neLat = busCenter + r.latitudeDelta / 2;
+                  const neLng = centerLng + r.longitudeDelta / 2;
                   lastBoundsRef.current = { swLat, swLng, neLat, neLng, zoom: currentZoom };
+                  setBusQueryCenter({ latitude: busCenter, longitude: centerLng });
 
                   if (showBusStops) {
                     if (busStopFetchRef.current) clearTimeout(busStopFetchRef.current);
-                    if (currentZoom < 16) {
+                    if (currentZoom < 13) {
                       setBusStops([]);
                     } else {
                       busStopFetchRef.current = setTimeout(() => {
@@ -1394,6 +1401,7 @@ export default function MapScreen() {
                 distanceFilterCenter={distanceFilterCenter}
                 busStops={showBusStops ? busStops : []}
                 onBusStopPress={setSelectedBusStop}
+                busQueryCenter={busQueryCenter}
               />
             </MapErrorBoundary>
           )}
@@ -1528,7 +1536,7 @@ export default function MapScreen() {
                   setBusStops([]);
                 } else {
                   const bounds = lastBoundsRef.current;
-                  if (bounds && bounds.zoom >= 16) {
+                  if (bounds && bounds.zoom >= 13) {
                     getBusStopsInBounds(bounds.swLat, bounds.swLng, bounds.neLat, bounds.neLng)
                       .then(setBusStops)
                       .catch(() => {});

--- a/frontend/services/bus.service.ts
+++ b/frontend/services/bus.service.ts
@@ -5,12 +5,14 @@ export type BusStop = {
   stopName: string;
   latitude: number;
   longitude: number;
+  cityCode?: string;
 };
 
 export type BusArrivalItem = {
   routeId: string;
   routeNo: string;
   destination: string;
+  arrivalSec: number | null;
   arrivalMin: number | null;
   arrivalMessage: string;
   remainingStops: number | null;
@@ -19,6 +21,7 @@ export type BusArrivalItem = {
 export type BusArrivalResponse = {
   stopName: string;
   cityCode: string;
+  cachedAt: number;
   arrivals: BusArrivalItem[];
 };
 


### PR DESCRIPTION
## 개요
버스 정류장 마커 표시, 실시간 도착 정보 바텀시트, 노선-정류장 DB 동기화 기능 추가

## 관련 이슈
- Refs #bus

## 작업 내용
**백엔드**
- [x] `bus_stop_routes` 테이블 추가 (정류장별 경유 노선 매핑 저장)
- [x] 노선 동기화 역방향 매핑으로 전환 (노선 목록 → 경유 정류장 순으로 역방향 구성)
- [x] 동기화 시 종점명(`endNodeName`) 저장
- [x] 미승인 TAGO API(`getRouteBySttn`) 제거, 노선 조회 DB 단독 처리로 전환
- [x] `BusStop`에 `has_routes` 컬럼 추가, bounds 조회 시 노선 없는 정류장 제외
- [x] 도착 정보 응답에 `cachedAt`(ms), `arrivalSec` 필드 추가
- [x] 매일 새벽 3시 충주시 자동 동기화 스케줄러 등록

**프론트엔드**
- [x] 지도에 버스 정류장 마커 표시 (줌/원형 기반 클러스터링)
- [x] 정류장 탭 시 바텀시트: 경유 노선 목록 + 실시간 도착 카운트다운
- [x] `cachedAt` 기반 카운트다운으로 재탭 시 리셋 방지
- [x] 운행 중인 버스 없어도 시간표 기반 노선 목록 표시

## 체크리스트
- [x] 빌드가 에러 없이 수행되는가?
- [x] 불필요한 로그(console.log 등)는 없는가?
