### PR TITLE
구역 편집 - 오류 수정

### DIFF
--- a/frontend/app/(tabs)/mypage/admin-event-edit-detail.tsx
+++ b/frontend/app/(tabs)/mypage/admin-event-edit-detail.tsx
@@ -239,6 +239,14 @@ export default function AdminEventEditDetailScreen() {
 
   useFocusEffect(
     React.useCallback(() => {
+      // 존 픽커 결과 (위치 픽커 결과와 독립적으로 처리)
+      const zoneResult = getZonePickResult();
+      if (openedZonePickerRef.current && zoneResult) {
+        setZonePolygon(JSON.stringify(zoneResult.polygon));
+        clearZonePickResult();
+        openedZonePickerRef.current = false;
+      }
+
       const picked = getPickedLocation();
       if (!picked) return;
       if (picked.forArea === "food" || picked.forArea === "experience") {
@@ -276,12 +284,6 @@ export default function AdminEventEditDetailScreen() {
         reverseGeocode(picked.latitude, picked.longitude).then((addr) => {
           if (addr) setPlaceAddress(addr);
         });
-      }
-      const zoneResult = getZonePickResult();
-      if (openedZonePickerRef.current && zoneResult) {
-        setZonePolygon(JSON.stringify(zoneResult.polygon));
-        clearZonePickResult();
-        openedZonePickerRef.current = false;
       }
     }, [])
   );


### PR DESCRIPTION
## 개요
축제 구역 폴리곤 지도 표시, 관리자 행사 수정 오류 수정

## 관련 이슈
- Refs #

## 작업 내용
- [x] 축제 구역 폴리곤 지도 렌더링 수정 (NaverMap IIFE → useMemo 리팩터링)
- [x] 관리자 상세형 폼에서 구역 편집 결과 미반영 수정 (useFocusEffect 조기 return 문제)
- [x] 관리자 상세형 폼 수정 저장 시 Data integrity violation 수정 (posterUrls null 처리)

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [x] 불필요한 로그(console.log 등)는 없는가? (__DEV__ 조건부 로그만 존재)
