### PR TITLE
fix: 행사 이미지 응답을 presigned URL → CloudFront 경로로 변경 

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/AdminUploadController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/AdminUploadController.java
@@ -2,6 +2,7 @@ package com.dailo.backend.controller;
 
 import com.dailo.backend.service.S3UploadService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +21,9 @@ public class AdminUploadController {
 
     private final S3UploadService s3UploadService;
 
+    @Value("${app.upload.static-base-path:/static}")
+    private String staticBasePath;
+
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Map<String, String>> upload(@RequestParam("file") MultipartFile file) {
         if (file == null || file.isEmpty()) {
@@ -32,7 +36,7 @@ public class AdminUploadController {
 
         try {
             String key = s3UploadService.upload(file, "admin");
-            String url = s3UploadService.getPresignedUrl(key);
+            String url = staticBasePath + "/" + key;
             return ResponseEntity.ok(Map.of("key", key, "url", url));
         } catch (IOException e) {
             return ResponseEntity.internalServerError().build();

--- a/backend/src/main/java/com/dailo/backend/service/S3UploadService.java
+++ b/backend/src/main/java/com/dailo/backend/service/S3UploadService.java
@@ -1,5 +1,6 @@
 package com.dailo.backend.service;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +35,18 @@ public class S3UploadService {
     @Value("${cloud.aws.s3.presigned-url-expiration-minutes}")
     private int presignedUrlExpirationMinutes;
 
+    @Value("${app.upload.static-base-path:/static}")
+    private String staticBasePath;
+
+    private String normalizedStaticBase;
+
+    @PostConstruct
+    void initStaticBase() {
+        normalizedStaticBase = staticBasePath.endsWith("/")
+                ? staticBasePath.substring(0, staticBasePath.length() - 1)
+                : staticBasePath;
+    }
+
     public String upload(MultipartFile file, String directory) throws IOException {
         String originalFilename = file.getOriginalFilename();
         String extension = getExtension(originalFilename);
@@ -63,7 +76,8 @@ public class S3UploadService {
     public String resolveUrl(String value) {
         if (value == null || value.isBlank()) return null;
         if (value.startsWith("http://") || value.startsWith("https://")) return value;
-        return getPresignedUrl(value);
+        if (value.startsWith("/")) return value;
+        return normalizedStaticBase + "/" + value;
     }
 
     public String getPresignedUrl(String key) {

--- a/backend/src/main/resources/static/api/admin/web/js/app.js
+++ b/backend/src/main/resources/static/api/admin/web/js/app.js
@@ -169,7 +169,7 @@ function openEventModal(id, data) {
   document.getElementById('eventFilter').value = data?.filterGroup || '';
   document.getElementById('eventDesc').value = data?.description || '';
   document.getElementById('eventContact').value = data?.hostContact || '';
-  document.getElementById('eventThumbKey').value = data?.thumbnailUrl || '';
+  document.getElementById('eventThumbKey').value = data?.thumbnailKey || data?.thumbnailUrl || '';
   const preview = document.getElementById('eventThumbPreview');
   const placeholder = document.getElementById('eventDropPlaceholder');
   if (data?.thumbnailUrl) {


### PR DESCRIPTION
- AdminUploadController: presigned URL 대신 /static/{key} 반환
- S3UploadService.resolveUrl(): S3 키를 CloudFront 정적 경로로 변환

매 요청마다 presigned URL 50개씩 서명 생성하던 부담 제거,
URL이 고정되어 클라이언트/CloudFront 캐시 동작 → 행사 리스트 조회 속도 개선