### PR TITLE
fix: S3 키 불일치로 이미지 조회 안 되던 버그 수정

### DIFF
--- a/backend/src/main/java/com/dailo/backend/controller/AdminUploadController.java
+++ b/backend/src/main/java/com/dailo/backend/controller/AdminUploadController.java
@@ -2,7 +2,6 @@ package com.dailo.backend.controller;
 
 import com.dailo.backend.service.S3UploadService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,9 +20,6 @@ public class AdminUploadController {
 
     private final S3UploadService s3UploadService;
 
-    @Value("${app.upload.static-base-path:/static}")
-    private String staticBasePath;
-
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Map<String, String>> upload(@RequestParam("file") MultipartFile file) {
         if (file == null || file.isEmpty()) {
@@ -36,7 +32,7 @@ public class AdminUploadController {
 
         try {
             String key = s3UploadService.upload(file, "admin");
-            String url = staticBasePath + "/" + key;
+            String url = "/" + key;
             return ResponseEntity.ok(Map.of("key", key, "url", url));
         } catch (IOException e) {
             return ResponseEntity.internalServerError().build();

--- a/backend/src/main/java/com/dailo/backend/dto/AdminEventResponse.java
+++ b/backend/src/main/java/com/dailo/backend/dto/AdminEventResponse.java
@@ -27,6 +27,7 @@ public class AdminEventResponse {
     private EventStatus status;
     /** 규모(지도·달력 마커 색상): CHUNGJU_CITY, UNIVERSITY, STUDENT_COUNCIL, COLLEGE, CLUB — 관리자 화면·지도 표시 일치용 */
     private String filterGroup;
+    private String thumbnailKey;
     private String thumbnailUrl;
     private String description;
     private String hostContact;
@@ -48,7 +49,7 @@ public class AdminEventResponse {
                 .categories(event.getCategories())
                 .status(event.getStatus())
                 .filterGroup(event.getFilterGroup())
-                .thumbnailUrl(event.getThumbnailUrl())
+                .thumbnailKey(event.getThumbnailUrl())
                 .description(event.getDescription())
                 .hostContact(event.getHostContact())
                 .isAdminManaged(event.isAdminManaged())

--- a/backend/src/main/java/com/dailo/backend/service/AdminEventService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AdminEventService.java
@@ -32,6 +32,7 @@ public class AdminEventService {
     private final EventHistoryRepository eventHistoryRepository;
     private final EventLikeRepository eventLikeRepository;
     private final ClickLogRepository clickLogRepository;
+    private final S3UploadService s3UploadService;
 
     // 행사 생성
     @Transactional // 쓰기 모드
@@ -120,17 +121,42 @@ public class AdminEventService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 행사를 찾을 수 없습니다. id=" + eventId));
 
-        return AdminEventResponse.from(event);
+        return resolveThumb(AdminEventResponse.from(event));
     }
 
     // 행사 목록 조회 (페이징, 키워드 없으면 전체)
     public Page<AdminEventResponse> getEventList(Pageable pageable, String keyword) {
         if (keyword != null && !keyword.isBlank()) {
             return eventRepository.searchByKeywordAdmin(keyword.trim(), pageable)
-                    .map(AdminEventResponse::from);
+                    .map(AdminEventResponse::from)
+                    .map(this::resolveThumb);
         }
         return eventRepository.findAll(pageable)
-                .map(AdminEventResponse::from);
+                .map(AdminEventResponse::from)
+                .map(this::resolveThumb);
+    }
+
+    private AdminEventResponse resolveThumb(AdminEventResponse r) {
+        return AdminEventResponse.builder()
+                .id(r.getId())
+                .title(r.getTitle())
+                .placeName(r.getPlaceName())
+                .placeAddress(r.getPlaceAddress())
+                .regionName(r.getRegionName())
+                .latitude(r.getLatitude())
+                .longitude(r.getLongitude())
+                .startAt(r.getStartAt())
+                .endAt(r.getEndAt())
+                .categories(r.getCategories())
+                .status(r.getStatus())
+                .filterGroup(r.getFilterGroup())
+                .thumbnailKey(r.getThumbnailKey())
+                .thumbnailUrl(s3UploadService.resolveUrl(r.getThumbnailKey()))
+                .description(r.getDescription())
+                .hostContact(r.getHostContact())
+                .isAdminManaged(r.isAdminManaged())
+                .extraJson(r.getExtraJson())
+                .build();
     }
 
     /** 행사별 좋아요 수 (관리자용) - 좋아요 많은 순 */

--- a/backend/src/main/java/com/dailo/backend/service/S3UploadService.java
+++ b/backend/src/main/java/com/dailo/backend/service/S3UploadService.java
@@ -1,6 +1,5 @@
 package com.dailo.backend.service;
 
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,18 +34,6 @@ public class S3UploadService {
     @Value("${cloud.aws.s3.presigned-url-expiration-minutes}")
     private int presignedUrlExpirationMinutes;
 
-    @Value("${app.upload.static-base-path:/static}")
-    private String staticBasePath;
-
-    private String normalizedStaticBase;
-
-    @PostConstruct
-    void initStaticBase() {
-        normalizedStaticBase = staticBasePath.endsWith("/")
-                ? staticBasePath.substring(0, staticBasePath.length() - 1)
-                : staticBasePath;
-    }
-
     public String upload(MultipartFile file, String directory) throws IOException {
         String originalFilename = file.getOriginalFilename();
         String extension = getExtension(originalFilename);
@@ -55,7 +42,8 @@ public class S3UploadService {
             throw new IllegalArgumentException("허용되지 않는 파일 형식입니다. (jpg, jpeg, png, gif, webp만 가능)");
         }
 
-        String key = directory + "/" + UUID.randomUUID() + "." + extension;
+        // CloudFront /static/* → S3 키 매칭을 위해 static/ 접두사 포함
+        String key = "static/" + directory + "/" + UUID.randomUUID() + "." + extension;
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
@@ -77,7 +65,10 @@ public class S3UploadService {
         if (value == null || value.isBlank()) return null;
         if (value.startsWith("http://") || value.startsWith("https://")) return value;
         if (value.startsWith("/")) return value;
-        return normalizedStaticBase + "/" + value;
+        // static/ 접두사가 포함된 키 → /static/... 경로로 변환 (CloudFront → S3 직접 매칭)
+        if (value.startsWith("static/")) return "/" + value;
+        // 레거시 키(접두사 없음) → presigned URL 폴백
+        return getPresignedUrl(value);
     }
 
     public String getPresignedUrl(String key) {


### PR DESCRIPTION
S3 업로드 키에 static/ 접두사를 포함시켜 CloudFront 경로와 S3 오브젝트 키가 일치하도록 수정. 레거시 키(접두사 없음)는 presigned URL로 폴백.
