### PR TITLE
버스 정류장 마커 표시, 실시간 도착 정보 바텀시트, 노선-정류장 DB 동기화 기능 추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,7 @@ COPY src ./src
 RUN ./gradlew clean build -x test --no-daemon
 
 # 2단계: 실행 단계
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre-jammy
 
 # 작업 디렉토리
 WORKDIR /app

--- a/backend/src/main/java/com/dailo/backend/dto/BusArrivalResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/BusArrivalResponse.java
@@ -11,6 +11,7 @@ public class BusArrivalResponse {
 
     private String stopName;
     private String cityCode;
+    private Long cachedAt;
     private List<ArrivalItem> arrivals;
 
     @Getter
@@ -19,6 +20,7 @@ public class BusArrivalResponse {
         private String routeId;
         private String routeNo;
         private String destination;
+        private Integer arrivalSec;
         private Integer arrivalMin;
         private String arrivalMessage;
         private Integer remainingStops;

--- a/backend/src/main/java/com/dailo/backend/entity/BusStop.java
+++ b/backend/src/main/java/com/dailo/backend/entity/BusStop.java
@@ -38,6 +38,9 @@ public class BusStop {
     @Column(name = "city_code", length = 10)
     private String cityCode;
 
+    @Column(name = "has_routes")
+    private Boolean hasRoutes;
+
     @UpdateTimestamp
     @Column(name = "synced_at")
     private LocalDateTime syncedAt;

--- a/backend/src/main/java/com/dailo/backend/entity/BusStopRoute.java
+++ b/backend/src/main/java/com/dailo/backend/entity/BusStopRoute.java
@@ -1,0 +1,33 @@
+package com.dailo.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "bus_stop_routes", indexes = {
+        @Index(name = "idx_bus_stop_route_stop_id", columnList = "stop_id")
+}, uniqueConstraints = {
+        @UniqueConstraint(name = "uk_bus_stop_route", columnNames = {"stop_id", "route_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BusStopRoute {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "stop_id", nullable = false, length = 30)
+    private String stopId;
+
+    @Column(name = "route_id", nullable = false, length = 30)
+    private String routeId;
+
+    @Column(name = "route_no", length = 20)
+    private String routeNo;
+
+    @Column(name = "end_node_name", length = 50)
+    private String endNodeName;
+}

--- a/backend/src/main/java/com/dailo/backend/repository/BusStopRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/BusStopRepository.java
@@ -1,8 +1,10 @@
 package com.dailo.backend.repository;
 
 import com.dailo.backend.entity.BusStop;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,7 +21,8 @@ public interface BusStopRepository extends JpaRepository<BusStop, Long> {
 
     @Query("SELECT b FROM BusStop b WHERE " +
             "b.latitude BETWEEN :minLat AND :maxLat AND " +
-            "b.longitude BETWEEN :minLng AND :maxLng")
+            "b.longitude BETWEEN :minLng AND :maxLng AND " +
+            "(b.hasRoutes IS NULL OR b.hasRoutes = true)")
     List<BusStop> findByBounds(
             @Param("minLat") double minLat,
             @Param("maxLat") double maxLat,
@@ -27,4 +30,9 @@ public interface BusStopRepository extends JpaRepository<BusStop, Long> {
             @Param("maxLng") double maxLng,
             Pageable pageable
     );
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE BusStop b SET b.hasRoutes = :hasRoutes WHERE b.stopId = :stopId")
+    void updateHasRoutes(@Param("stopId") String stopId, @Param("hasRoutes") Boolean hasRoutes);
 }

--- a/backend/src/main/java/com/dailo/backend/repository/BusStopRouteRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/BusStopRouteRepository.java
@@ -1,0 +1,22 @@
+package com.dailo.backend.repository;
+
+import com.dailo.backend.entity.BusStopRoute;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BusStopRouteRepository extends JpaRepository<BusStopRoute, Long> {
+
+    List<BusStopRoute> findByStopId(String stopId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM BusStopRoute r WHERE r.stopId IN :stopIds")
+    void deleteByStopIdIn(@Param("stopIds") List<String> stopIds);
+}

--- a/backend/src/main/java/com/dailo/backend/service/AppleLoginService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AppleLoginService.java
@@ -15,10 +15,12 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigInteger;
@@ -37,6 +39,10 @@ public class AppleLoginService {
     private static final String APPLE_ISSUER = "https://appleid.apple.com";
     private static final String DEFAULT_SOCIAL_PASSWORD = "oauth2user";
 
+    // application.yml에서 설정 (없으면 기본값 사용)
+    @Value("${apple.client-id:com.knut.dailo}")
+    private String appleClientId;
+
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
@@ -46,41 +52,65 @@ public class AppleLoginService {
 
     @Transactional
     public TokenDto loginWithApple(AppleLoginRequestDto request) {
-        // 1. identityToken 검증
-        Claims claims = verifyIdentityToken(request.getIdentityToken());
+        log.info("[Apple Login] 로그인 시도 시작");
+        log.debug("[Apple Login] Request - user: {}, email: {}, fullName: {}, identityToken length: {}",
+                request.getUser(),
+                request.getEmail(),
+                request.getFullName(),
+                request.getIdentityToken() != null ? request.getIdentityToken().length() : 0);
 
-        // 2. Apple 사용자 ID (sub claim)
-        String appleUserId = claims.getSubject();
-        if (appleUserId == null || appleUserId.isBlank()) {
-            throw new IllegalArgumentException("Apple 사용자 ID를 가져올 수 없습니다.");
+        try {
+            // 1. identityToken 검증
+            Claims claims = verifyIdentityToken(request.getIdentityToken());
+            log.info("[Apple Login] JWT 검증 성공");
+
+            // 2. Apple 사용자 ID (sub claim)
+            String appleUserId = claims.getSubject();
+            if (appleUserId == null || appleUserId.isBlank()) {
+                log.error("[Apple Login] Apple 사용자 ID(sub)가 없습니다. claims: {}", claims);
+                throw new IllegalArgumentException("Apple 사용자 ID를 가져올 수 없습니다.");
+            }
+            log.info("[Apple Login] Apple User ID: {}", appleUserId.substring(0, Math.min(10, appleUserId.length())) + "...");
+
+            // 3. 이메일 추출 (JWT claims 또는 request에서)
+            String email = claims.get("email", String.class);
+            if ((email == null || email.isBlank()) && request.getEmail() != null) {
+                email = request.getEmail();
+            }
+            log.info("[Apple Login] 이메일: {}", email != null ? email : "(없음 - 대체 이메일 생성 예정)");
+
+            // 4. 회원 조회 또는 생성
+            Member member = findOrCreateAppleMember(appleUserId, email, request.getFullName());
+            Member savedMember = memberRepository.save(member);
+            log.info("[Apple Login] 회원 저장 완료 - Member ID: {}", savedMember.getId());
+
+            // 5. JWT 토큰 발급
+            TokenDto tokenDto = tokenProvider.generateTokenDtoForMember(
+                    savedMember.getEmail(),
+                    savedMember.getRole() != null ? savedMember.getRole().name() : Role.USER.name()
+            );
+            log.info("[Apple Login] JWT 토큰 발급 완료");
+
+            // 6. Refresh Token 저장
+            RefreshToken refreshToken = RefreshToken.builder()
+                    .keyId(savedMember.getEmail())
+                    .value(tokenDto.getRefreshToken())
+                    .build();
+            refreshTokenRepository.save(refreshToken);
+            log.info("[Apple Login] Refresh Token 저장 완료");
+
+            log.info("[Apple Login] 로그인 성공 - Member ID: {}, email: {}", savedMember.getId(), savedMember.getEmail());
+            return tokenDto;
+
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            // 이미 적절한 메시지가 있는 예외는 그대로 던짐
+            log.warn("[Apple Login] 로그인 실패 - {}", e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            // 예상치 못한 예외
+            log.error("[Apple Login] 예상치 못한 오류 발생", e);
+            throw new IllegalStateException("Apple 로그인 처리 중 오류가 발생했습니다: " + e.getMessage());
         }
-
-        // 3. 이메일 추출 (JWT claims 또는 request에서)
-        String email = claims.get("email", String.class);
-        if ((email == null || email.isBlank()) && request.getEmail() != null) {
-            email = request.getEmail();
-        }
-
-        // 4. 회원 조회 또는 생성
-        Member member = findOrCreateAppleMember(appleUserId, email, request.getFullName());
-        Member savedMember = memberRepository.save(member);
-
-        log.info("Apple 로그인 성공 - Member ID: {}", savedMember.getId());
-
-        // 5. JWT 토큰 발급
-        TokenDto tokenDto = tokenProvider.generateTokenDtoForMember(
-                savedMember.getEmail(),
-                savedMember.getRole() != null ? savedMember.getRole().name() : Role.USER.name()
-        );
-
-        // 6. Refresh Token 저장
-        RefreshToken refreshToken = RefreshToken.builder()
-                .keyId(savedMember.getEmail())
-                .value(tokenDto.getRefreshToken())
-                .build();
-        refreshTokenRepository.save(refreshToken);
-
-        return tokenDto;
     }
 
     /**
@@ -89,6 +119,7 @@ public class AppleLoginService {
      */
     private Claims verifyIdentityToken(String identityToken) {
         if (identityToken == null || identityToken.isBlank()) {
+            log.error("[Apple JWT] identityToken이 null 또는 빈 문자열");
             throw new IllegalArgumentException("Apple identityToken이 없습니다.");
         }
 
@@ -96,34 +127,71 @@ public class AppleLoginService {
             // JWT 헤더에서 kid 추출
             String[] parts = identityToken.split("\\.");
             if (parts.length != 3) {
+                log.error("[Apple JWT] 잘못된 JWT 형식 - parts: {}", parts.length);
                 throw new IllegalArgumentException("잘못된 JWT 형식입니다.");
             }
 
             String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
+            log.debug("[Apple JWT] Header: {}", headerJson);
+
             JsonNode header = objectMapper.readTree(headerJson);
             String kid = header.get("kid").asText();
             String alg = header.get("alg").asText();
+            log.info("[Apple JWT] kid: {}, alg: {}", kid, alg);
+
+            // Payload 미리 확인 (디버깅용)
+            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+            JsonNode payload = objectMapper.readTree(payloadJson);
+            log.debug("[Apple JWT] Payload: {}", payloadJson);
+            log.info("[Apple JWT] iss: {}, aud: {}, sub: {}",
+                    payload.has("iss") ? payload.get("iss").asText() : "N/A",
+                    payload.has("aud") ? payload.get("aud").asText() : "N/A",
+                    payload.has("sub") ? payload.get("sub").asText().substring(0, 10) + "..." : "N/A");
 
             // Apple 공개키 가져오기
             PublicKey publicKey = getApplePublicKey(kid, alg);
+            log.info("[Apple JWT] 공개키 조회 성공");
 
             // JWT 검증 및 Claims 추출
-            return Jwts.parserBuilder()
+            Claims claims = Jwts.parserBuilder()
                     .setSigningKey(publicKey)
                     .requireIssuer(APPLE_ISSUER)
+                    .requireAudience(appleClientId)  // Bundle ID 검증 추가!
                     .build()
                     .parseClaimsJws(identityToken)
                     .getBody();
 
+            log.info("[Apple JWT] JWT 검증 성공 - sub: {}", claims.getSubject().substring(0, 10) + "...");
+            return claims;
+
         } catch (io.jsonwebtoken.ExpiredJwtException e) {
-            log.warn("Apple identityToken 만료됨");
+            log.warn("[Apple JWT] 토큰 만료됨 - expiration: {}", e.getClaims().getExpiration());
             throw new IllegalArgumentException("Apple 로그인 토큰이 만료되었습니다. 다시 로그인해주세요.");
+        } catch (io.jsonwebtoken.IncorrectClaimException e) {
+            log.error("[Apple JWT] Claim 불일치 - {}", e.getMessage());
+            if (e.getMessage().contains("aud")) {
+                throw new IllegalArgumentException("Apple 토큰의 앱 ID가 일치하지 않습니다. (aud mismatch)");
+            }
+            if (e.getMessage().contains("iss")) {
+                throw new IllegalArgumentException("Apple 토큰의 발급자가 올바르지 않습니다. (iss mismatch)");
+            }
+            throw new IllegalArgumentException("Apple 토큰 검증 실패: " + e.getMessage());
+        } catch (io.jsonwebtoken.MalformedJwtException e) {
+            log.error("[Apple JWT] 잘못된 JWT 형식 - {}", e.getMessage());
+            throw new IllegalArgumentException("Apple 토큰 형식이 올바르지 않습니다.");
+        } catch (io.jsonwebtoken.SignatureException e) {
+            log.error("[Apple JWT] 서명 검증 실패 - {}", e.getMessage());
+            throw new IllegalArgumentException("Apple 토큰 서명이 유효하지 않습니다.");
         } catch (io.jsonwebtoken.JwtException e) {
-            log.warn("Apple identityToken 검증 실패: {}", e.getMessage());
-            throw new IllegalArgumentException("Apple 로그인 토큰이 유효하지 않습니다.");
+            log.warn("[Apple JWT] JWT 검증 실패: {}", e.getMessage());
+            throw new IllegalArgumentException("Apple 로그인 토큰이 유효하지 않습니다: " + e.getMessage());
+        } catch (IllegalArgumentException e) {
+            // Base64 디코딩 실패 등
+            log.error("[Apple JWT] 토큰 파싱 오류 - {}", e.getMessage());
+            throw new IllegalArgumentException("Apple 토큰을 파싱할 수 없습니다: " + e.getMessage());
         } catch (Exception e) {
-            log.error("Apple identityToken 검증 중 오류", e);
-            throw new IllegalStateException("Apple 로그인 처리 중 오류가 발생했습니다.");
+            log.error("[Apple JWT] 검증 중 예상치 못한 오류", e);
+            throw new IllegalStateException("Apple 토큰 검증 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
@@ -133,21 +201,45 @@ public class AppleLoginService {
      */
     private PublicKey getApplePublicKey(String kid, String alg) {
         try {
+            log.debug("[Apple Key] Apple 공개키 조회 시작 - URL: {}", APPLE_PUBLIC_KEYS_URL);
             ResponseEntity<String> response = restTemplate.getForEntity(APPLE_PUBLIC_KEYS_URL, String.class);
+
+            if (response.getBody() == null) {
+                log.error("[Apple Key] Apple 공개키 응답이 비어있음");
+                throw new IllegalStateException("Apple 서버에서 공개키를 받지 못했습니다.");
+            }
+
+            log.debug("[Apple Key] Apple 응답: {}", response.getBody().substring(0, Math.min(200, response.getBody().length())) + "...");
+
             JsonNode keys = objectMapper.readTree(response.getBody()).get("keys");
+            if (keys == null || !keys.isArray()) {
+                log.error("[Apple Key] keys 배열이 없음");
+                throw new IllegalStateException("Apple 공개키 형식이 올바르지 않습니다.");
+            }
 
             for (JsonNode key : keys) {
-                if (kid.equals(key.get("kid").asText()) && alg.equals(key.get("alg").asText())) {
+                String keyKid = key.has("kid") ? key.get("kid").asText() : "";
+                String keyAlg = key.has("alg") ? key.get("alg").asText() : "";
+
+                if (kid.equals(keyKid) && alg.equals(keyAlg)) {
                     String n = key.get("n").asText();
                     String e = key.get("e").asText();
+                    log.info("[Apple Key] 일치하는 키 발견 - kid: {}", kid);
                     return createRSAPublicKey(n, e);
                 }
             }
 
-            throw new IllegalStateException("일치하는 Apple 공개키를 찾을 수 없습니다.");
-        } catch (Exception ex) {
-            log.error("Apple 공개키 조회 실패", ex);
-            throw new IllegalStateException("Apple 서버와 통신 중 오류가 발생했습니다.");
+            log.error("[Apple Key] 일치하는 키를 찾을 수 없음 - 요청 kid: {}, alg: {}", kid, alg);
+            throw new IllegalStateException("일치하는 Apple 공개키를 찾을 수 없습니다. (kid: " + kid + ")");
+
+        } catch (RestClientException e) {
+            log.error("[Apple Key] Apple 서버 통신 실패", e);
+            throw new IllegalStateException("Apple 서버와 통신할 수 없습니다. 잠시 후 다시 시도해주세요.");
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[Apple Key] 공개키 조회 중 오류", e);
+            throw new IllegalStateException("Apple 공개키 조회 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
@@ -176,24 +268,26 @@ public class AppleLoginService {
 
         if (memberOptional.isPresent()) {
             Member existingMember = memberOptional.get();
-            log.info("기존 Apple 회원 로그인 처리 - Member ID: {}", existingMember.getId());
+            log.info("[Apple Member] 기존 회원 로그인 - Member ID: {}", existingMember.getId());
             return existingMember;
         }
 
         // 신규 회원 생성
-        log.info("신규 Apple 회원 가입 진행");
+        log.info("[Apple Member] 신규 회원 가입 시작");
 
         // 이메일 처리: 숨김 선택 시 프라이빗 릴레이 이메일 또는 대체 이메일 생성
         String resolvedEmail = resolveEmail(email, appleUserId);
+        log.info("[Apple Member] 해결된 이메일: {}", resolvedEmail);
 
         // 이메일 중복 체크
         if (memberRepository.existsByEmail(resolvedEmail)) {
-            log.warn("이메일 중복으로 Apple 회원가입 실패 - email: {}", resolvedEmail);
+            log.warn("[Apple Member] 이메일 중복 - email: {}", resolvedEmail);
             throw new IllegalStateException("이미 동일한 이메일로 가입된 계정이 존재합니다. 기존 방식으로 로그인해주세요.");
         }
 
         // 닉네임 처리
         String nickname = resolveNickname(fullName);
+        log.info("[Apple Member] 닉네임: {}", nickname);
 
         return Member.builder()
                 .email(resolvedEmail)

--- a/backend/src/main/java/com/dailo/backend/service/BusApiService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BusApiService.java
@@ -92,6 +92,7 @@ public class BusApiService {
                 .routeId(item.path("routeid").asText(""))
                 .routeNo(item.path("routeno").asText(""))
                 .destination(item.path("nodenm").asText("")) // 현재 버스 위치 정류장명 (행선지 방면 표시용)
+                .arrivalSec(arrivalSec >= 0 ? arrivalSec : null)
                 .arrivalMin(arrivalMin)
                 .arrivalMessage(arrivalMessage)
                 .remainingStops(remainingStops >= 0 ? remainingStops : null)
@@ -99,41 +100,52 @@ public class BusApiService {
     }
 
     /**
-     * 정류장 경유 노선 목록 조회
-     * BusRouteInfoInqireService/getRouteBySttn
+     * 도시 전체 노선 목록 조회 (routeId + routeNo)
+     * BusRouteInfoInqireService/getRouteNoList
      */
-    public List<BusRouteInfoResponse> getRoutesByStop(String cityCode, String stopId) {
-        URI uri = UriComponentsBuilder
-                .fromHttpUrl(baseUrl + "/BusRouteInfoInqireService/getRouteBySttn")
-                .queryParam("serviceKey", apiKey)
-                .queryParam("cityCode", cityCode)
-                .queryParam("nodeId", stopId)
-                .queryParam("numOfRows", 30)
-                .queryParam("pageNo", 1)
-                .queryParam("_type", "json")
-                .build(true)
-                .toUri();
-
+    public List<BusRouteInfoResponse> getRoutes(String cityCode) {
         List<BusRouteInfoResponse> result = new ArrayList<>();
-        try {
-            String response = restTemplate.getForObject(uri, String.class);
-            JsonNode items = objectMapper.readTree(response)
-                    .path("response").path("body").path("items").path("item");
+        int page = 1;
+        final int perPage = 100;
 
-            if (items.isMissingNode() || items.isNull()) return result;
+        while (true) {
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(baseUrl + "/BusRouteInfoInqireService/getRouteNoList")
+                    .queryParam("serviceKey", apiKey)
+                    .queryParam("cityCode", cityCode)
+                    .queryParam("numOfRows", perPage)
+                    .queryParam("pageNo", page)
+                    .queryParam("_type", "json")
+                    .build(true).toUri();
 
-            Iterable<JsonNode> rows = items.isArray() ? items : List.of(items);
-            for (JsonNode item : rows) {
-                result.add(BusRouteInfoResponse.builder()
-                        .routeId(item.path("routeid").asText(""))
-                        .routeNo(item.path("routeno").asText(""))
+            try {
+                String response = restTemplate.getForObject(uri, String.class);
+                JsonNode body = objectMapper.readTree(response).path("response").path("body");
+                JsonNode items = body.path("items").path("item");
 
-                        .endNodeName(item.path("endnodenm").asText(""))
-                        .build());
+                if (items.isMissingNode() || items.isNull()) break;
+
+                Iterable<JsonNode> rows = items.isArray() ? items : List.of(items);
+                for (JsonNode item : rows) {
+                    String routeId = item.path("routeid").asText("");
+                    if (!routeId.isEmpty()) {
+                        result.add(BusRouteInfoResponse.builder()
+                                .routeId(routeId)
+                                .routeNo(item.path("routeno").asText(""))
+                                .endNodeName(item.path("endnodenm").asText(""))
+                                .build());
+                    }
+                }
+
+                int totalCount = body.path("totalCount").asInt(0);
+                if ((long) page * perPage >= totalCount) break;
+                page++;
+            } catch (Exception e) {
+                log.error("노선 목록 조회 실패 - cityCode: {}, error: {}", cityCode, e.getMessage());
+                break;
             }
-        } catch (Exception e) {
-            log.error("정류장 경유 노선 조회 실패 - stopId: {}, error: {}", stopId, e.getMessage());
         }
+
         return result;
     }
 

--- a/backend/src/main/java/com/dailo/backend/service/BusService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BusService.java
@@ -7,6 +7,7 @@ import com.dailo.backend.dto.BusRouteStopResponse;
 import com.dailo.backend.dto.BusStopResponse;
 import com.dailo.backend.entity.BusStop;
 import com.dailo.backend.repository.BusStopRepository;
+import com.dailo.backend.repository.BusStopRouteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
@@ -15,7 +16,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,6 +27,7 @@ public class BusService {
     private static final String DEFAULT_CITY_CODE = "33020";
 
     private final BusStopRepository busStopRepository;
+    private final BusStopRouteRepository busStopRouteRepository;
     private final BusApiService busApiService;
 
     // @Cacheable 메서드 간 호출 시 프록시를 통해야 캐시가 동작하므로 자기주입 사용
@@ -52,7 +53,7 @@ public class BusService {
      * 지도 bounds 내 정류장 조회
      */
     public List<BusStopResponse> getStopsInBounds(double swLat, double swLng, double neLat, double neLng) {
-        return busStopRepository.findByBounds(swLat, neLat, swLng, neLng, PageRequest.of(0, 15))
+        return busStopRepository.findByBounds(swLat, neLat, swLng, neLng, PageRequest.of(0, 200))
                 .stream().map(BusStopResponse::from).collect(Collectors.toList());
     }
 
@@ -74,6 +75,7 @@ public class BusService {
         return BusArrivalResponse.builder()
                 .stopName(stop.getStopName())
                 .cityCode(cityCode)
+                .cachedAt(System.currentTimeMillis())
                 .arrivals(corrected)
                 .build();
     }
@@ -108,6 +110,7 @@ public class BusService {
                     .routeId(item.getRouteId())
                     .routeNo(item.getRouteNo())
                     .destination(item.getDestination())
+                    .arrivalSec(item.getArrivalSec())
                     .arrivalMin(item.getArrivalMin())
                     .arrivalMessage(item.getArrivalMessage())
                     .remainingStops(currentNodeOrder - closestNodeOrder)
@@ -118,13 +121,16 @@ public class BusService {
     }
 
     /**
-     * 정류장 경유 노선 목록 조회
+     * 정류장 경유 노선 목록 조회 (DB)
      */
     public List<BusRouteInfoResponse> getRoutesByStop(String stopId) {
-        BusStop stop = busStopRepository.findByStopId(stopId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "STOP_NOT_FOUND"));
-        String cityCode = stop.getCityCode() != null ? stop.getCityCode() : DEFAULT_CITY_CODE;
-        return busApiService.getRoutesByStop(cityCode, stopId);
+        return busStopRouteRepository.findByStopId(stopId).stream()
+                .map(r -> BusRouteInfoResponse.builder()
+                        .routeId(r.getRouteId())
+                        .routeNo(r.getRouteNo())
+                        .endNodeName(r.getEndNodeName() != null ? r.getEndNodeName() : "")
+                        .build())
+                .collect(Collectors.toList());
     }
 
     /**

--- a/backend/src/main/java/com/dailo/backend/service/BusStopSyncService.java
+++ b/backend/src/main/java/com/dailo/backend/service/BusStopSyncService.java
@@ -1,7 +1,11 @@
 package com.dailo.backend.service;
 
+import com.dailo.backend.dto.BusRouteInfoResponse;
+import com.dailo.backend.dto.BusRouteStopResponse;
 import com.dailo.backend.entity.BusStop;
+import com.dailo.backend.entity.BusStopRoute;
 import com.dailo.backend.repository.BusStopRepository;
+import com.dailo.backend.repository.BusStopRouteRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +20,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -31,10 +37,67 @@ public class BusStopSyncService {
     private String baseUrl;
 
     private final BusStopRepository busStopRepository;
+    private final BusStopRouteRepository busStopRouteRepository;
+    private final BusApiService busApiService;
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
     private static final int PER_PAGE = 100;
+
+    /**
+     * 노선 목록 → 경유 정류장 역방향으로 (stopId → List<route>) 매핑 구성 후 DB 저장
+     * 동시에 노선 보유 정류장 ID Set 반환
+     */
+    private Set<String> buildAndSaveRouteMapping(String cityCode) {
+        List<BusRouteInfoResponse> routes = busApiService.getRoutes(cityCode);
+        log.info("노선 수: {}개 - cityCode: {}", routes.size(), cityCode);
+
+        // (stopId, routeId) 중복 방지용 Set + stopId → list of BusStopRoute
+        Map<String, List<BusStopRoute>> stopRouteMap = new HashMap<>();
+        Set<String> seen = new HashSet<>(); // "stopId:routeId"
+
+        for (BusRouteInfoResponse route : routes) {
+            try {
+                List<BusRouteStopResponse> stops = busApiService.getRouteStops(cityCode, route.getRouteId());
+                for (BusRouteStopResponse stop : stops) {
+                    String stopId = stop.getNodeId();
+                    if (stopId == null || stopId.isEmpty()) continue;
+                    String key = stopId + ":" + route.getRouteId();
+                    if (!seen.add(key)) continue; // 이미 추가된 조합은 건너뜀
+                    stopRouteMap.computeIfAbsent(stopId, k -> new ArrayList<>())
+                            .add(BusStopRoute.builder()
+                                    .stopId(stopId)
+                                    .routeId(route.getRouteId())
+                                    .routeNo(route.getRouteNo())
+                                    .endNodeName(route.getEndNodeName())
+                                    .build());
+                }
+            } catch (Exception e) {
+                log.warn("노선 경유 정류장 조회 실패 - routeId: {}", route.getRouteId());
+            }
+        }
+
+        Set<String> stopsWithRoutes = stopRouteMap.keySet();
+        log.info("노선 보유 정류장 수: {}개", stopsWithRoutes.size());
+
+        // 기존 데이터 삭제 후 새로 저장 (배치)
+        List<String> stopIds = new ArrayList<>(stopsWithRoutes);
+        for (int i = 0; i < stopIds.size(); i += 500) {
+            List<String> batch = stopIds.subList(i, Math.min(i + 500, stopIds.size()));
+            busStopRouteRepository.deleteByStopIdIn(batch);
+        }
+
+        List<BusStopRoute> allRoutes = new ArrayList<>();
+        for (List<BusStopRoute> routeList : stopRouteMap.values()) {
+            allRoutes.addAll(routeList);
+        }
+        for (int i = 0; i < allRoutes.size(); i += 500) {
+            busStopRouteRepository.saveAll(allRoutes.subList(i, Math.min(i + 500, allRoutes.size())));
+        }
+
+        log.info("노선-정류장 매핑 저장 완료: {}건", allRoutes.size());
+        return new HashSet<>(stopsWithRoutes);
+    }
 
     /**
      * TAGO BusSttnInfoInqireService → 전체 도시코드 목록 조회
@@ -68,6 +131,9 @@ public class BusStopSyncService {
      */
     @Async
     public void syncByCity(String cityCode, String cityName) {
+        log.info("노선 보유 정류장 목록 구성 시작 - {}", cityName);
+        Set<String> stopsWithRoutes = buildAndSaveRouteMapping(cityCode);
+
         int page = 1;
         int totalSaved = 0;
 
@@ -93,7 +159,15 @@ public class BusStopSyncService {
 
                 for (JsonNode item : rows) {
                     String stopId = item.path("nodeid").asText();
-                    if (busStopRepository.existsByStopId(stopId)) continue;
+                    boolean hasRoutes = stopsWithRoutes.contains(stopId);
+                    boolean exists = busStopRepository.existsByStopId(stopId);
+
+                    if (exists) {
+                        busStopRepository.updateHasRoutes(stopId, hasRoutes);
+                        continue;
+                    }
+
+                    if (!hasRoutes) continue;
 
                     try {
                         toSave.add(BusStop.builder()
@@ -103,6 +177,7 @@ public class BusStopSyncService {
                                 .longitude(item.path("gpslong").asDouble())
                                 .regionName(cityName)
                                 .cityCode(cityCode)
+                                .hasRoutes(true)
                                 .build());
                     } catch (Exception e) {
                         log.warn("정류장 파싱 실패 - stopId: {}", stopId);

--- a/backend/src/test/java/com/dailo/backend/integration/BusApiTest.java
+++ b/backend/src/test/java/com/dailo/backend/integration/BusApiTest.java
@@ -2,10 +2,11 @@ package com.dailo.backend.integration;
 
 import com.dailo.backend.dto.BusArrivalResponse;
 import com.dailo.backend.dto.BusLocationResponse;
-import com.dailo.backend.dto.BusRouteInfoResponse;
 import com.dailo.backend.dto.BusRouteStopResponse;
 import com.dailo.backend.entity.BusStop;
+import com.dailo.backend.entity.BusStopRoute;
 import com.dailo.backend.repository.BusStopRepository;
+import com.dailo.backend.repository.BusStopRouteRepository;
 import com.dailo.backend.service.BusApiService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +39,9 @@ class BusApiTest {
 
     @Autowired
     private BusStopRepository busStopRepository;
+
+    @Autowired
+    private BusStopRouteRepository busStopRouteRepository;
 
     @MockBean
     private BusApiService busApiService;
@@ -185,12 +189,9 @@ class BusApiTest {
     @Test
     @DisplayName("GET /stops/{stopId}/routes - 경유 노선 목록 반환")
     void getRoutesByStop_returnsRoutes() throws Exception {
-        given(busApiService.getRoutesByStop(anyString(), anyString()))
-                .willReturn(List.of(
-                        BusRouteInfoResponse.builder()
-                                .routeId(ROUTE_ID).routeNo("100").endNodeName("종점")
-                                .build()
-                ));
+        busStopRouteRepository.save(BusStopRoute.builder()
+                .stopId(STOP_ID).routeId(ROUTE_ID).routeNo("100").endNodeName("종점")
+                .build());
 
         mockMvc.perform(get("/api/bus/stops/{stopId}/routes", STOP_ID))
                 .andExpect(status().isOk())
@@ -201,10 +202,11 @@ class BusApiTest {
     }
 
     @Test
-    @DisplayName("GET /stops/{stopId}/routes - 존재하지 않는 정류장이면 404")
-    void getRoutesByStop_unknownStop_returns404() throws Exception {
+    @DisplayName("GET /stops/{stopId}/routes - 노선 없는 정류장이면 빈 배열")
+    void getRoutesByStop_unknownStop_returnsEmpty() throws Exception {
         mockMvc.perform(get("/api/bus/stops/{stopId}/routes", "INVALID"))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
     }
 
     @Test

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "다일로",
     "slug": "app",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "app",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.knut.dailo",
-      "buildNumber": "7",
+      "buildNumber": "8",
       "usesAppleSignIn": true,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "다일로",
     "slug": "app",
-    "version": "3.0.0",
+    "version": "4.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "app",
@@ -11,6 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.knut.dailo",
+      "buildNumber": "7",
       "usesAppleSignIn": true,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,

--- a/frontend/app/(tabs)/map/_components/BusStopBottomSheet.tsx
+++ b/frontend/app/(tabs)/map/_components/BusStopBottomSheet.tsx
@@ -31,6 +31,7 @@ type MergedItem = {
   routeNo: string;
   endNodeName: string; // 종점 (노선 기본 정보)
   destination: string | null; // 도착 정보의 행선지
+  arrivalSec: number | null;
   arrivalMin: number | null;
   arrivalMessage: string | null;
   remainingStops: number | null;
@@ -50,6 +51,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState(false);
+  const [cachedAt, setCachedAt] = useState<number | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [tick, setTick] = useState(0);
   const [cooldown, setCooldown] = useState(0);
@@ -118,7 +120,11 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
 
         if (arrivalsRes) {
           setStopName(arrivalsRes.stopName);
-          setCityCode(arrivalsRes.cityCode);
+          setCityCode(arrivalsRes.cityCode || stop?.cityCode || '');
+          setCachedAt(arrivalsRes.cachedAt ?? Date.now());
+        } else {
+          setCityCode(stop?.cityCode || '');
+          setCachedAt(Date.now());
         }
 
         const arrivals = arrivalsRes?.arrivals ?? [];
@@ -138,6 +144,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
             routeNo: route.routeNo,
             endNodeName: route.endNodeName,
             destination: arrival?.destination ?? null,
+            arrivalSec: arrival?.arrivalSec ?? null,
             arrivalMin: arrival?.arrivalMin ?? null,
             arrivalMessage: arrival?.arrivalMessage ?? null,
             remainingStops: arrival?.remainingStops ?? null,
@@ -151,6 +158,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
             routeNo: a.routeNo,
             endNodeName: a.destination ?? "",
             destination: a.destination,
+            arrivalSec: a.arrivalSec,
             arrivalMin: a.arrivalMin,
             arrivalMessage: a.arrivalMessage,
             remainingStops: a.remainingStops,
@@ -175,7 +183,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
         stopSpin();
       }
     },
-    [startSpin, stopSpin, startCooldown, cooldown],
+    [startSpin, stopSpin, startCooldown, cooldown, stop],
   );
 
   useEffect(() => {
@@ -183,14 +191,19 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
     fetchData(stop.stopId);
   }, [stop?.stopId]);
 
-  const getCountdown = (arrivalMin: number | null, arrivalMessage: string | null) => {
-    if (arrivalMin == null || !lastUpdated) return arrivalMessage;
-    const elapsedSec = Math.floor((Date.now() - lastUpdated.getTime()) / 1000);
-    const remainingSec = arrivalMin * 60 - elapsedSec;
+  const getCountdown = (arrivalSec: number | null, arrivalMessage: string | null) => {
+    if (arrivalSec == null || !cachedAt) return arrivalMessage;
+    const elapsedSec = Math.floor((Date.now() - cachedAt) / 1000);
+    const remainingSec = arrivalSec - elapsedSec;
     if (remainingSec <= 0) return "곧 도착";
     const min = Math.floor(remainingSec / 60);
     const sec = remainingSec % 60;
     if (min === 0) return `${sec}초 후 도착`;
+    if (min >= 60) {
+      const hour = Math.floor(min / 60);
+      const remMin = min % 60;
+      return remMin > 0 ? `${hour}시간 ${remMin}분 후 도착` : `${hour}시간 후 도착`;
+    }
     return `${min}분 ${sec < 10 ? `0${sec}` : sec}초 후 도착`;
   };
 
@@ -266,7 +279,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
           </View>
         ) : items.length === 0 ? (
           <View style={styles.center}>
-            <Text style={styles.emptyText}>운행중인 버스가 없습니다.</Text>
+            <Text style={styles.emptyText}>이 정류장의 노선 정보가 없습니다.</Text>
           </View>
         ) : (
           <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
@@ -309,7 +322,7 @@ export function BusStopBottomSheet({ stop, onClose }: Props) {
                           styles.arrivalTimeSoon,
                       ]}
                     >
-                      {getCountdown(item.arrivalMin, item.arrivalMessage)}
+                      {getCountdown(item.arrivalSec, item.arrivalMessage)}
                     </Text>
                   ) : (
                     <Text style={styles.noArrival}>운행 정보 없음</Text>

--- a/frontend/app/(tabs)/map/_components/NaverMap.tsx
+++ b/frontend/app/(tabs)/map/_components/NaverMap.tsx
@@ -60,7 +60,7 @@ type Props = {
   events: Event[];
   onMarkerPress: (event: Event) => void;
   /** 카메라 이동이 끝났을 때(드래그/줌 후) 호출. region 동기화용 (latitude/longitude는 남서쪽, center 아님) */
-  onCameraIdle?: (params: { region: { latitude: number; longitude: number; latitudeDelta: number; longitudeDelta: number }; zoom?: number }) => void;
+  onCameraIdle?: (params: { latitude?: number; longitude?: number; zoom?: number; region: { latitude: number; longitude: number; latitudeDelta: number; longitudeDelta: number } }) => void;
   /** 현재 위치 버튼을 눌렀을 때 표시할 파란 동그라미 위치 */
   currentLocation?: { latitude: number; longitude: number } | null;
   /** 동그라미 표시용 좌표(실제 위치 못 받을 때 fallback 등). 있으면 이걸 우선 사용 */
@@ -77,6 +77,8 @@ type Props = {
   busStops?: BusStop[];
   /** 버스 정류장 마커 탭 콜백 */
   onBusStopPress?: (stop: BusStop) => void;
+  /** 버스 정류장 쿼리 중심 (원형 필터 기준점) */
+  busQueryCenter?: { latitude: number; longitude: number } | null;
 };
 
 // 현재 위치 점: 화면 상에서 항상 일정한 크기의 점으로 표시 (줌 레벨과 무관)
@@ -117,8 +119,47 @@ const DISTANCE_FILTER_CIRCLE_COLOR = 'rgba(59, 130, 246, 0.15)';
 const DISTANCE_FILTER_CIRCLE_OUTLINE_WIDTH = 2;
 const DISTANCE_FILTER_CIRCLE_OUTLINE_COLOR = 'rgba(59, 130, 246, 0.5)';
 
+const CLUSTER_CELL_SIZES = [0.001, 0.002, 0.003, 0.005, 0.007, 0.01, 0.015, 0.02, 0.03, 0.05, 0.1];
+const CLUSTER_TARGET = 15;
+
+function clusterBusStops(stops: BusStop[], zoom: number, centerLat: number, centerLng: number): BusStop[] {
+  if (stops.length === 0) return stops;
+
+  // 원형 필터: 직사각형 bounds 모서리 제거
+  const cosLat = Math.cos(centerLat * Math.PI / 180);
+  const radiusDeg = 0.05 * Math.pow(2, Math.max(0, 14 - zoom));
+  const circular = stops.filter(s => {
+    const dLat = s.latitude - centerLat;
+    const dLng = (s.longitude - centerLng) * cosLat;
+    return dLat * dLat + dLng * dLng <= radiusDeg * radiusDeg;
+  });
+  const candidates = circular.length >= 5 ? circular : stops;
+
+  if (zoom >= 16 || candidates.length <= CLUSTER_TARGET) return candidates;
+
+  // 각 셀에서 셀 중심에 가장 가까운 정류장을 대표로 선택 (DB 정렬 순서 의존 제거)
+  for (const cellSize of CLUSTER_CELL_SIZES) {
+    const cells = new Map<string, { stop: BusStop; dist: number }>();
+    for (const stop of candidates) {
+      const row = Math.floor(stop.latitude / cellSize);
+      const col = Math.floor(stop.longitude / cellSize);
+      const key = `${row}_${col}`;
+      const cellCenterLat = (row + 0.5) * cellSize;
+      const cellCenterLng = (col + 0.5) * cellSize;
+      const dist = Math.hypot(stop.latitude - cellCenterLat, stop.longitude - cellCenterLng);
+      const existing = cells.get(key);
+      if (!existing || dist < existing.dist) cells.set(key, { stop, dist });
+    }
+    if (cells.size <= CLUSTER_TARGET) {
+      return Array.from(cells.values()).map(v => v.stop);
+    }
+  }
+
+  return candidates.slice(0, CLUSTER_TARGET);
+}
+
 export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
-  { style, camera, events, onMarkerPress, onCameraIdle, currentLocation, circleCoords, showMyLocationCircle, selectedEvent, distanceFilterRadiusM, distanceFilterCenter, busStops, onBusStopPress },
+  { style, camera, events, onMarkerPress, onCameraIdle, currentLocation, circleCoords, showMyLocationCircle, selectedEvent, distanceFilterRadiusM, distanceFilterCenter, busStops, onBusStopPress, busQueryCenter },
   ref
 ) {
   const myLocationCoords = circleCoords ?? currentLocation ?? null;
@@ -145,6 +186,12 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
       ),
     [events]
   );
+
+  const clusteredBusStops = useMemo(() => {
+    const filterLat = busQueryCenter?.latitude ?? effectiveCamera.latitude;
+    const filterLng = busQueryCenter?.longitude ?? effectiveCamera.longitude;
+    return clusterBusStops(busStops ?? [], effectiveCamera.zoom, filterLat, filterLng);
+  }, [busStops, effectiveCamera.zoom, effectiveCamera.latitude, effectiveCamera.longitude, busQueryCenter]);
 
   return (
     <NaverMapView
@@ -271,7 +318,7 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
             />
           </NaverMapMarkerOverlay>
         )}
-      {busStops?.map((stop) => (
+      {clusteredBusStops.map((stop) => (
         <NaverMapMarkerOverlay
           key={`bus-stop-${stop.stopId}`}
           latitude={stop.latitude}
@@ -279,16 +326,10 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
           width={BUS_STOP_SIZE}
           height={BUS_STOP_SIZE}
           anchor={{ x: 0.5, y: 0.5 }}
+          image={BUS_STOP_MARKER}
           onTap={() => onBusStopPress?.(stop)}
           globalZIndex={180000}
-          isHideCollidedMarkers
-        >
-          <Image
-            source={BUS_STOP_MARKER}
-            style={{ width: BUS_STOP_SIZE, height: BUS_STOP_SIZE }}
-            resizeMode="contain"
-          />
-        </NaverMapMarkerOverlay>
+        />
       ))}
       {distanceFilterRadiusM != null &&
         distanceFilterRadiusM > 0 &&

--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -705,6 +705,7 @@ export default function MapScreen() {
   const [showBusStops, setShowBusStops] = useState(false);
   const [busStops, setBusStops] = useState<BusStop[]>([]);
   const [selectedBusStop, setSelectedBusStop] = useState<BusStop | null>(null);
+  const [busQueryCenter, setBusQueryCenter] = useState<{ latitude: number; longitude: number } | null>(null);
   const busStopFetchRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastBoundsRef = useRef<{ swLat: number; swLng: number; neLat: number; neLng: number; zoom: number } | null>(null);
 
@@ -1348,8 +1349,11 @@ export default function MapScreen() {
                 onCameraIdle={(params) => {
                   const r = params.region;
                   if (!r || !Number.isFinite(r.latitude) || !Number.isFinite(r.longitude)) return;
-                  const centerLat = r.latitude + r.latitudeDelta / 2;
-                  const centerLng = r.longitude + r.longitudeDelta / 2;
+                  // params.latitude/longitude = 카메라 중심 (탭바 뒤 포함 전체 뷰 기준)
+                  // r.latitude = SW 모서리이나 탭바 영역만큼 남쪽으로 밀려 있어,
+                  // 중심 기준으로 delta 절반씩 잡아 정확한 가시 범위를 계산
+                  const centerLat = Number.isFinite(params.latitude) ? (params.latitude as number) : r.latitude + r.latitudeDelta / 2;
+                  const centerLng = Number.isFinite(params.longitude) ? (params.longitude as number) : r.longitude + r.longitudeDelta / 2;
                   const zoom = params.zoom != null
                     ? Math.round(params.zoom)
                     : 14 - Math.round(Math.log2(r.latitudeDelta / 0.01));
@@ -1366,16 +1370,19 @@ export default function MapScreen() {
                   }, 600);
 
                   // 버스 정류장: 줌 13 이상일 때만 현재 화면 bounds로 조회
+                  // 카메라 중심 기준으로 delta 절반씩 잡아 가시 영역에 정확히 맞춤
                   const currentZoom = params.zoom ?? 14;
-                  const swLat = r.latitude;
-                  const swLng = r.longitude;
-                  const neLat = r.latitude + r.latitudeDelta;
-                  const neLng = r.longitude + r.longitudeDelta;
+                  const busCenter = centerLat + r.latitudeDelta * 0.30;
+                  const swLat = busCenter - r.latitudeDelta / 2;
+                  const swLng = centerLng - r.longitudeDelta / 2;
+                  const neLat = busCenter + r.latitudeDelta / 2;
+                  const neLng = centerLng + r.longitudeDelta / 2;
                   lastBoundsRef.current = { swLat, swLng, neLat, neLng, zoom: currentZoom };
+                  setBusQueryCenter({ latitude: busCenter, longitude: centerLng });
 
                   if (showBusStops) {
                     if (busStopFetchRef.current) clearTimeout(busStopFetchRef.current);
-                    if (currentZoom < 16) {
+                    if (currentZoom < 13) {
                       setBusStops([]);
                     } else {
                       busStopFetchRef.current = setTimeout(() => {
@@ -1394,6 +1401,7 @@ export default function MapScreen() {
                 distanceFilterCenter={distanceFilterCenter}
                 busStops={showBusStops ? busStops : []}
                 onBusStopPress={setSelectedBusStop}
+                busQueryCenter={busQueryCenter}
               />
             </MapErrorBoundary>
           )}
@@ -1528,7 +1536,7 @@ export default function MapScreen() {
                   setBusStops([]);
                 } else {
                   const bounds = lastBoundsRef.current;
-                  if (bounds && bounds.zoom >= 16) {
+                  if (bounds && bounds.zoom >= 13) {
                     getBusStopsInBounds(bounds.swLat, bounds.swLng, bounds.neLat, bounds.neLng)
                       .then(setBusStops)
                       .catch(() => {});

--- a/frontend/app/(tabs)/mypage/settings.tsx
+++ b/frontend/app/(tabs)/mypage/settings.tsx
@@ -107,6 +107,15 @@ export default function MyPageSettingsScreen() {
 
           <Pressable
             style={styles.item}
+            onPress={() => router.push('/terms-of-service')}
+          >
+            <Ionicons name="document-text-outline" size={22} style={styles.icon} />
+            <Text style={styles.label}>이용약관</Text>
+            <Ionicons name="chevron-forward" size={18} style={styles.arrow} />
+          </Pressable>
+
+          <Pressable
+            style={styles.item}
             onPress={() => router.push('/(tabs)/mypage/privacy-policy')}
           >
             <Ionicons name="shield-checkmark-outline" size={22} style={styles.icon} />

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -316,6 +316,96 @@ export default function PostDetailScreen() {
     sendChatToUser(authorId);
   };
 
+  // 댓글 신고
+  const handleCommentReport = async (commentId: string) => {
+    console.log("[CommentReport] called with commentId:", commentId);
+    setCommentMenuId(null);
+
+    // 로그인 체크
+    const token = await authService.getAccessToken();
+    console.log("[CommentReport] token exists:", !!token?.trim());
+    if (!token?.trim()) {
+      Alert.alert("로그인 필요", "신고 기능은 로그인 후 사용할 수 있습니다.", [
+        { text: "취소", style: "cancel" },
+        { text: "로그인", onPress: () => router.push("/login") },
+      ]);
+      return;
+    }
+
+    const reasons: { title: string; reason: reportService.ReportReason }[] = [
+      { title: "스팸", reason: "SPAM" },
+      { title: "욕설/혐오", reason: "ABUSE" },
+      { title: "부적절한 내용", reason: "INAPPROPRIATE" },
+      { title: "기타", reason: "OTHER" },
+    ];
+    Alert.alert(
+      "댓글 신고",
+      "신고 사유를 선택해 주세요.",
+      [
+        { text: "취소", style: "cancel" },
+        ...reasons.map((r) => ({
+          text: r.title,
+          onPress: async () => {
+            console.log("[CommentReport] submitting:", { commentId, reason: r.reason });
+            try {
+              await reportService.createReport({
+                targetType: "COMMENT",
+                targetId: Number(commentId),
+                reason: r.reason,
+              });
+              console.log("[CommentReport] success");
+              Alert.alert("완료", "신고가 접수되었습니다.");
+            } catch (e) {
+              console.error("[CommentReport] error:", e);
+              Alert.alert("오류", "신고 접수에 실패했습니다.");
+            }
+          },
+        })),
+      ]
+    );
+  };
+
+  // 댓글 작성자 차단
+  const handleCommentBlock = async (authorId: number, authorName: string) => {
+    console.log("[CommentBlock] called with authorId:", authorId, "authorName:", authorName);
+    setCommentMenuId(null);
+
+    // 로그인 체크
+    const token = await authService.getAccessToken();
+    console.log("[CommentBlock] token exists:", !!token?.trim());
+    if (!token?.trim()) {
+      Alert.alert("로그인 필요", "차단 기능은 로그인 후 사용할 수 있습니다.", [
+        { text: "취소", style: "cancel" },
+        { text: "로그인", onPress: () => router.push("/login") },
+      ]);
+      return;
+    }
+
+    Alert.alert(
+      "사용자 차단",
+      `${authorName}님을 차단하시겠습니까?\n차단하면 이 사용자의 게시물과 댓글이 표시되지 않습니다.`,
+      [
+        { text: "취소", style: "cancel" },
+        {
+          text: "차단",
+          style: "destructive",
+          onPress: async () => {
+            console.log("[CommentBlock] submitting:", authorId);
+            try {
+              await blockService.blockUser(authorId);
+              console.log("[CommentBlock] success");
+              Alert.alert("완료", "사용자를 차단했습니다.");
+              refetchComments();
+            } catch (e) {
+              console.error("[CommentBlock] error:", e);
+              Alert.alert("오류", "차단에 실패했습니다.");
+            }
+          },
+        },
+      ]
+    );
+  };
+
   const sendChatToUser = (targetId: number) => {
     if (!targetId || targetId <= 0) return;
     const myId = user?.id != null ? Number(user.id) : null;
@@ -798,7 +888,10 @@ export default function PostDetailScreen() {
                     {!c.deleted && (
                       <View style={styles.commentRight}>
                         {commentMenuId === c.id && (
-                          <View style={styles.commentDropdown}>
+                          <Pressable
+                            style={styles.commentDropdown}
+                            onTouchStart={(e) => e.stopPropagation()}
+                          >
                             {isMine ? (
                               <>
                                 {/* 댓글 수정 기능 비활성화
@@ -811,11 +904,28 @@ export default function PostDetailScreen() {
                                 </Pressable>
                               </>
                             ) : (
-                              <Pressable style={styles.commentDropdownItem} onPress={() => c.authorId && handleSendCommentChat(c.authorId)}>
-                                <Text style={styles.commentDropdownText}>채팅하기</Text>
-                              </Pressable>
+                              <>
+                                <Pressable
+                                  style={styles.commentDropdownItem}
+                                  onPress={() => { console.log("[Chat] pressed"); c.authorId && handleSendCommentChat(c.authorId); }}
+                                >
+                                  <Text style={styles.commentDropdownText}>채팅하기</Text>
+                                </Pressable>
+                                <Pressable
+                                  style={styles.commentDropdownItem}
+                                  onPress={() => { console.log("[Report] pressed"); handleCommentReport(c.id); }}
+                                >
+                                  <Text style={styles.commentDropdownText}>신고</Text>
+                                </Pressable>
+                                <Pressable
+                                  style={styles.commentDropdownItem}
+                                  onPress={() => { console.log("[Block] pressed"); c.authorId && handleCommentBlock(c.authorId, c.author); }}
+                                >
+                                  <Text style={[styles.commentDropdownText, styles.commentDropdownTextDanger]}>차단</Text>
+                                </Pressable>
+                              </>
                             )}
-                          </View>
+                          </Pressable>
                         )}
                         <Pressable style={styles.commentLikeWrap} onPress={() => toggleCommentLike(c.id)}>
                           <Animated.View style={{ transform: [{ scale: getCommentLikeAnim(c.id) }] }}>
@@ -904,7 +1014,10 @@ export default function PostDetailScreen() {
                         {!reply.deleted && (
                           <View style={styles.commentRight}>
                             {commentMenuId === reply.id && (
-                              <View style={styles.commentDropdown}>
+                              <Pressable
+                                style={styles.commentDropdown}
+                                onTouchStart={(e) => e.stopPropagation()}
+                              >
                                 {isMyReply ? (
                                   <>
                                     <Pressable
@@ -921,14 +1034,22 @@ export default function PostDetailScreen() {
                                     </Pressable>
                                   </>
                                 ) : (
-                                  <Pressable
-                                    style={styles.commentDropdownItem}
-                                    onPress={() => reply.authorId && handleSendCommentChat(reply.authorId)}
-                                  >
-                                    <Text style={styles.commentDropdownText}>채팅하기</Text>
-                                  </Pressable>
+                                  <>
+                                    <Pressable
+                                      style={styles.commentDropdownItem}
+                                      onPress={() => reply.authorId && handleSendCommentChat(reply.authorId)}
+                                    >
+                                      <Text style={styles.commentDropdownText}>채팅하기</Text>
+                                    </Pressable>
+                                    <Pressable style={styles.commentDropdownItem} onPress={() => handleCommentReport(reply.id)}>
+                                      <Text style={styles.commentDropdownText}>신고</Text>
+                                    </Pressable>
+                                    <Pressable style={styles.commentDropdownItem} onPress={() => reply.authorId && handleCommentBlock(reply.authorId, reply.author)}>
+                                      <Text style={[styles.commentDropdownText, styles.commentDropdownTextDanger]}>차단</Text>
+                                    </Pressable>
+                                  </>
                                 )}
-                              </View>
+                              </Pressable>
                             )}
                             <Pressable style={styles.commentLikeWrap} onPress={() => toggleCommentLike(reply.id)}>
                               <Animated.View style={{ transform: [{ scale: getCommentLikeAnim(reply.id) }] }}>

--- a/frontend/app/login/index.tsx
+++ b/frontend/app/login/index.tsx
@@ -229,8 +229,11 @@ export default function LoginScreen() {
               }}
               placeholder="비밀번호"
               placeholderTextColor="#9CA3AF"
-              secureTextEntry
+              secureTextEntry={true}
               autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="off"
+              textContentType="oneTimeCode"
             />
             {errorMessage ? (
               <Text style={styles.errorText}>{errorMessage}</Text>

--- a/frontend/app/signup/index.tsx
+++ b/frontend/app/signup/index.tsx
@@ -182,8 +182,11 @@ export default function SignupScreen() {
               onChangeText={setPassword}
               placeholder="비밀번호를 입력하세요"
               placeholderTextColor="#9CA3AF"
-              secureTextEntry
+              secureTextEntry={true}
               autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="off"
+              textContentType="oneTimeCode"
             />
           </View>
           <View style={styles.inputWrap}>
@@ -198,8 +201,11 @@ export default function SignupScreen() {
                 }}
                 placeholder="비밀번호를 한 번 더 입력하세요"
                 placeholderTextColor="#9CA3AF"
-                secureTextEntry
+                secureTextEntry={true}
                 autoCapitalize="none"
+                autoCorrect={false}
+                autoComplete="off"
+                textContentType="oneTimeCode"
               />
               <Pressable
                 style={({ pressed }) => [

--- a/frontend/app/signup/index.tsx
+++ b/frontend/app/signup/index.tsx
@@ -21,6 +21,7 @@ export default function SignupScreen() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [nickname, setNickname] = useState('');
+  const [agreeTerms, setAgreeTerms] = useState(false);
   const [agreePrivacy, setAgreePrivacy] = useState(false);
   const [loading, setLoading] = useState(false);
   const [authCode, setAuthCode] = useState('');
@@ -81,6 +82,10 @@ export default function SignupScreen() {
     }
     if (!authCode.trim()) {
       Alert.alert('입력 오류', '이메일로 받은 6자리 인증번호를 입력해 주세요.');
+      return;
+    }
+    if (!agreeTerms) {
+      Alert.alert('동의 필요', '이용약관에 동의해 주세요.');
       return;
     }
     if (!agreePrivacy) {
@@ -225,6 +230,29 @@ export default function SignupScreen() {
             />
           </View>
 
+          {/* 이용약관 동의 */}
+          <Pressable
+            style={styles.agreeRow}
+            onPress={() => setAgreeTerms((v) => !v)}
+          >
+            <View style={[styles.checkbox, agreeTerms && styles.checkboxChecked]}>
+              {agreeTerms ? (
+                <Ionicons name="checkmark" size={16} color="#FFFFFF" />
+              ) : null}
+            </View>
+            <Text style={styles.agreeLabel}>
+              <Text style={styles.agreeLabelPlain}>이용약관에 동의합니다 </Text>
+              <Text style={styles.agreeLabelRequired}>(필수)</Text>
+            </Text>
+            <Pressable
+              hitSlop={8}
+              onPress={() => router.push('/terms-of-service')}
+            >
+              <Text style={styles.agreeLabelLink}>(보기)</Text>
+            </Pressable>
+          </Pressable>
+
+          {/* 개인정보처리방침 동의 */}
           <Pressable
             style={styles.agreeRow}
             onPress={() => setAgreePrivacy((v) => !v)}
@@ -236,6 +264,7 @@ export default function SignupScreen() {
             </View>
             <Text style={styles.agreeLabel}>
               <Text style={styles.agreeLabelPlain}>개인정보처리방침에 동의합니다 </Text>
+              <Text style={styles.agreeLabelRequired}>(필수)</Text>
             </Text>
             <Pressable
               hitSlop={8}
@@ -377,6 +406,10 @@ const styles = StyleSheet.create({
     color: '#374151',
   },
   agreeLabelPlain: {},
+  agreeLabelRequired: {
+    color: '#EF4444',
+    fontSize: 12,
+  },
   agreeLabelLink: {
     color: '#4C8BF5',
     fontWeight: '500',

--- a/frontend/app/terms-of-service.tsx
+++ b/frontend/app/terms-of-service.tsx
@@ -1,0 +1,29 @@
+// app/terms-of-service.tsx - 이용약관 페이지
+import React from 'react';
+import { Pressable } from 'react-native';
+import { Stack, router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { TermsOfServiceContent } from '../components/TermsOfServiceContent';
+
+export default function TermsOfServiceScreen() {
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: '이용약관',
+          headerShown: true,
+          headerTitleAlign: 'center',
+          headerLeft: () => (
+            <Pressable onPress={() => router.back()} hitSlop={8} style={{ paddingHorizontal: 4 }}>
+              <Ionicons name="chevron-back" size={22} color="#111827" />
+            </Pressable>
+          ),
+        }}
+      />
+      <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }} edges={['left', 'right', 'bottom']}>
+        <TermsOfServiceContent />
+      </SafeAreaView>
+    </>
+  );
+}

--- a/frontend/components/TermsOfServiceContent.tsx
+++ b/frontend/components/TermsOfServiceContent.tsx
@@ -1,0 +1,172 @@
+/**
+ * 이용약관(서비스 이용약관) 문구 로드·렌더링
+ */
+import React from 'react';
+import { Text, StyleSheet, ScrollView } from 'react-native';
+
+export const TERMS_OF_SERVICE = `## 다일로(Dailo) 서비스 이용약관
+
+### 제1조 (목적)
+본 약관은 다일로(Dailo) 앱(이하 "서비스")의 이용 조건 및 절차, 이용자와 서비스 제공자의 권리와 의무를 규정함을 목적으로 합니다.
+
+### 제2조 (서비스 이용)
+1. 서비스는 축제, 공연, 학교 행사 정보 제공 및 커뮤니티 기능을 포함합니다.
+2. 이용자는 본 약관에 동의함으로써 서비스를 이용할 수 있습니다.
+
+### 제3조 (이용자의 의무)
+이용자는 다음 행위를 하여서는 안 됩니다:
+
+1. **욕설 및 비방 금지**
+   - 다른 이용자를 모욕하거나 비방하는 내용 게시
+   - 욕설, 비속어, 혐오 표현 사용
+
+2. **혐오 콘텐츠 금지**
+   - 인종, 성별, 종교, 국적, 장애 등을 이유로 한 차별적 표현
+   - 특정 집단에 대한 증오를 조장하는 콘텐츠
+
+3. **불법 콘텐츠 금지**
+   - 저작권 침해 자료 게시
+   - 음란물, 폭력적 콘텐츠 게시
+   - 개인정보 무단 유출
+   - 사기, 피싱 등 범죄 관련 콘텐츠
+
+4. **스팸 및 광고 금지**
+   - 무분별한 광고성 게시물
+   - 동일 내용 반복 게시
+
+5. **기타 금지 행위**
+   - 서비스 운영을 방해하는 행위
+   - 타인의 계정을 도용하는 행위
+   - 허위 정보 유포
+
+### 제4조 (신고 및 차단 기능)
+1. 이용자는 부적절한 게시물이나 댓글을 발견할 경우 **신고** 기능을 통해 운영진에게 알릴 수 있습니다.
+   - 게시글/댓글의 우측 상단 메뉴(···)에서 "신고" 선택
+
+2. 이용자는 특정 사용자의 콘텐츠를 보고 싶지 않을 경우 **차단** 기능을 사용할 수 있습니다.
+   - 해당 사용자 프로필의 우측 상단 메뉴(···)에서 "차단하기" 선택
+   - 차단된 사용자의 게시물과 댓글은 표시되지 않습니다.
+
+### 제5조 (제재 조치)
+본 약관을 위반한 이용자에 대해 다음과 같은 조치를 취할 수 있습니다:
+
+1. **경고**: 최초 위반 시 경고 조치
+2. **게시물 삭제**: 위반 콘텐츠 즉시 삭제
+3. **일시 정지**: 반복 위반 시 7일~30일 이용 정지
+4. **영구 정지**: 심각한 위반 또는 반복적 위반 시 계정 영구 정지
+
+### 제6조 (면책 조항)
+1. 서비스는 이용자가 게시한 콘텐츠에 대해 책임지지 않습니다.
+2. 이용자 간 분쟁에 대해 서비스는 중재 의무를 지지 않습니다.
+
+### 제7조 (약관 변경)
+1. 서비스는 필요 시 본 약관을 변경할 수 있습니다.
+2. 변경된 약관은 앱 내 공지를 통해 안내됩니다.
+
+### 제8조 (문의)
+서비스 이용 관련 문의: yuntyu01@gmail.com
+
+### 부칙
+본 약관은 2026년 4월 24일부터 시행됩니다.`;
+
+function renderLine(line: string, index: number): React.ReactNode {
+  const t = line.trim();
+  if (!t) return <Text key={index} style={styles.paragraph} />;
+  if (t.startsWith('### ')) {
+    return (
+      <Text key={index} style={[styles.sectionSubtitle, { marginTop: 16 }]}>
+        {t.slice(4)}
+      </Text>
+    );
+  }
+  if (t.startsWith('## ')) {
+    return (
+      <Text key={index} style={[styles.sectionTitle, { marginTop: index === 0 ? 0 : 24 }]}>
+        {t.slice(3)}
+      </Text>
+    );
+  }
+  if (t.startsWith('- ')) {
+    return (
+      <Text key={index} style={styles.listItem}>
+        {'  •  '}{t.slice(2)}
+      </Text>
+    );
+  }
+  if (/^\d+\.\s/.test(t)) {
+    return (
+      <Text key={index} style={styles.numberedItem}>
+        {t}
+      </Text>
+    );
+  }
+  if (t.startsWith('**') && t.endsWith('**')) {
+    return (
+      <Text key={index} style={styles.boldText}>
+        {t.slice(2, -2)}
+      </Text>
+    );
+  }
+  return (
+    <Text key={index} style={styles.body}>
+      {t}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  sectionSubtitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 6,
+  },
+  body: {
+    fontSize: 14,
+    color: '#4B5563',
+    lineHeight: 22,
+    marginBottom: 6,
+  },
+  boldText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#374151',
+    lineHeight: 22,
+    marginBottom: 4,
+  },
+  listItem: {
+    fontSize: 14,
+    color: '#4B5563',
+    lineHeight: 22,
+    marginBottom: 4,
+    paddingLeft: 8,
+  },
+  numberedItem: {
+    fontSize: 14,
+    color: '#4B5563',
+    lineHeight: 22,
+    marginBottom: 4,
+  },
+  paragraph: { height: 8 },
+  scroll: { flex: 1 },
+  scrollContent: { padding: 20, paddingBottom: 40 },
+});
+
+export function TermsOfServiceContent() {
+  const lines = TERMS_OF_SERVICE.split(/\n/);
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.scrollContent}
+    >
+      {lines.map((line, i) => renderLine(line, i))}
+    </ScrollView>
+  );
+}

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -8,7 +8,7 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "http://192.168.0.7:8080"
+        "EXPO_PUBLIC_API_URL": "http://192.168.229.36:8080"
       }
     },
     "preview": {

--- a/frontend/services/bus.service.ts
+++ b/frontend/services/bus.service.ts
@@ -5,12 +5,14 @@ export type BusStop = {
   stopName: string;
   latitude: number;
   longitude: number;
+  cityCode?: string;
 };
 
 export type BusArrivalItem = {
   routeId: string;
   routeNo: string;
   destination: string;
+  arrivalSec: number | null;
   arrivalMin: number | null;
   arrivalMessage: string;
   remainingStops: number | null;
@@ -19,6 +21,7 @@ export type BusArrivalItem = {
 export type BusArrivalResponse = {
   stopName: string;
   cityCode: string;
+  cachedAt: number;
   arrivals: BusArrivalItem[];
 };
 


### PR DESCRIPTION
## 개요
버스 정류장 마커 표시, 실시간 도착 정보 바텀시트, 노선-정류장 DB 동기화 기능 추가

## 관련 이슈
- Refs #bus

## 작업 내용
**백엔드**
- [x] `bus_stop_routes` 테이블 추가 (정류장별 경유 노선 매핑 저장)
- [x] 노선 동기화 역방향 매핑으로 전환 (노선 목록 → 경유 정류장 순으로 역방향 구성)
- [x] 동기화 시 종점명(`endNodeName`) 저장
- [x] 미승인 TAGO API(`getRouteBySttn`) 제거, 노선 조회 DB 단독 처리로 전환
- [x] `BusStop`에 `has_routes` 컬럼 추가, bounds 조회 시 노선 없는 정류장 제외
- [x] 도착 정보 응답에 `cachedAt`(ms), `arrivalSec` 필드 추가
- [x] 매일 새벽 3시 충주시 자동 동기화 스케줄러 등록

**프론트엔드**
- [x] 지도에 버스 정류장 마커 표시 (줌/원형 기반 클러스터링)
- [x] 정류장 탭 시 바텀시트: 경유 노선 목록 + 실시간 도착 카운트다운
- [x] `cachedAt` 기반 카운트다운으로 재탭 시 리셋 방지
- [x] 운행 중인 버스 없어도 시간표 기반 노선 목록 표시

## 체크리스트
- [x] 빌드가 에러 없이 수행되는가?
- [x] 불필요한 로그(console.log 등)는 없는가?
