### PR TITLE
feat/event-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,10 @@ backend/docs/
 
 *.jks
 *.jks
+
+# Node
+node_modules/
+admin-web/package-lock.json
+
+# Frontend
+frontend/.env

--- a/admin-web/package.json
+++ b/admin-web/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "dotenv": "^17.4.2",
     "express": "^4.18.2"
   }
 }

--- a/admin-web/server.js
+++ b/admin-web/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 

--- a/backend/src/main/java/com/dailo/backend/config/EventSeedRunner.java
+++ b/backend/src/main/java/com/dailo/backend/config/EventSeedRunner.java
@@ -16,8 +16,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * 앱 기동 시 한국교통대·건국대 충주캠퍼스 기준 시드 행사 3건을 등록합니다.
- * 이전에 등록된 대축제/소축제 시드는 기동 시 삭제 후, 새 3건이 없을 때만 삽입합니다.
+ * 앱 기동 시 한국교통대·건국대 충주캠퍼스 및 지역 축제 시드 데이터를 등록합니다.
+ * 'Gate to YEOJEONG' 동아리 축제 데이터를 포함합니다.
  */
 @Slf4j
 @Order(Integer.MAX_VALUE)
@@ -35,21 +35,23 @@ public class EventSeedRunner implements ApplicationRunner {
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
-        // 이전 시드(대축제/소축제) 삭제
+        // 1. 이전 구버전 시드 데이터 삭제
         List<Event> toRemove = eventRepository.findByTitleIn(OLD_SEED_TITLES);
         toRemove.forEach(eventRepository::delete);
         if (!toRemove.isEmpty()) {
             log.info("이전 시드 데이터 삭제: {} 건", toRemove.size());
         }
 
-        // 한국교통대·건국대 충주 기준 행사 3건 (없을 때만 삽입)
+        // 2. 신규 통합 축제: Gate to YEOJEONG (2026-04-30)
+        if (!eventRepository.existsByTitleContaining("Gate to YEOJEONG")) {
+            eventRepository.save(buildGateToYeojeongFestival());
+            log.info("시드 데이터 저장: 국립한국교통대 동아리 축제 Gate to YEOJEONG");
+        }
+
+        // 3. 기존 대학교 및 지역 시드 데이터 (중복 확인 후 삽입)
         if (!eventRepository.existsByTitleContaining("한국교통대 대축제")) {
             eventRepository.save(buildKnutDaechukje());
             log.info("시드 데이터 저장: 한국교통대 대축제");
-        }
-        if (!eventRepository.existsByTitleContaining("한국교통대 봄 소축제")) {
-            eventRepository.save(buildKnutSochukje());
-            log.info("시드 데이터 저장: 한국교통대 봄 소축제");
         }
         if (!eventRepository.existsByTitleContaining("건국대 충주캠퍼스 축제")) {
             eventRepository.save(buildKkuChungjuFestival());
@@ -59,19 +61,84 @@ public class EventSeedRunner implements ApplicationRunner {
             eventRepository.save(buildChungjuJungangtapEvent());
             log.info("시드 데이터 저장: 충주시 축제 중앙탑 행사");
         }
-        // 2.20 다양한 카테고리 행사 3건
         if (!eventRepository.existsByTitleContaining("충주 시민 미술 전시")) {
             eventRepository.save(buildChungjuArtExhibition());
             log.info("시드 데이터 저장: 충주 시민 미술 전시");
         }
-        if (!eventRepository.existsByTitleContaining("금요일 라이브 공연")) {
-            eventRepository.save(buildFridayLivePerformance());
-            log.info("시드 데이터 저장: 금요일 라이브 공연");
-        }
-        if (!eventRepository.existsByTitleContaining("주말 푸드트럭 페스타")) {
-            eventRepository.save(buildWeekendFoodTruckFesta());
-            log.info("시드 데이터 저장: 주말 푸드트럭 페스타");
-        }
+    }
+
+    /** 국립한국교통대학교 충주캠퍼스 동아리 축제 - Gate to YEOJEONG (2026-04-30) */
+    private Event buildGateToYeojeongFestival() {
+        LocalDateTime start = LocalDateTime.of(2026, 4, 30, 11, 0, 0);
+        LocalDateTime end = LocalDateTime.of(2026, 4, 30, 20, 0, 0);
+
+        String description = "국립한국교통대학교 충주캠퍼스 동아리 축제 'Gate to YEOJEONG'입니다.\n"
+                + "2026년 4월 30일(목) 한국교통대학교 학생광장 일원에서 열립니다.";
+
+        String extraJson = "{"
+            + "\"timeline\":["
+            +   "{\"id\":\"t1\",\"startTime\":\"11:00\",\"endTime\":\"13:00\",\"title\":\"행사 준비 및 푸드트럭 운영 시작\"},"
+            +   "{\"id\":\"t2\",\"startTime\":\"13:00\",\"endTime\":\"17:30\",\"title\":\"동아리 부스 운영\",\"details\":[\"체험 이벤트\",\"경품 증정\"]},"
+            +   "{\"id\":\"t3\",\"startTime\":\"17:00\",\"endTime\":\"20:00\",\"title\":\"동아리 공연\","
+            +   "\"performers\":["
+            +     "{\"name\":\"포세이돈\",\"genre\":\"밴드\",\"setlist\":[\"Get your Gun - 브로큰발렌타인\",\"Ao to natsu - Mrs. Greenapple\",\"Poker Face - 브로큰발렌타인\"]},"
+            +     "{\"name\":\"어울림\",\"genre\":\"밴드\",\"setlist\":[\"흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야 - 장범준\",\"나에게로 떠나는 여행 - 버즈\",\"사랑 Two - YB\"]},"
+            +     "{\"name\":\"소리담\",\"genre\":\"밴드\",\"setlist\":[\"Tokyo Inn - 혁오\",\"춤을 춰요 - 라쿠나\",\"Highlight - 터치드\"]},"
+            +     "{\"name\":\"MUSE\",\"genre\":\"밴드\",\"setlist\":[\"antifreeze - 검정치마\",\"에잇 - 아이유\",\"우리의 꿈 - 코요태\"]},"
+            +     "{\"name\":\"식스라인\",\"genre\":\"밴드\",\"setlist\":[\"Pain - 하현상\",\"금붕어 - 한로로\",\"See your eyes - 잔나비\",\"어리고 부끄럽고 바보 같은 - Xdinary Heroes\"]},"
+            +     "{\"name\":\"신문고\",\"genre\":\"밴드\",\"setlist\":[\"데칼코마니 - 마마무\",\"Loveholic - 러브홀릭\",\"나에게로 떠나는 여행 - 버즈\"]},"
+            +     "{\"name\":\"4D\",\"genre\":\"댄스\",\"setlist\":[\"내일에서 기다릴게 - 투모로우바이투게더\",\"404 - 키키\",\"할리우드 액션 - 보이넥스트도어\",\"아브라카타브라 - 미야오\",\"페이머스 - 올데이프로젝트\",\"퓨어허니 - 비욘세\",\"마음에 따라 뛰는건 멋지지않아 - 투어스\"]},"
+            +     "{\"name\":\"피날레\",\"genre\":\"댄스\",\"setlist\":[\"THAT'S A NO NO - ITZY\",\"Loving U - 씨스타\",\"10 Minutes - 이효리\",\"다시 만난 오늘 - TWS\",\"ZOO - NCT & aespa\",\"Supersonic - fromis_9\",\"Friday Night - Young Gunz\",\"짧은 치마 - AOA\"]},"
+            +     "{\"name\":\"바이탈싸인\",\"genre\":\"힙합/댄스\",\"setlist\":[\"404 - 키키\",\"Love me right + 으르렁 - EXO\",\"Bad girl good girl + 보핍보핍 (KISS OF LIFE ver.)\"]}"
+            +   "]}"
+            + "],"
+            + "\"foodBooths\":["
+            +   "{\"id\":\"f1\",\"name\":\"서우푸드\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"닭꼬치 5,000원\",\"닭똥집튀김 10,000원\",\"소떡소떡 4,000원\"]},"
+            +   "{\"id\":\"f2\",\"name\":\"용타코\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"수제타코야끼(8알) 5,000원\",\"수제타코야끼(12알) 7,000원\",\"슬러시 3,000원\"]},"
+            +   "{\"id\":\"f3\",\"name\":\"오감푸드\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"크림새우 10,000원\",\"칠리새우 10,000원\",\"반반새우 15,000원\"]},"
+            +   "{\"id\":\"f4\",\"name\":\"쏘굿\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"크레페 7,000원\",\"아이스크림크레페 8,000원\"]},"
+            +   "{\"id\":\"f5\",\"name\":\"써니푸드\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"닭강정(중) 10,000원\",\"닭강정(대) 17,000원\"]},"
+            +   "{\"id\":\"f6\",\"name\":\"춘자곱창\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"곱창(소) 13,000원\",\"곱창(중) 18,000원\"]},"
+            +   "{\"id\":\"f7\",\"name\":\"차군식당\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"스테이크(1인) 13,000원\",\"스테이크(2인) 23,000원\"]},"
+            +   "{\"id\":\"f8\",\"name\":\"나드리\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"야끼소바 10,000원\",\"오코노미야끼 10,000원\"]},"
+            +   "{\"id\":\"f9\",\"name\":\"윤셰프\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"츄러스 4,000원\",\"아이스크림츄러스 6,000원\"]},"
+            +   "{\"id\":\"f10\",\"name\":\"인생컴퍼니\",\"type\":\"food\",\"time\":\"11:00~20:00\",\"menu\":[\"소고기직화초밥(10p) 12,000원\",\"새우직화초밥(10p) 12,000원\"]}"
+            + "],"
+            + "\"experienceBooths\":["
+            +   "{\"id\":\"b1\",\"name\":\"PPC 패션동아리\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"PPC 스타일 유형 진단, 비즈키링 만들기, 캔뱃지 제작\"},"
+            +   "{\"id\":\"b2\",\"name\":\"CCC 기독교 동아리\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"전통놀이 체험 (공기놀이, 제기차기, 딱지치기, 투호놀이)\",\"prizes\":[\"2개 성공 → 뽑기권 1장\",\"4개 모두 성공 → 뽑기권 2장\"]},"
+            +   "{\"id\":\"b3\",\"name\":\"러빙 프렌즈\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"제한 시간 내 망치로 지정된 위치에 못 박기 체험\",\"prizes\":[\"성공 여부에 따라 소정의 상품 제공\"]},"
+            +   "{\"id\":\"b4\",\"name\":\"아가페 천주교 동아리\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"세례명 정해보기, 기도 대신 해드림, 책갈피 만들기\"},"
+            +   "{\"id\":\"b5\",\"name\":\"LUDENS 게임 동아리\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"롤, 발로란트 캐릭터/맵 맞히기 게임 (난이도 선택 가능)\",\"prizes\":[\"결과에 따라 소정의 상품 제공\"]},"
+            +   "{\"id\":\"b6\",\"name\":\"엘림찬양단\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"성경인물 이모지 게임, 찬양 관련 퀴즈\",\"prizes\":[\"솜사탕 + 소정의 간식\"]},"
+            +   "{\"id\":\"b7\",\"name\":\"총학생회\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"총학생회 체험 부스\"},"
+            +   "{\"id\":\"b8\",\"name\":\"오투 축구 동아리\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"골대를 향해 슈팅 체험 + 축구선수 콘셉트 포토존\",\"prizes\":[\"목표 정확히 맞출 시 상품 제공\"]},"
+            +   "{\"id\":\"b9\",\"name\":\"YOUTH&JCI\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"행운을 나누는 한마디 (가챠 감성) - 행운부적에 좋은 말 작성 후 랜덤으로 뽑기\",\"prizes\":[\"참여 선물: 소정의 간식 + 행운의 부적\",\"인스타 팔로우 이벤트: 가챠 인형 증정\"]},"
+            +   "{\"id\":\"b10\",\"name\":\"POLICE 방범대\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"인형 사격게임\",\"prizes\":[\"성공 시 인형 증정\"]},"
+            +   "{\"id\":\"b11\",\"name\":\"보드라이프\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"보드게임 체험 3종: HUES AND CUES, 구룡투, 5초준다\",\"prizes\":[\"게임 성공 시 뽑기 추첨\"]},"
+            +   "{\"id\":\"b12\",\"name\":\"사랑방 극 연구 예술회\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"사랑방약국 - 감정 키워드를 통해 나만의 마음 약을 처방받는 체험 부스\"},"
+            +   "{\"id\":\"b13\",\"name\":\"하비온\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"감각 제한 미션(눈 가리고 맞추기), 일심동체 게임\",\"prizes\":[\"타투스티커, 야광팔찌, 소정의 간식\"]},"
+            +   "{\"id\":\"b14\",\"name\":\"총동아리연합회 여정\",\"type\":\"experience\",\"time\":\"13:00~17:30\",\"description\":\"트래비를 이겨라(수도 맞추기), 랜덤 여행지 게임, 캐리어 무게 맞추기\",\"prizes\":[\"단계별 성공 시 차등 상품 지급\",\"실패 시 이전 보상 몰수\"]}"
+            + "]}";
+
+        return Event.builder()
+                .title("한국교통대 동아리 축제 Gate to YEOJEONG")
+                .regionName("충북 충주")
+                .filterGroup("CLUB")
+                .placeName("한국교통대학교 학생광장 일원")
+                .placeAddress("충청북도 충주시 대소원면 대학로 50")
+                .latitude(36.9118)
+                .longitude(127.8070)
+                .startAt(start)
+                .endAt(end)
+                .thumbnailUrl("https://picsum.photos/seed/yeojeong-2026/400/300")
+                .categories(List.of(EventCategory.FESTIVAL, EventCategory.PERFORMANCE, EventCategory.FOOD_TRUCK))
+                .status(EventStatus.ACTIVE)
+                .description(description)
+                .extraJson(extraJson)
+                .hostContact("한국교통대 총동아리연합회")
+                .isAdminManaged(true)
+                .build();
     }
 
     /** 한국교통대학교 충주캠퍼스 - 대축제 */
@@ -91,33 +158,8 @@ public class EventSeedRunner implements ApplicationRunner {
                 .thumbnailUrl("https://picsum.photos/seed/knut-dae/400/300")
                 .categories(List.of(EventCategory.FESTIVAL))
                 .status(EventStatus.ACTIVE)
-                .posterUrls(List.of())
-                .description("한국교통대학교 충주캠퍼스 대축제입니다. 메인 무대, 동아리 부스, 푸드트럭, 체험 부스가 준비되어 있습니다.")
+                .description("한국교통대학교 메인 대축제입니다.")
                 .hostContact("043-718-2000")
-                .isAdminManaged(true)
-                .build();
-    }
-
-    /** 한국교통대학교 충주캠퍼스 - 봄 소축제 */
-    private Event buildKnutSochukje() {
-        LocalDateTime start = LocalDateTime.now().plusDays(21).withHour(14).withMinute(0).withSecond(0).withNano(0);
-        LocalDateTime end = start.plusHours(6);
-        return Event.builder()
-                .title("한국교통대 봄 소축제")
-                .regionName("충북 충주")
-                .filterGroup("CLUB")
-                .placeName("한국교통대학교 학생광장")
-                .placeAddress("충청북도 충주시 대소원면 대학로 50")
-                .latitude(36.9118)
-                .longitude(127.8070)
-                .startAt(start)
-                .endAt(end)
-                .thumbnailUrl("https://picsum.photos/seed/knut-so/400/300")
-                .categories(List.of(EventCategory.FESTIVAL))
-                .status(EventStatus.ACTIVE)
-                .posterUrls(List.of())
-                .description("한국교통대 동아리 연합 봄 소축제. 버스킹, 체험 부스, 간식 나눔 등이 진행됩니다.")
-                .hostContact("한국교통대 학생회 043-718-2XXX")
                 .isAdminManaged(true)
                 .build();
     }
@@ -139,8 +181,7 @@ public class EventSeedRunner implements ApplicationRunner {
                 .thumbnailUrl("https://picsum.photos/seed/kku-chungju/400/300")
                 .categories(List.of(EventCategory.FESTIVAL))
                 .status(EventStatus.ACTIVE)
-                .posterUrls(List.of())
-                .description("건국대학교 글로컬캠퍼스(충주) 축제입니다. 공연, 부스, 이벤트가 준비되어 있습니다.")
+                .description("건국대학교 글로컬캠퍼스 축제입니다.")
                 .hostContact("043-840-3114")
                 .isAdminManaged(true)
                 .build();
@@ -163,17 +204,16 @@ public class EventSeedRunner implements ApplicationRunner {
                 .thumbnailUrl("https://picsum.photos/seed/chungju-jungangtap/400/300")
                 .categories(List.of(EventCategory.FESTIVAL))
                 .status(EventStatus.ACTIVE)
-                .posterUrls(List.of())
-                .description("충주시 축제의 중앙탑 행사입니다. 중앙탑사적공원에서 다양한 공연과 부스가 준비되어 있습니다.")
+                .description("충주시 주관 중앙탑 사적공원 행사입니다.")
                 .hostContact("충주시청 043-850-5000")
                 .isAdminManaged(true)
                 .build();
     }
 
-    /** 2.20 전시 - 충주 시민 미술 전시 */
+    /** 전시 - 충주 시민 미술 전시 */
     private Event buildChungjuArtExhibition() {
-        LocalDateTime start = LocalDateTime.of(2026, 2, 20, 9, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2026, 2, 22, 18, 0, 0);
+        LocalDateTime start = LocalDateTime.of(2026, 4, 20, 9, 0, 0);
+        LocalDateTime end = LocalDateTime.of(2026, 4, 22, 18, 0, 0);
         return Event.builder()
                 .title("충주 시민 미술 전시")
                 .regionName("충북 충주")
@@ -187,57 +227,8 @@ public class EventSeedRunner implements ApplicationRunner {
                 .thumbnailUrl("https://picsum.photos/seed/chungju-art/400/300")
                 .categories(List.of(EventCategory.EXHIBITION))
                 .status(EventStatus.ACTIVE)
-                .posterUrls(List.of())
-                .description("충주 시민 작가들의 미술 전시회. 회화, 조소, 사진 등 다양한 작품을 만나보세요.")
-                .hostContact("충주시립미술관 043-850-3XXX")
-                .isAdminManaged(true)
-                .build();
-    }
-
-    /** 2.20 공연 - 금요일 라이브 공연 */
-    private Event buildFridayLivePerformance() {
-        LocalDateTime start = LocalDateTime.of(2026, 2, 20, 19, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2026, 2, 20, 22, 0, 0);
-        return Event.builder()
-                .title("금요일 라이브 공연")
-                .regionName("충북 충주")
-                .filterGroup("CLUB")
-                .placeName("건국대 글로컬캠퍼스 중앙광장")
-                .placeAddress("충청북도 충주시 충주대학로 268")
-                .latitude(36.9705)
-                .longitude(127.9320)
-                .startAt(start)
-                .endAt(end)
-                .thumbnailUrl("https://picsum.photos/seed/live-performance/400/300")
-                .categories(List.of(EventCategory.PERFORMANCE))
-                .status(EventStatus.ACTIVE)
-                .posterUrls(List.of())
-                .description("동아리 밴드와 뮤지션들의 금요일 저녁 라이브 공연. 무료 관람.")
-                .hostContact("건국대 동아리연합회")
-                .isAdminManaged(true)
-                .build();
-    }
-
-    /** 2.20 푸드트럭 - 주말 푸드트럭 페스타 (개인 = 파란색) */
-    private Event buildWeekendFoodTruckFesta() {
-        LocalDateTime start = LocalDateTime.of(2026, 2, 20, 11, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2026, 2, 21, 20, 0, 0);
-        return Event.builder()
-                .title("주말 푸드트럭 페스타")
-                .regionName("충북 충주")
-                .filterGroup("")
-                .placeName("충주 호반 씨네마 앞 광장")
-                .placeAddress("충청북도 충주시 호반로 123")
-                .latitude(36.9910)
-                .longitude(127.9260)
-                .startAt(start)
-                .endAt(end)
-                .thumbnailUrl("https://picsum.photos/seed/foodtruck/400/300")
-                .categories(List.of(EventCategory.FOOD_TRUCK))
-                .status(EventStatus.ACTIVE)
-                .posterUrls(List.of())
-                .description("다양한 푸드트럭이 모이는 주말 페스타. 타코, 버거, 디저트, 음료 등 맛집 트럭을 만나보세요.")
-                .hostContact("충주시 상인회 043-8XX-XXXX")
+                .description("충주 시민 작가들의 미술 전시회입니다.")
+                .hostContact("043-850-3XXX")
                 .isAdminManaged(true)
                 .build();
     }

--- a/frontend/app/event/[id].tsx
+++ b/frontend/app/event/[id].tsx
@@ -382,7 +382,7 @@ const styles = StyleSheet.create({
   bodyInner: {
     paddingTop: 10,
   },
-  timelineWrap: { flex: 1 },
+  timelineWrap: {},
   timelineDateNavRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/frontend/components/detail/BoothLayoutMap.tsx
+++ b/frontend/components/detail/BoothLayoutMap.tsx
@@ -1,0 +1,363 @@
+import React, { useState } from 'react';
+import {
+  View, Text, StyleSheet, Pressable,
+  Modal, TouchableOpacity,
+} from 'react-native';
+import type { EventBoothItem } from '../../types/event';
+
+interface Props {
+  foodBooths?: EventBoothItem[] | null;
+  experienceBooths?: EventBoothItem[] | null;
+  eventId?: number;
+  eventTitle?: string;
+}
+
+// 푸드트럭 = 주황 라인, 체험부스 = 파랑 라인, 배경은 모두 흰색
+const FOOD = { bg: '#FFFFFF', border: '#E8763A', text: '#C05E25' };
+const EXP  = { bg: '#FFFFFF', border: '#4D86CC', text: '#2D66AA' };
+
+type SelectedBooth = EventBoothItem & { colorType: 'food' | 'exp' };
+
+export default function BoothLayoutMap({ foodBooths, experienceBooths }: Props) {
+  const [selected, setSelected] = useState<SelectedBooth | null>(null);
+
+  const food = foodBooths ?? [];
+  const exp  = experienceBooths ?? [];
+
+  // 앞절반 = 왼쪽 열, 뒷절반 = 오른쪽 열
+  const foodMid = Math.ceil(food.length / 2);
+  const foodLeft  = food.slice(0, foodMid);
+  const foodRight = food.slice(foodMid);
+
+  const expMid = Math.ceil(exp.length / 2);
+  const expLeft  = exp.slice(0, expMid);
+  const expRight = exp.slice(expMid);
+
+  function BoothCard({ booth, colorType }: { booth: EventBoothItem; colorType: 'food' | 'exp' }) {
+    const c = colorType === 'food' ? FOOD : EXP;
+    return (
+      <Pressable
+        style={[styles.boothCard, { borderColor: c.border }]}
+        onPress={() => setSelected({ ...booth, colorType })}
+      >
+        <Text style={styles.boothText} numberOfLines={2}>
+          {booth.name}
+        </Text>
+      </Pressable>
+    );
+  }
+
+  // 한 열: 푸드트럭 → 구분 → 체험부스
+  function BoothColumn({ foodItems, expItems }: { foodItems: EventBoothItem[]; expItems: EventBoothItem[] }) {
+    return (
+      <View style={styles.column}>
+        {foodItems.map(b => <BoothCard key={b.id} booth={b} colorType="food" />)}
+        {foodItems.length > 0 && expItems.length > 0 && <View style={styles.sectionGap} />}
+        {expItems.map(b => <BoothCard key={b.id} booth={b} colorType="exp" />)}
+      </View>
+    );
+  }
+
+  function Tooltip() {
+    if (!selected) return null;
+    const isFood = selected.colorType === 'food';
+    const c = isFood ? FOOD : EXP;
+    return (
+      <View style={[styles.tooltipCard, { borderColor: c.border }]}>
+        <View style={[styles.tooltipHeader, { borderBottomColor: '#F3F4F6' }]}>
+          <Text style={styles.tooltipTitle}>{selected.name}</Text>
+          {selected.time && <Text style={styles.tooltipMeta}>운영시간: {selected.time}</Text>}
+          {selected.host && <Text style={styles.tooltipMeta}>주최: {selected.host}</Text>}
+        </View>
+        <View style={styles.tooltipBody}>
+          {!!selected.description && (
+            <Text style={styles.tooltipDesc}>{selected.description}</Text>
+          )}
+          {isFood && !!selected.menu?.length && (
+            <View style={styles.tooltipSection}>
+              <Text style={styles.tooltipSectionTitle}>메뉴</Text>
+              {selected.menu.map((item, i) => (
+                <Text key={i} style={styles.tooltipBullet}>• {item}</Text>
+              ))}
+            </View>
+          )}
+          {!isFood && !!selected.prizes?.length && (
+            <View style={styles.tooltipSection}>
+              <Text style={styles.tooltipSectionTitle}>시상 및 상품</Text>
+              {selected.prizes.map((item, i) => (
+                <Text key={i} style={styles.tooltipBullet}>• {item}</Text>
+              ))}
+            </View>
+          )}
+        </View>
+        <TouchableOpacity style={styles.tooltipClose} onPress={() => setSelected(null)}>
+          <Text style={styles.tooltipCloseText}>닫기</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      {/* 범례 */}
+      <View style={styles.legend}>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: FOOD.border }]} />
+          <Text style={styles.legendLabel}>푸드트럭</Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: EXP.border }]} />
+          <Text style={styles.legendLabel}>체험부스</Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: '#9CA3AF' }]} />
+          <Text style={styles.legendLabel}>공간</Text>
+        </View>
+      </View>
+
+      {/* 지도 */}
+      <View style={styles.mapWrapper}>
+        <View style={styles.mapRow}>
+
+          {/* 왼쪽: 피크닉존 + 동아리무대 */}
+          <View style={styles.leftArea}>
+            <View style={styles.picnicZone}>
+              <Text style={styles.picnicText}>피크닉존</Text>
+            </View>
+            <View style={styles.stageBox}>
+              <Text style={styles.stageText}>동아리{'\n'}무대</Text>
+            </View>
+          </View>
+
+          {/* 오른쪽: 클린존 + 두 부스 열 */}
+          <View style={styles.rightArea}>
+            {/* 클린존 - 두 열 사이 상단 */}
+            <View style={styles.cleanZoneRow}>
+              <View style={styles.cleanZone}>
+                <Text style={styles.cleanZoneText}>클린존</Text>
+              </View>
+            </View>
+
+            {/* 두 부스 열 */}
+            <View style={styles.boothsArea}>
+              <BoothColumn foodItems={foodLeft} expItems={expLeft} />
+              <View style={styles.columnDivider} />
+              <BoothColumn foodItems={foodRight} expItems={expRight} />
+            </View>
+          </View>
+
+        </View>
+      </View>
+
+      <Text style={styles.tapHint}>부스를 탭하면 상세 정보를 볼 수 있어요</Text>
+
+      {/* 툴팁 오버레이 */}
+      <Modal visible={!!selected} transparent animationType="fade" onRequestClose={() => setSelected(null)}>
+        <TouchableOpacity style={styles.overlay} activeOpacity={1} onPress={() => setSelected(null)}>
+          <TouchableOpacity activeOpacity={1}>
+            <Tooltip />
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  legend: { flexDirection: 'row', gap: 14, marginBottom: 10 },
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  legendDot: { width: 10, height: 10, borderRadius: 5 },
+  legendLabel: { fontSize: 11, color: '#6B7280' },
+
+  mapWrapper: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
+    overflow: 'hidden',
+    paddingBottom: 4,
+  },
+
+  mapRow: {
+    flexDirection: 'row',
+    padding: 8,
+    gap: 8,
+  },
+
+  // 왼쪽 랜드마크 (피크닉존 + 동아리무대)
+  leftArea: {
+    width: 66,
+    gap: 6,
+  },
+  picnicZone: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 12,
+    borderWidth: 1.5,
+    borderColor: '#D1D5DB',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 6,
+  },
+  picnicText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#6B7280',
+    textAlign: 'center',
+  },
+  stageBox: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: '#D1D5DB',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+  },
+  stageText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#6B7280',
+    textAlign: 'center',
+  },
+
+  // 오른쪽 부스 영역
+  rightArea: {
+    flex: 1,
+    gap: 4,
+  },
+  cleanZoneRow: {
+    alignItems: 'center',
+  },
+  cleanZone: {
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: '#D1D5DB',
+    paddingVertical: 5,
+    paddingHorizontal: 16,
+  },
+  cleanZoneText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#6B7280',
+  },
+
+  // 두 부스 열
+  boothsArea: {
+    flexDirection: 'row',
+    gap: 4,
+  },
+  column: {
+    flex: 1,
+    gap: 3,
+  },
+  columnDivider: {
+    width: 1,
+    backgroundColor: '#E5E7EB',
+  },
+  sectionGap: {
+    height: 5,
+    backgroundColor: '#E5E7EB',
+    borderRadius: 1,
+  },
+
+  // 부스 카드
+  boothCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    borderWidth: 1.5,
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 52,
+  },
+  boothText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#111827',
+    textAlign: 'center',
+    lineHeight: 16,
+  },
+
+  tapHint: {
+    textAlign: 'center',
+    fontSize: 11,
+    color: '#9CA3AF',
+    marginTop: 10,
+  },
+
+  // 툴팁
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  tooltipCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    borderWidth: 2,
+    width: '100%',
+    maxWidth: 340,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 12,
+    elevation: 8,
+  },
+  tooltipHeader: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+  },
+  tooltipTitle: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  tooltipMeta: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginTop: 2,
+  },
+  tooltipBody: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  tooltipDesc: {
+    fontSize: 13,
+    color: '#374151',
+    lineHeight: 19,
+  },
+  tooltipSection: { gap: 4 },
+  tooltipSectionTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 2,
+  },
+  tooltipBullet: {
+    fontSize: 12,
+    color: '#4B5563',
+    lineHeight: 18,
+  },
+  tooltipClose: {
+    borderTopWidth: 1,
+    borderTopColor: '#F3F4F6',
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  tooltipCloseText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#374151',
+  },
+});

--- a/frontend/components/detail/EventBoothTab.tsx
+++ b/frontend/components/detail/EventBoothTab.tsx
@@ -5,11 +5,12 @@ import { View, Text, StyleSheet, Pressable, Platform, ToastAndroid, Alert } from
 import { Ionicons } from "@expo/vector-icons";
 import BoothMap from "./BoothMap";
 import BoothDetailModal from "./BoothDetailModal";
+import BoothLayoutMap from "./BoothLayoutMap";
 import type { EventBoothItem } from "../../types/event";
 import * as boothFavoriteService from "../../services/boothFavorite.service";
 
 export type BoothType = "food" | "experience";
-type Mode = "list" | "map";
+type Mode = "list" | "map" | "layout";
 
 export type Booth = EventBoothItem & { locationLabel?: string };
 
@@ -101,116 +102,131 @@ export default function EventBoothTab({
   );
 
   return (
-    <View style={{ flex: 1 }}>
-      {/* 상단 토글 (리스트/지도 모드 모두 표시) */}
-      <View style={styles.segmentContainer}>
+    <View>
+      {/* 모드 토글 (배치도 / 목록) — 배치도 모드에서는 푸드트럭/체험부스 세그먼트 숨김 */}
+      <View style={styles.modeToggleRow}>
         <Pressable
-          style={[
-            styles.segmentItem,
-            boothType === "food" && styles.segmentItemActive,
-          ]}
-          onPress={() => setBoothType("food")}
+          style={[styles.modeToggleBtn, mode === "layout" && styles.modeToggleBtnActive]}
+          onPress={() => setMode("layout")}
         >
-          <Text
-            style={[
-              styles.segmentText,
-              boothType === "food" && styles.segmentTextActive,
-            ]}
-          >
-            푸드트럭
-          </Text>
+          <Text style={[styles.modeToggleText, mode === "layout" && styles.modeToggleTextActive]}>배치도</Text>
         </Pressable>
         <Pressable
-          style={[
-            styles.segmentItem,
-            boothType === "experience" && styles.segmentItemActive,
-          ]}
-          onPress={() => setBoothType("experience")}
+          style={[styles.modeToggleBtn, mode === "list" && styles.modeToggleBtnActive]}
+          onPress={() => setMode("list")}
         >
-          <Text
-            style={[
-              styles.segmentText,
-              boothType === "experience" && styles.segmentTextActive,
-            ]}
-          >
-            체험부스
-          </Text>
+          <Text style={[styles.modeToggleText, mode === "list" && styles.modeToggleTextActive]}>목록</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.modeToggleBtn, mode === "map" && styles.modeToggleBtnActive]}
+          onPress={() => setMode("map")}
+        >
+          <Text style={[styles.modeToggleText, mode === "map" && styles.modeToggleTextActive]}>위치</Text>
         </Pressable>
       </View>
 
-      {mode === "map" ? (
+      {/* 배치도 모드 */}
+      {mode === "layout" && (
+        <BoothLayoutMap
+          foodBooths={foodBooths}
+          experienceBooths={experienceBooths}
+          eventId={eventId}
+          eventTitle={eventTitle}
+        />
+      )}
+
+      {/* 위치 모드 */}
+      {mode === "map" && (
         <>
+          {/* 푸드트럭/체험부스 세그먼트 */}
+          <View style={styles.segmentContainer}>
+            <Pressable
+              style={[styles.segmentItem, boothType === "food" && styles.segmentItemActive]}
+              onPress={() => setBoothType("food")}
+            >
+              <Text style={[styles.segmentText, boothType === "food" && styles.segmentTextActive]}>푸드트럭</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.segmentItem, boothType === "experience" && styles.segmentItemActive]}
+              onPress={() => setBoothType("experience")}
+            >
+              <Text style={[styles.segmentText, boothType === "experience" && styles.segmentTextActive]}>체험부스</Text>
+            </Pressable>
+          </View>
           <BoothMap
             centerLatitude={mapCenter?.latitude}
             centerLongitude={mapCenter?.longitude}
           />
-          <Pressable
-            style={[styles.bottomButton, { alignSelf: "center", marginTop: 16 }]}
-            onPress={() => setMode("list")}
-          >
-            <Text style={styles.bottomButtonText}>부스 목록 보기</Text>
-          </Pressable>
-        </>
-      ) : (
-        <>
-          {/* 부스 리스트 */}
-          <View style={styles.listWrapper}>
-        {booths.length === 0 ? (
-          <Text style={styles.emptyText}>등록된 부스가 없습니다.</Text>
-        ) : (
-          booths.map((booth) => (
-            <Pressable
-              key={booth.id}
-              style={styles.boothCard}
-              onPress={() => setSelectedBooth(booth)}
-            >
-              <View style={styles.iconPlaceholder} />
-              <View style={{ flex: 1 }}>
-                <Text style={styles.boothName}>{booth.name}</Text>
-                <Text style={styles.boothLocation}>{booth.locationLabel ?? ""}</Text>
-              </View>
-              {eventId != null ? (
-                <Pressable
-                  hitSlop={8}
-                  onPress={(e) => {
-                    e.stopPropagation?.();
-                    handleToggleFavorite(booth);
-                  }}
-                  style={styles.starButton}
-                >
-                  <Ionicons
-                    name={isFavorite(booth) ? "star" : "star-outline"}
-                    size={24}
-                    color={isFavorite(booth) ? "#EAB308" : "#D1D5DB"}
-                  />
-                </Pressable>
-              ) : (
-                <Ionicons name="star-outline" size={24} color="#D1D5DB" />
-              )}
-            </Pressable>
-          ))
-        )}
-          </View>
-          <Pressable
-            style={[styles.bottomButton, { alignSelf: "center", marginTop: 16 }]}
-            onPress={() => setMode("map")}
-          >
-            <Text style={styles.bottomButtonText}>위치 보기</Text>
-          </Pressable>
         </>
       )}
 
-      {/* 상세 모달 */}
+      {/* 목록 모드 */}
+      {mode === "list" && (
+        <>
+          {/* 푸드트럭/체험부스 세그먼트 */}
+          <View style={styles.segmentContainer}>
+            <Pressable
+              style={[styles.segmentItem, boothType === "food" && styles.segmentItemActive]}
+              onPress={() => setBoothType("food")}
+            >
+              <Text style={[styles.segmentText, boothType === "food" && styles.segmentTextActive]}>푸드트럭</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.segmentItem, boothType === "experience" && styles.segmentItemActive]}
+              onPress={() => setBoothType("experience")}
+            >
+              <Text style={[styles.segmentText, boothType === "experience" && styles.segmentTextActive]}>체험부스</Text>
+            </Pressable>
+          </View>
+          <View style={styles.listWrapper}>
+            {booths.length === 0 ? (
+              <Text style={styles.emptyText}>등록된 부스가 없습니다.</Text>
+            ) : (
+              booths.map((booth) => (
+                <Pressable
+                  key={booth.id}
+                  style={styles.boothCard}
+                  onPress={() => setSelectedBooth(booth)}
+                >
+                  <View style={[
+                    styles.iconPlaceholder,
+                    boothType === "food"
+                      ? { backgroundColor: "#FEF0E6" }
+                      : { backgroundColor: "#EBF3FB" },
+                  ]} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.boothName}>{booth.name}</Text>
+                    <Text style={styles.boothLocation}>{booth.locationLabel ?? ""}</Text>
+                  </View>
+                  {eventId != null ? (
+                    <Pressable
+                      hitSlop={8}
+                      onPress={(e) => { e.stopPropagation?.(); handleToggleFavorite(booth); }}
+                      style={styles.starButton}
+                    >
+                      <Ionicons
+                        name={isFavorite(booth) ? "star" : "star-outline"}
+                        size={24}
+                        color={isFavorite(booth) ? "#EAB308" : "#D1D5DB"}
+                      />
+                    </Pressable>
+                  ) : (
+                    <Ionicons name="star-outline" size={24} color="#D1D5DB" />
+                  )}
+                </Pressable>
+              ))
+            )}
+          </View>
+        </>
+      )}
+
+      {/* 상세 모달 (목록 모드용) */}
       <BoothDetailModal
         visible={!!selectedBooth}
         booth={selectedBooth}
         eventId={eventId}
         isFavorite={selectedBooth ? isFavorite(selectedBooth) : false}
-        onToggleFavorite={
-          selectedBooth
-            ? () => handleToggleFavorite(selectedBooth)
-            : undefined
-        }
+        onToggleFavorite={selectedBooth ? () => handleToggleFavorite(selectedBooth) : undefined}
         onClose={() => setSelectedBooth(null)}
       />
     </View>
@@ -218,6 +234,33 @@ export default function EventBoothTab({
 }
 
 const styles = StyleSheet.create({
+  modeToggleRow: {
+    flexDirection: "row",
+    gap: 6,
+    marginTop: 12,
+    marginBottom: 8,
+  },
+  modeToggleBtn: {
+    flex: 1,
+    paddingVertical: 7,
+    borderRadius: 8,
+    alignItems: "center",
+    backgroundColor: "#F3F4F6",
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  modeToggleBtnActive: {
+    backgroundColor: "#111827",
+    borderColor: "#111827",
+  },
+  modeToggleText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#6B7280",
+  },
+  modeToggleTextActive: {
+    color: "#FFFFFF",
+  },
   segmentContainer: {
     flexDirection: "row",
     backgroundColor: "#f3f3f3",
@@ -266,7 +309,6 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 12,
-    backgroundColor: "#ffe9c7",
     marginRight: 12,
   },
   boothName: {

--- a/frontend/components/detail/Timeline.tsx
+++ b/frontend/components/detail/Timeline.tsx
@@ -1,12 +1,11 @@
 // frontend/components/detail/Timeline.tsx
-import React from "react";
-import { View, Text, StyleSheet } from "react-native";
-import type { EventTimelineItem } from "../../types/event";
+import React, { useState } from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { EventTimelineItem, PerformerItem } from "../../types/event";
 
 interface TimelineProps {
-  /** 표시할 날짜 라벨 (예: 11.29(목)) */
   dateLabel?: string | null;
-  /** 저장된 타임테이블 목록 */
   items?: EventTimelineItem[] | null;
 }
 
@@ -34,6 +33,13 @@ function formatEventDate(iso: string): string {
   }
 }
 
+function genreStyle(genre: string): { bg: string; text: string } {
+  if (genre.includes("밴드"))   return { bg: "#FFF3E0", text: "#C05E25" };
+  if (genre.includes("힙합"))   return { bg: "#F3E5F5", text: "#7B1FA2" };
+  if (genre.includes("댄스"))   return { bg: "#E3F2FD", text: "#1565C0" };
+  return { bg: "#F3F4F6", text: "#374151" };
+}
+
 export default function Timeline({ dateLabel, items }: TimelineProps) {
   const raw = items && items.length > 0 ? items : [];
   const list = sortByStartTime(raw);
@@ -52,11 +58,7 @@ export default function Timeline({ dateLabel, items }: TimelineProps) {
           <Text style={styles.emptyText}>등록된 타임테이블이 없습니다.</Text>
         ) : (
           list.map((item, index) => (
-            <TimelineRow
-              key={item.id}
-              item={item}
-              isLast={index === list.length - 1}
-            />
+            <TimelineRow key={item.id} item={item} isLast={index === list.length - 1} />
           ))
         )}
       </View>
@@ -64,30 +66,95 @@ export default function Timeline({ dateLabel, items }: TimelineProps) {
   );
 }
 
-interface RowProps {
-  item: EventTimelineItem;
-  isLast: boolean;
-}
-
-function TimelineRow({ item, isLast }: RowProps) {
+function TimelineRow({ item, isLast }: { item: EventTimelineItem; isLast: boolean }) {
   const timeStr = `${item.startTime}${item.endTime ? ` ~ ${item.endTime}` : ""}`;
+  const hasPerformers = !!item.performers?.length;
+
   return (
     <View style={styles.row}>
       <View style={styles.lineCol}>
         <View style={styles.circle} />
         {!isLast && <View style={styles.line} />}
       </View>
+
       <View style={styles.cardWrap}>
         <Text style={styles.timeText}>{timeStr}</Text>
         <View style={styles.card}>
           <Text style={styles.titleText}>{item.title}</Text>
-          {item.details?.map((d) => (
-            <Text key={d} style={styles.detailText}>
-              • {d}
-            </Text>
-          ))}
+
+          {hasPerformers ? (
+            <PerformerList performers={item.performers!} />
+          ) : (
+            <BulletDetails details={item.details ?? []} />
+          )}
         </View>
       </View>
+    </View>
+  );
+}
+
+function PerformerList({ performers }: { performers: PerformerItem[] }) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <View style={styles.performerList}>
+      {performers.map((p, i) => {
+        const isOpen = openIndex === i;
+        const gs = genreStyle(p.genre);
+
+        return (
+          <View key={i}>
+            <Pressable
+              style={[styles.performerRow, isOpen && styles.performerRowOpen]}
+              onPress={() => setOpenIndex(isOpen ? null : i)}
+            >
+              {/* 순서 번호 */}
+              <View style={styles.orderBadge}>
+                <Text style={styles.orderText}>{i + 1}</Text>
+              </View>
+
+              {/* 이름 */}
+              <Text style={styles.performerName}>{p.name}</Text>
+
+              {/* 장르 뱃지 */}
+              <View style={[styles.genreBadge, { backgroundColor: gs.bg }]}>
+                <Text style={[styles.genreText, { color: gs.text }]}>{p.genre}</Text>
+              </View>
+
+              {/* 화살표 */}
+              <Ionicons
+                name={isOpen ? "chevron-up" : "chevron-down"}
+                size={14}
+                color="#9CA3AF"
+                style={styles.chevron}
+              />
+            </Pressable>
+
+            {/* 셋리스트 */}
+            {isOpen && (
+              <View style={[styles.setlistBox, { borderLeftColor: gs.text }]}>
+                {p.setlist.map((song, si) => (
+                  <View key={si} style={styles.setlistRow}>
+                    <Text style={styles.setlistIndex}>{si + 1}</Text>
+                    <Text style={styles.setlistSong}>{song}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function BulletDetails({ details }: { details: string[] }) {
+  if (details.length === 0) return null;
+  return (
+    <View style={{ marginTop: 4 }}>
+      {details.map((d, i) => (
+        <Text key={i} style={styles.detailText}>• {d}</Text>
+      ))}
     </View>
   );
 }
@@ -95,55 +162,21 @@ function TimelineRow({ item, isLast }: RowProps) {
 export { formatEventDate };
 
 const styles = StyleSheet.create({
-  dateHeader: {
-    marginBottom: 12,
-    paddingHorizontal: 4,
-  },
-  dateText: {
-    fontSize: 16,
-    fontWeight: "bold",
-  },
-  emptyText: {
-    fontSize: 14,
-    color: "#9CA3AF",
-    textAlign: "center",
-    paddingVertical: 24,
-  },
-  timelineContent: {
-    paddingTop: 4,
-    paddingBottom: 32,
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    marginBottom: 16,
-  },
-  lineCol: {
-    width: 32,
-    alignItems: "center",
-  },
+  dateHeader: { marginBottom: 12, paddingHorizontal: 4 },
+  dateText: { fontSize: 16, fontWeight: "bold" },
+  emptyText: { fontSize: 14, color: "#9CA3AF", textAlign: "center", paddingVertical: 24 },
+  timelineContent: { paddingTop: 4, paddingBottom: 32 },
+
+  row: { flexDirection: "row", alignItems: "flex-start", marginBottom: 16 },
+  lineCol: { width: 32, alignItems: "center" },
   circle: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    backgroundColor: "#00C853", // 초록색 포인트
-    borderWidth: 2,
-    borderColor: "#e0f2f1",
+    width: 10, height: 10, borderRadius: 5,
+    backgroundColor: "#00C853", borderWidth: 2, borderColor: "#e0f2f1",
   },
-  line: {
-    width: 2,
-    flex: 1,
-    backgroundColor: "#e0f2f1",
-    marginTop: 2,
-  },
-  cardWrap: {
-    flex: 1,
-  },
-  timeText: {
-    fontSize: 12,
-    color: "#888",
-    marginBottom: 6,
-  },
+  line: { width: 2, flex: 1, backgroundColor: "#e0f2f1", marginTop: 2 },
+
+  cardWrap: { flex: 1 },
+  timeText: { fontSize: 12, color: "#888", marginBottom: 6 },
   card: {
     borderRadius: 12,
     backgroundColor: "#ffffff",
@@ -156,14 +189,51 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.03,
     shadowRadius: 4,
     elevation: 1,
+    overflow: "hidden",
   },
-  titleText: {
-    fontSize: 14,
-    fontWeight: "bold",
-    marginBottom: 4,
+  titleText: { fontSize: 14, fontWeight: "bold", marginBottom: 10 },
+  detailText: { fontSize: 12, color: "#555", marginBottom: 2 },
+
+  // 공연자 리스트
+  performerList: { gap: 2 },
+  performerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    borderRadius: 8,
+    gap: 8,
   },
-  detailText: {
-    fontSize: 12,
-    color: "#555",
+  performerRowOpen: {
+    backgroundColor: "#F9FAFB",
   },
+  orderBadge: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: "#F3F4F6",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  orderText: { fontSize: 11, fontWeight: "700", color: "#6B7280" },
+  performerName: { flex: 1, fontSize: 13, fontWeight: "600", color: "#111827" },
+  genreBadge: {
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  genreText: { fontSize: 11, fontWeight: "600" },
+  chevron: { marginLeft: 2 },
+
+  // 셋리스트
+  setlistBox: {
+    marginLeft: 28,
+    marginBottom: 6,
+    paddingLeft: 10,
+    borderLeftWidth: 2,
+    gap: 5,
+  },
+  setlistRow: { flexDirection: "row", gap: 8, alignItems: "flex-start" },
+  setlistIndex: { fontSize: 11, color: "#9CA3AF", fontWeight: "600", minWidth: 14 },
+  setlistSong: { fontSize: 12, color: "#374151", flex: 1, lineHeight: 17 },
 });

--- a/frontend/types/event.ts
+++ b/frontend/types/event.ts
@@ -44,6 +44,12 @@ export interface EventNewsItem {
 }
 
 /** 타임테이블 한 건 (extraJson 내 timeline[]) */
+export interface PerformerItem {
+  name: string;
+  genre: string;
+  setlist: string[];
+}
+
 export interface EventTimelineItem {
   id: string;
   dateLabel?: string;
@@ -52,6 +58,7 @@ export interface EventTimelineItem {
   title: string;
   location?: string;
   details?: string[];
+  performers?: PerformerItem[];
 }
 
 /** 부스 한 건 (extraJson 내 foodBooths / experienceBooths) */


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->
축제 상세 데이터를 연동하고, 사용자가 행사 일정과 부스 위치를 직관적으로 확인할 수 있도록 상세 페이지 UI 및 배치도 컴포넌트를 구현
## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용

- [x] 'Gate to YEOJEONG' 시드 데이터 추가 (EventSeedRunner.java)
- [x] 상세 페이지 탭 컴포넌트 구현 (EventDetailTabs.tsx)
- [x] 타임라인 및 부스/푸드트럭 리스트 UI 적용 (Timeline.tsx, EventBoothTab.tsx)

## 체크리스트
- [x] 빌드가 에러 없이 수행되는가?
- [x] 불필요한 로그(console.log 등)는 없는가?
