### PR TITLE
feat(booth): 배치도/목록 부스 UI 개선 및 스크롤 버그 수정

### DIFF
--- a/frontend/components/detail/BoothDetailModal.tsx
+++ b/frontend/components/detail/BoothDetailModal.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   StyleSheet,
   Pressable,
+  ScrollView,
   GestureResponderEvent,
   Linking,
   Modal,
@@ -123,72 +124,79 @@ export default function BoothDetailModal({
           )}
         </View>
 
-        {/* 내용 영역 */}
-        {booth.type === "food" && booth.menu && booth.menu.length > 0 && (
-          <>
-            <View style={styles.infoDivider} />
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>메뉴</Text>
-              {booth.menu.map((m) => (
-                <View key={m} style={styles.menuCard}>
-                  <Text style={styles.menuCardText}>{formatFoodMenuLine(m)}</Text>
+        {/* 내용 영역 — 스크롤 가능 */}
+        <ScrollView
+          style={styles.scrollBody}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {booth.type === "food" && booth.menu && booth.menu.length > 0 && (
+            <>
+              <View style={styles.infoDivider} />
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>메뉴</Text>
+                {booth.menu.map((m) => (
+                  <View key={m} style={styles.menuCard}>
+                    <Text style={styles.menuCardText}>{formatFoodMenuLine(m)}</Text>
+                  </View>
+                ))}
+              </View>
+            </>
+          )}
+
+          {booth.type === "experience" && (
+            <>
+              {booth.description && (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>이벤트 방식</Text>
+                  <Text style={styles.bodyText}>{booth.description}</Text>
                 </View>
-              ))}
+              )}
+              {booth.rules && booth.rules.length > 0 && (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>진행 규칙</Text>
+                  {booth.rules.map((r) => (
+                    <Text key={r} style={styles.bodyText}>
+                      • {r}
+                    </Text>
+                  ))}
+                </View>
+              )}
+              {booth.prizes && booth.prizes.length > 0 && (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>시상 및 상품 안내</Text>
+                  {booth.prizes.map((p) => (
+                    <Text key={p} style={styles.bodyText}>
+                      • {p}
+                    </Text>
+                  ))}
+                </View>
+              )}
+            </>
+          )}
+
+          {/* 외부 링크 (맨 아래) */}
+          {booth.externalLink && booth.externalLink.trim() && (
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>외부 링크</Text>
+              <Pressable
+                onPress={() => {
+                  const url = booth.externalLink!.trim();
+                  const toOpen = url.startsWith("http") ? url : `https://${url}`;
+                  Linking.openURL(toOpen).catch(() => {});
+                }}
+                style={styles.linkRow}
+              >
+                <Ionicons name="link" size={16} color="#4C8BF5" />
+                <Text style={styles.linkText} numberOfLines={1}>
+                  {booth.externalLink!.trim()}
+                </Text>
+                <Ionicons name="open-outline" size={14} color="#4C8BF5" />
+              </Pressable>
             </View>
-          </>
-        )}
-
-        {booth.type === "experience" && (
-          <>
-            {booth.description && (
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>이벤트 방식</Text>
-                <Text style={styles.bodyText}>{booth.description}</Text>
-              </View>
-            )}
-            {booth.rules && booth.rules.length > 0 && (
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>진행 규칙</Text>
-                {booth.rules.map((r) => (
-                  <Text key={r} style={styles.bodyText}>
-                    • {r}
-                  </Text>
-                ))}
-              </View>
-            )}
-            {booth.prizes && booth.prizes.length > 0 && (
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>시상 및 상품 안내</Text>
-                {booth.prizes.map((p) => (
-                  <Text key={p} style={styles.bodyText}>
-                    • {p}
-                  </Text>
-                ))}
-              </View>
-            )}
-          </>
-        )}
-
-        {/* 외부 링크 (맨 아래) */}
-        {booth.externalLink && booth.externalLink.trim() && (
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>외부 링크</Text>
-            <Pressable
-              onPress={() => {
-                const url = booth.externalLink!.trim();
-                const toOpen = url.startsWith("http") ? url : `https://${url}`;
-                Linking.openURL(toOpen).catch(() => {});
-              }}
-              style={styles.linkRow}
-            >
-              <Ionicons name="link" size={16} color="#4C8BF5" />
-              <Text style={styles.linkText} numberOfLines={1}>
-                {booth.externalLink!.trim()}
-              </Text>
-              <Ionicons name="open-outline" size={14} color="#4C8BF5" />
-            </Pressable>
-          </View>
-        )}
+          )}
+          <View style={styles.scrollBottomPad} />
+        </ScrollView>
         </View>
       </View>
     </Modal>
@@ -208,15 +216,23 @@ const styles = StyleSheet.create({
   },
   card: {
     width: "82%",
+    maxHeight: "78%",
     borderRadius: 20,
     backgroundColor: "#fff",
     paddingHorizontal: 20,
-    paddingVertical: 18,
+    paddingTop: 18,
+    paddingBottom: 0,
     shadowColor: "#000",
     shadowOpacity: 0.18,
     shadowOffset: { width: 0, height: 6 },
     shadowRadius: 12,
     elevation: 8,
+  },
+  scrollBody: {
+    flexGrow: 0,
+  },
+  scrollBottomPad: {
+    height: 18,
   },
   headerRow: {
     flexDirection: "row",

--- a/frontend/components/detail/BoothLayoutMap.tsx
+++ b/frontend/components/detail/BoothLayoutMap.tsx
@@ -1,9 +1,23 @@
-import React, { useState } from 'react';
+// frontend/components/detail/BoothLayoutMap.tsx
+
+import React, { useMemo, useState } from "react";
 import {
-  View, Text, StyleSheet, Pressable,
-  Modal, TouchableOpacity,
-} from 'react-native';
-import type { EventBoothItem } from '../../types/event';
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Modal,
+  ScrollView,
+  Linking,
+} from "react-native";
+import type { StyleProp, ViewStyle } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type { EventBoothItem } from "../../types/event";
+import {
+  getBoothVisual,
+  type BoothIconName,
+  type BoothKind,
+} from "../../utils/boothVisual";
 
 interface Props {
   foodBooths?: EventBoothItem[] | null;
@@ -12,352 +26,980 @@ interface Props {
   eventTitle?: string;
 }
 
-// 푸드트럭 = 주황 라인, 체험부스 = 파랑 라인, 배경은 모두 흰색
-const FOOD = { bg: '#FFFFFF', border: '#E8763A', text: '#C05E25' };
-const EXP  = { bg: '#FFFFFF', border: '#4D86CC', text: '#2D66AA' };
+const FOOD = {
+  border: "#E8763A",
+  chipBg: "#FFE7D8",
+  text: "#B85721",
+};
 
-type SelectedBooth = EventBoothItem & { colorType: 'food' | 'exp' };
+const EXP = {
+  border: "#4D86CC",
+  chipBg: "#E8F1FD",
+  text: "#2F63A7",
+};
 
-export default function BoothLayoutMap({ foodBooths, experienceBooths }: Props) {
+const CARD_HEIGHT = 78;
+const CARD_GAP = 10;
+const SECTION_HEADER_HEIGHT = 48;
+const SECTION_GAP = 34;
+
+type SelectedBooth = EventBoothItem & { colorType: BoothKind };
+
+function splitColumns<T>(items: T[]) {
+  const half = Math.ceil(items.length / 2);
+  return [items.slice(0, half), items.slice(half)];
+}
+
+function sectionHeight(rowCount: number) {
+  const rows = Math.max(rowCount, 1);
+  return (
+    SECTION_HEADER_HEIGHT +
+    rows * CARD_HEIGHT +
+    Math.max(rows - 1, 0) * CARD_GAP
+  );
+}
+
+function normalizeExternalLink(url: string) {
+  const trimmed = url.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed.startsWith("@")) return `https://instagram.com/${trimmed.slice(1)}`;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
+function MapLabel({
+  label,
+  subLabel,
+  icon,
+  backgroundColor,
+  borderColor,
+  textColor = "#374151",
+  style,
+}: {
+  label: string;
+  subLabel?: string;
+  icon?: BoothIconName;
+  backgroundColor: string;
+  borderColor: string;
+  textColor?: string;
+  style?: StyleProp<ViewStyle>;
+}) {
+  return (
+    <View style={[styles.mapLabel, { backgroundColor, borderColor }, style]}>
+      <View style={styles.mapLabelRow}>
+        {icon ? <Ionicons name={icon} size={14} color={textColor} /> : null}
+        <Text
+          style={[styles.mapLabelText, { color: textColor }]}
+          numberOfLines={2}
+        >
+          {label}
+        </Text>
+      </View>
+
+      {subLabel ? (
+        <Text
+          style={[styles.mapLabelSubText, { color: textColor }]}
+          numberOfLines={2}
+        >
+          {subLabel}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function BoothCard({
+  booth,
+  colorType,
+  spotCode,
+  onPress,
+}: {
+  booth: EventBoothItem;
+  colorType: BoothKind;
+  spotCode: string;
+  onPress: () => void;
+}) {
+  const theme = colorType === "food" ? FOOD : EXP;
+  const visual = getBoothVisual(booth, colorType);
+
+  return (
+    <Pressable
+      style={[styles.boothCard, { borderColor: theme.border }]}
+      onPress={onPress}
+    >
+      <View style={styles.boothCardTop}>
+        <View style={[styles.boothIconBubble, { backgroundColor: theme.chipBg }]}>
+          <Ionicons name={visual.icon} size={14} color={theme.text} />
+        </View>
+        <Text style={[styles.spotCode, { color: theme.text }]}>{spotCode}</Text>
+      </View>
+
+      <Text style={styles.boothName} numberOfLines={2}>
+        {booth.name}
+      </Text>
+
+      <Text style={[styles.boothCategory, { color: theme.text }]} numberOfLines={1}>
+        {visual.label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function DetailSection({ title, items }: { title: string; items: string[] }) {
+  if (!items || items.length === 0) return null;
+
+  return (
+    <View style={styles.detailSection}>
+      <Text style={styles.detailSectionTitle}>{title}</Text>
+      {items.map((item, idx) => (
+        <Text key={`${title}-${idx}`} style={styles.detailBullet}>
+          • {item}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+export default function BoothLayoutMap({
+  foodBooths,
+  experienceBooths,
+}: Props) {
   const [selected, setSelected] = useState<SelectedBooth | null>(null);
 
   const food = foodBooths ?? [];
-  const exp  = experienceBooths ?? [];
+  const exp = experienceBooths ?? [];
 
-  // 앞절반 = 왼쪽 열, 뒷절반 = 오른쪽 열
-  const foodMid = Math.ceil(food.length / 2);
-  const foodLeft  = food.slice(0, foodMid);
-  const foodRight = food.slice(foodMid);
+  const [foodLeft, foodRight] = useMemo(() => splitColumns(food), [food]);
+  const [expLeft, expRight] = useMemo(() => splitColumns(exp), [exp]);
 
-  const expMid = Math.ceil(exp.length / 2);
-  const expLeft  = exp.slice(0, expMid);
-  const expRight = exp.slice(expMid);
+  const foodRows = Math.max(foodLeft.length, foodRight.length, 1);
+  const expRows = Math.max(expLeft.length, expRight.length, 1);
 
-  function BoothCard({ booth, colorType }: { booth: EventBoothItem; colorType: 'food' | 'exp' }) {
-    const c = colorType === 'food' ? FOOD : EXP;
+  const foodHeight = sectionHeight(foodRows);
+  const expHeight = sectionHeight(expRows);
+
+  const foodTop = 82;
+  const expTop = foodTop + foodHeight + SECTION_GAP;
+  const canvasHeight = expTop + expHeight + 84;
+
+  const selectedTheme = selected?.colorType === "food" ? FOOD : EXP;
+  const selectedVisual = selected
+    ? getBoothVisual(selected, selected.colorType)
+    : null;
+
+  const openExternalLink = async () => {
+    if (!selected?.externalLink) return;
+
+    const url = normalizeExternalLink(selected.externalLink);
+
+    try {
+      const supported = await Linking.canOpenURL(url);
+      if (supported) await Linking.openURL(url);
+    } catch (e) {
+      console.warn("외부 링크 열기 실패", e);
+    }
+  };
+
+  const renderGrid = (
+    items: EventBoothItem[],
+    leftItems: EventBoothItem[],
+    rightItems: EventBoothItem[],
+    kind: BoothKind
+  ) => {
+    const prefix = kind === "food" ? "F" : "B";
+
+    if (items.length === 0) {
+      return (
+        <View style={styles.emptyArea}>
+          <Ionicons name="information-circle-outline" size={18} color="#94A3B8" />
+          <Text style={styles.emptyText}>
+            {kind === "food"
+              ? "등록된 푸드트럭 정보가 없습니다."
+              : "등록된 동아리 / 체험부스 정보가 없습니다."}
+          </Text>
+        </View>
+      );
+    }
+
     return (
-      <Pressable
-        style={[styles.boothCard, { borderColor: c.border }]}
-        onPress={() => setSelected({ ...booth, colorType })}
-      >
-        <Text style={styles.boothText} numberOfLines={2}>
-          {booth.name}
-        </Text>
-      </Pressable>
-    );
-  }
+      <View style={styles.gridRow}>
+        <View style={styles.gridColumn}>
+          {leftItems.map((booth, idx) => (
+            <BoothCard
+              key={`${kind}-left-${booth.id}-${idx}`}
+              booth={booth}
+              colorType={kind}
+              spotCode={`${prefix}${String(idx + 1).padStart(2, "0")}`}
+              onPress={() => setSelected({ ...booth, colorType: kind })}
+            />
+          ))}
+        </View>
 
-  // 한 열: 푸드트럭 → 구분 → 체험부스
-  function BoothColumn({ foodItems, expItems }: { foodItems: EventBoothItem[]; expItems: EventBoothItem[] }) {
-    return (
-      <View style={styles.column}>
-        {foodItems.map(b => <BoothCard key={b.id} booth={b} colorType="food" />)}
-        {foodItems.length > 0 && expItems.length > 0 && <View style={styles.sectionGap} />}
-        {expItems.map(b => <BoothCard key={b.id} booth={b} colorType="exp" />)}
+        <View style={styles.gridColumn}>
+          {rightItems.map((booth, idx) => (
+            <BoothCard
+              key={`${kind}-right-${booth.id}-${idx}`}
+              booth={booth}
+              colorType={kind}
+              spotCode={`${prefix}${String(leftItems.length + idx + 1).padStart(
+                2,
+                "0"
+              )}`}
+              onPress={() => setSelected({ ...booth, colorType: kind })}
+            />
+          ))}
+        </View>
       </View>
     );
-  }
-
-  function Tooltip() {
-    if (!selected) return null;
-    const isFood = selected.colorType === 'food';
-    const c = isFood ? FOOD : EXP;
-    return (
-      <View style={[styles.tooltipCard, { borderColor: c.border }]}>
-        <View style={[styles.tooltipHeader, { borderBottomColor: '#F3F4F6' }]}>
-          <Text style={styles.tooltipTitle}>{selected.name}</Text>
-          {selected.time && <Text style={styles.tooltipMeta}>운영시간: {selected.time}</Text>}
-          {selected.host && <Text style={styles.tooltipMeta}>주최: {selected.host}</Text>}
-        </View>
-        <View style={styles.tooltipBody}>
-          {!!selected.description && (
-            <Text style={styles.tooltipDesc}>{selected.description}</Text>
-          )}
-          {isFood && !!selected.menu?.length && (
-            <View style={styles.tooltipSection}>
-              <Text style={styles.tooltipSectionTitle}>메뉴</Text>
-              {selected.menu.map((item, i) => (
-                <Text key={i} style={styles.tooltipBullet}>• {item}</Text>
-              ))}
-            </View>
-          )}
-          {!isFood && !!selected.prizes?.length && (
-            <View style={styles.tooltipSection}>
-              <Text style={styles.tooltipSectionTitle}>시상 및 상품</Text>
-              {selected.prizes.map((item, i) => (
-                <Text key={i} style={styles.tooltipBullet}>• {item}</Text>
-              ))}
-            </View>
-          )}
-        </View>
-        <TouchableOpacity style={styles.tooltipClose} onPress={() => setSelected(null)}>
-          <Text style={styles.tooltipCloseText}>닫기</Text>
-        </TouchableOpacity>
-      </View>
-    );
-  }
+  };
 
   return (
     <>
-      {/* 범례 */}
-      <View style={styles.legend}>
-        <View style={styles.legendItem}>
-          <View style={[styles.legendDot, { backgroundColor: FOOD.border }]} />
-          <Text style={styles.legendLabel}>푸드트럭</Text>
-        </View>
-        <View style={styles.legendItem}>
-          <View style={[styles.legendDot, { backgroundColor: EXP.border }]} />
-          <Text style={styles.legendLabel}>체험부스</Text>
-        </View>
-        <View style={styles.legendItem}>
-          <View style={[styles.legendDot, { backgroundColor: '#9CA3AF' }]} />
-          <Text style={styles.legendLabel}>공간</Text>
+      <View style={styles.headerCard}>
+
+        <View style={styles.legendRow}>
+          <View style={styles.legendItem}>
+            <View style={[styles.legendDot, { backgroundColor: FOOD.border }]} />
+            <Text style={styles.legendText}>푸드트럭</Text>
+          </View>
+
+          <View style={styles.legendItem}>
+            <View style={[styles.legendDot, { backgroundColor: EXP.border }]} />
+            <Text style={styles.legendText}>동아리 / 체험부스</Text>
+          </View>
+
+          <View style={styles.legendItem}>
+            <View style={[styles.legendDot, { backgroundColor: "#94A3B8" }]} />
+            <Text style={styles.legendText}>시설 / 공간</Text>
+          </View>
         </View>
       </View>
 
-      {/* 지도 */}
-      <View style={styles.mapWrapper}>
-        <View style={styles.mapRow}>
+      <View style={[styles.mapCanvas, { height: canvasHeight }]}>
+        <View style={styles.baseGround} />
 
-          {/* 왼쪽: 피크닉존 + 동아리무대 */}
-          <View style={styles.leftArea}>
-            <View style={styles.picnicZone}>
-              <Text style={styles.picnicText}>피크닉존</Text>
+        <View style={styles.leftGreenArea} />
+        <View style={styles.mainRoad} />
+        <View style={styles.parkingArea} />
+
+        <View style={styles.topRoadJoint} />
+        <View style={styles.bottomRoadJoint} />
+        <View style={styles.roadCenterLine} />
+
+        <View style={styles.parkingTitleBox}>
+          <Ionicons name="car-outline" size={16} color="#64748B" />
+          <Text style={styles.parkingTitle}>주차장</Text>
+        </View>
+
+        {Array.from({ length: 13 }).map((_, idx) => (
+          <View
+            key={`parking-${idx}`}
+            style={[styles.parkingLine, { top: 92 + idx * 38 }]}
+          />
+        ))}
+
+        <View style={styles.crosswalk}>
+          {Array.from({ length: 8 }).map((_, idx) => (
+            <View key={`cw-${idx}`} style={styles.crosswalkLine} />
+          ))}
+        </View>
+
+        <MapLabel
+          label="중앙도서관"
+          subLabel="좌측 건물"
+          icon="library-outline"
+          backgroundColor="#F8FAFC"
+          borderColor="#D7DEE8"
+          style={styles.libraryLabel}
+        />
+
+        <MapLabel
+          label="피크닉존"
+          subLabel="잔디광장"
+          icon="leaf-outline"
+          backgroundColor="#EAF6E8"
+          borderColor="#B6D8AE"
+          textColor="#497342"
+          style={styles.picnicLabel}
+        />
+
+        <MapLabel
+          label="노천극장"
+          subLabel="동아리 무대"
+          icon="musical-notes-outline"
+          backgroundColor="#FFF6EE"
+          borderColor="#E9CDB8"
+          textColor="#8A5C4B"
+          style={styles.stageLabel}
+        />
+
+        <MapLabel
+          label="클린존"
+          icon="trash-outline"
+          backgroundColor="#F8FAFC"
+          borderColor="#D7DEE8"
+          style={styles.cleanZone}
+        />
+
+        <View style={[styles.roadSection, { top: foodTop, height: foodHeight }]}>
+          <View style={styles.sectionHeader}>
+            <View style={[styles.sectionChip, { backgroundColor: FOOD.chipBg }]}>
+              <Ionicons name="fast-food-outline" size={14} color={FOOD.text} />
+              <Text style={[styles.sectionChipText, { color: FOOD.text }]}>
+                푸드트럭 존
+              </Text>
             </View>
-            <View style={styles.stageBox}>
-              <Text style={styles.stageText}>동아리{'\n'}무대</Text>
-            </View>
+            <Text style={styles.sectionHint}>도로 상단 구간</Text>
           </View>
 
-          {/* 오른쪽: 클린존 + 두 부스 열 */}
-          <View style={styles.rightArea}>
-            {/* 클린존 - 두 열 사이 상단 */}
-            <View style={styles.cleanZoneRow}>
-              <View style={styles.cleanZone}>
-                <Text style={styles.cleanZoneText}>클린존</Text>
+          {renderGrid(food, foodLeft, foodRight, "food")}
+        </View>
+
+        <View style={[styles.zoneDivider, { top: expTop - 18 }]} />
+
+        <View style={[styles.roadSection, { top: expTop, height: expHeight }]}>
+          <View style={styles.sectionHeader}>
+            <View style={[styles.sectionChip, { backgroundColor: EXP.chipBg }]}>
+              <Ionicons name="people-outline" size={14} color={EXP.text} />
+              <Text style={[styles.sectionChipText, { color: EXP.text }]}>
+                동아리 / 체험부스 존
+              </Text>
+            </View>
+            <Text style={styles.sectionHint}>도로 하단 구간</Text>
+          </View>
+
+          {renderGrid(exp, expLeft, expRight, "experience")}
+        </View>
+
+        <View style={styles.bottomInfoCard}>
+          <Ionicons name="information-circle-outline" size={14} color="#64748B" />
+          <Text style={styles.bottomInfoText}>
+            부스를 탭하면 운영시간, 메뉴, 설명 등 상세 정보를 확인할 수 있어요.
+          </Text>
+        </View>
+      </View>
+
+      <Modal
+        visible={!!selected}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setSelected(null)}
+      >
+        <View style={styles.overlay}>
+          <Pressable style={StyleSheet.absoluteFill} onPress={() => setSelected(null)} />
+          {selected && selectedVisual ? (
+              <View style={[styles.modalCard, { borderColor: selectedTheme.border }]}>
+                <View style={styles.modalHeader}>
+                  <View style={styles.modalHeaderTop}>
+                    <View
+                      style={[
+                        styles.modalTypeChip,
+                        {
+                          backgroundColor: selectedTheme.chipBg,
+                          borderColor: selectedTheme.border,
+                        },
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.modalTypeChipText,
+                          { color: selectedTheme.text },
+                        ]}
+                      >
+                        {selected.colorType === "food"
+                          ? "푸드트럭"
+                          : "동아리 / 체험부스"}
+                      </Text>
+                    </View>
+
+                    <Pressable onPress={() => setSelected(null)} hitSlop={8}>
+                      <Ionicons name="close" size={24} color="#6B7280" />
+                    </Pressable>
+                  </View>
+
+                  <View style={styles.modalTitleRow}>
+                    <View
+                      style={[
+                        styles.modalVisualBubble,
+                        { backgroundColor: selectedTheme.chipBg },
+                      ]}
+                    >
+                      <Ionicons name={selectedVisual.icon} size={30} color={selectedTheme.text} />
+                    </View>
+
+                    <View style={styles.modalTitleTextArea}>
+                      <Text style={styles.modalTitle}>{selected.name}</Text>
+                      <Text
+                        style={[
+                          styles.modalCategory,
+                          { color: selectedTheme.text },
+                        ]}
+                      >
+                        {selectedVisual.label}
+                      </Text>
+                    </View>
+                  </View>
+
+                  <View style={styles.metaList}>
+                    {selected.time ? (
+                      <View style={styles.metaRow}>
+                        <Ionicons name="time-outline" size={15} color="#6B7280" />
+                        <Text style={styles.metaText}>운영시간: {selected.time}</Text>
+                      </View>
+                    ) : null}
+
+                    {selected.host ? (
+                      <View style={styles.metaRow}>
+                        <Ionicons name="person-outline" size={15} color="#6B7280" />
+                        <Text style={styles.metaText}>운영주체: {selected.host}</Text>
+                      </View>
+                    ) : null}
+
+                    {selected.locationLabel ? (
+                      <View style={styles.metaRow}>
+                        <Ionicons name="location-outline" size={15} color="#6B7280" />
+                        <Text style={styles.metaText}>위치: {selected.locationLabel}</Text>
+                      </View>
+                    ) : null}
+                  </View>
+                </View>
+
+                <ScrollView
+                  style={styles.modalBody}
+                  contentContainerStyle={styles.modalBodyContent}
+                  showsVerticalScrollIndicator={false}
+                >
+                  {selected.description ? (
+                    <View style={styles.detailSection}>
+                      <Text style={styles.detailSectionTitle}>소개</Text>
+                      <Text style={styles.detailDescription}>
+                        {selected.description}
+                      </Text>
+                    </View>
+                  ) : null}
+
+                  {selected.menu && selected.menu.length > 0 ? (
+                    <DetailSection title="메뉴" items={selected.menu} />
+                  ) : null}
+
+                  {selected.rules && selected.rules.length > 0 ? (
+                    <DetailSection
+                      title="참여 방법 / 유의사항"
+                      items={selected.rules}
+                    />
+                  ) : null}
+
+                  {selected.prizes && selected.prizes.length > 0 ? (
+                    <DetailSection title="상품 / 혜택" items={selected.prizes} />
+                  ) : null}
+                </ScrollView>
+
+                <View style={styles.modalFooter}>
+                  {selected.externalLink ? (
+                    <Pressable
+                      style={[styles.modalButton, styles.modalButtonLight]}
+                      onPress={openExternalLink}
+                    >
+                      <Ionicons name="open-outline" size={15} color="#374151" />
+                      <Text style={styles.modalButtonLightText}>외부 링크</Text>
+                    </Pressable>
+                  ) : null}
+
+                  <Pressable
+                    style={[styles.modalButton, styles.modalButtonPrimary]}
+                    onPress={() => setSelected(null)}
+                  >
+                    <Text style={styles.modalButtonPrimaryText}>닫기</Text>
+                  </Pressable>
+                </View>
               </View>
-            </View>
-
-            {/* 두 부스 열 */}
-            <View style={styles.boothsArea}>
-              <BoothColumn foodItems={foodLeft} expItems={expLeft} />
-              <View style={styles.columnDivider} />
-              <BoothColumn foodItems={foodRight} expItems={expRight} />
-            </View>
-          </View>
-
+          ) : null}
         </View>
-      </View>
-
-      <Text style={styles.tapHint}>부스를 탭하면 상세 정보를 볼 수 있어요</Text>
-
-      {/* 툴팁 오버레이 */}
-      <Modal visible={!!selected} transparent animationType="fade" onRequestClose={() => setSelected(null)}>
-        <TouchableOpacity style={styles.overlay} activeOpacity={1} onPress={() => setSelected(null)}>
-          <TouchableOpacity activeOpacity={1}>
-            <Tooltip />
-          </TouchableOpacity>
-        </TouchableOpacity>
       </Modal>
     </>
   );
 }
 
 const styles = StyleSheet.create({
-  legend: { flexDirection: 'row', gap: 14, marginBottom: 10 },
-  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 4 },
-  legendDot: { width: 10, height: 10, borderRadius: 5 },
-  legendLabel: { fontSize: 11, color: '#6B7280' },
-
-  mapWrapper: {
-    borderRadius: 12,
+  headerCard: {
+    marginTop: 6,
+    marginBottom: 12,
+    padding: 14,
+    borderRadius: 18,
+    backgroundColor: "#FFFFFF",
     borderWidth: 1,
-    borderColor: '#E5E7EB',
-    backgroundColor: '#F9FAFB',
-    overflow: 'hidden',
-    paddingBottom: 4,
+    borderColor: "#E5E7EB",
+    gap: 12,
   },
-
-  mapRow: {
-    flexDirection: 'row',
-    padding: 8,
-    gap: 8,
-  },
-
-  // 왼쪽 랜드마크 (피크닉존 + 동아리무대)
-  leftArea: {
-    width: 66,
-    gap: 6,
-  },
-  picnicZone: {
-    flex: 1,
-    backgroundColor: '#F3F4F6',
-    borderRadius: 12,
-    borderWidth: 1.5,
-    borderColor: '#D1D5DB',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 6,
-  },
-  picnicText: {
-    fontSize: 11,
-    fontWeight: '700',
-    color: '#6B7280',
-    textAlign: 'center',
-  },
-  stageBox: {
-    flex: 1,
-    backgroundColor: '#F3F4F6',
-    borderRadius: 10,
-    borderWidth: 1.5,
-    borderColor: '#D1D5DB',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 8,
-    paddingHorizontal: 4,
-  },
-  stageText: {
-    fontSize: 10,
-    fontWeight: '700',
-    color: '#6B7280',
-    textAlign: 'center',
-  },
-
-  // 오른쪽 부스 영역
-  rightArea: {
-    flex: 1,
-    gap: 4,
-  },
-  cleanZoneRow: {
-    alignItems: 'center',
-  },
-  cleanZone: {
-    backgroundColor: '#F3F4F6',
-    borderRadius: 8,
-    borderWidth: 1.5,
-    borderColor: '#D1D5DB',
-    paddingVertical: 5,
-    paddingHorizontal: 16,
-  },
-  cleanZoneText: {
-    fontSize: 10,
-    fontWeight: '700',
-    color: '#6B7280',
-  },
-
-  // 두 부스 열
-  boothsArea: {
-    flexDirection: 'row',
-    gap: 4,
-  },
-  column: {
-    flex: 1,
-    gap: 3,
-  },
-  columnDivider: {
-    width: 1,
-    backgroundColor: '#E5E7EB',
-  },
-  sectionGap: {
-    height: 5,
-    backgroundColor: '#E5E7EB',
-    borderRadius: 1,
-  },
-
-  // 부스 카드
-  boothCard: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 10,
-    borderWidth: 1.5,
-    paddingVertical: 10,
-    paddingHorizontal: 4,
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 52,
-  },
-  boothText: {
-    fontSize: 12,
-    fontWeight: '700',
-    color: '#111827',
-    textAlign: 'center',
-    lineHeight: 16,
-  },
-
-  tapHint: {
-    textAlign: 'center',
-    fontSize: 11,
-    color: '#9CA3AF',
-    marginTop: 10,
-  },
-
-  // 툴팁
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 24,
-  },
-  tooltipCard: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 16,
-    borderWidth: 2,
-    width: '100%',
-    maxWidth: 340,
-    overflow: 'hidden',
-    shadowColor: '#000',
-    shadowOpacity: 0.15,
-    shadowOffset: { width: 0, height: 4 },
-    shadowRadius: 12,
-    elevation: 8,
-  },
-  tooltipHeader: {
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    borderBottomWidth: 1,
-  },
-  tooltipTitle: {
-    fontSize: 16,
-    fontWeight: '800',
-    color: '#111827',
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: "900",
+    color: "#111827",
     marginBottom: 4,
   },
-  tooltipMeta: {
+  headerSubtitle: {
     fontSize: 12,
-    color: '#6B7280',
-    marginTop: 2,
+    lineHeight: 18,
+    color: "#6B7280",
   },
-  tooltipBody: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    gap: 8,
+  legendRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 14,
   },
-  tooltipDesc: {
-    fontSize: 13,
-    color: '#374151',
-    lineHeight: 19,
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
   },
-  tooltipSection: { gap: 4 },
-  tooltipSectionTitle: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 2,
+  legendDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 999,
   },
-  tooltipBullet: {
+  legendText: {
     fontSize: 12,
-    color: '#4B5563',
+    color: "#6B7280",
+    fontWeight: "700",
+  },
+
+  mapCanvas: {
+    position: "relative",
+    overflow: "hidden",
+    borderRadius: 22,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    backgroundColor: "#F8FAFC",
+  },
+  baseGround: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "#F8FAFC",
+  },
+
+  leftGreenArea: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    bottom: 0,
+    width: "25%",
+    backgroundColor: "#EAF6E8",
+  },
+  mainRoad: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: "25%",
+    width: "58%",
+    backgroundColor: "#D1D7DF",
+  },
+  parkingArea: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    right: 0,
+    width: "17%",
+    backgroundColor: "#E8EDF3",
+  },
+  topRoadJoint: {
+    position: "absolute",
+    top: 0,
+    left: "25%",
+    width: "58%",
+    height: 46,
+    backgroundColor: "#BFC7D1",
+  },
+  bottomRoadJoint: {
+    position: "absolute",
+    bottom: 0,
+    left: "25%",
+    width: "58%",
+    height: 46,
+    backgroundColor: "#BFC7D1",
+  },
+  roadCenterLine: {
+    position: "absolute",
+    top: 20,
+    bottom: 20,
+    left: "54%",
+    width: 3,
+    backgroundColor: "rgba(255,255,255,0.68)",
+  },
+
+  parkingTitleBox: {
+    position: "absolute",
+    top: 56,
+    right: "2.5%",
+    width: "12%",
+    paddingVertical: 8,
+    borderRadius: 14,
+    backgroundColor: "rgba(255,255,255,0.72)",
+    alignItems: "center",
+    gap: 2,
+  },
+  parkingTitle: {
+    fontSize: 10.5,
+    fontWeight: "900",
+    color: "#64748B",
+  },
+  parkingLine: {
+    position: "absolute",
+    right: "3%",
+    width: "11%",
+    height: 1.2,
+    backgroundColor: "rgba(255,255,255,0.95)",
+  },
+
+  crosswalk: {
+    position: "absolute",
+    left: "39%",
+    bottom: 18,
+    width: "32%",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  crosswalkLine: {
+    width: 7,
+    height: 22,
+    backgroundColor: "#FFFFFF",
+    borderRadius: 2,
+  },
+
+  mapLabel: {
+    position: "absolute",
+    borderWidth: 1.2,
+    borderRadius: 16,
+    paddingHorizontal: 9,
+    paddingVertical: 9,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 4,
+    elevation: 1,
+    overflow: "hidden",
+  },
+  mapLabelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    flexWrap: "wrap",
+  },
+  mapLabelText: {
+    fontSize: 10.5,
+    fontWeight: "900",
+    lineHeight: 14,
+    flexShrink: 1,
+  },
+  mapLabelSubText: {
+    marginTop: 3,
+    fontSize: 9.3,
+    fontWeight: "700",
+    lineHeight: 12,
+    opacity: 0.85,
+  },
+
+  libraryLabel: {
+    top: 22,
+    left: 10,
+    width: "21%",
+  },
+  picnicLabel: {
+    top: 154,
+    left: 14,
+    width: "19%",
+    minHeight: 92,
+    justifyContent: "center",
+  },
+  stageLabel: {
+    top: 1000,
+    left: 9,
+    width: "22%",
+    minHeight: 96,
+    justifyContent: "center",
+  },
+  cleanZone: {
+    top: 110,
+    left: "4%",
+    borderRadius: 999,
+    paddingHorizontal: 11,
+    paddingVertical: 7,
+  },
+
+  roadSection: {
+    position: "absolute",
+    left: "31%",
+    width: "46%",
+  },
+  sectionHeader: {
+    height: SECTION_HEADER_HEIGHT,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+  },
+  sectionChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  sectionChipText: {
+    fontSize: 12,
+    fontWeight: "900",
+  },
+  sectionHint: {
+    fontSize: 10.5,
+    color: "#64748B",
+    fontWeight: "700",
+  },
+
+  gridRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  gridColumn: {
+    flex: 1,
+    gap: CARD_GAP,
+  },
+
+  boothCard: {
+    height: CARD_HEIGHT,
+    borderRadius: 17,
+    borderWidth: 2,
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 8,
+    paddingVertical: 7,
+    justifyContent: "space-between",
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 3,
+    elevation: 1,
+  },
+  boothCardTop: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  boothIconBubble: {
+    width: 27,
+    height: 27,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  spotCode: {
+    fontSize: 10,
+    fontWeight: "900",
+  },
+  boothName: {
+    fontSize: 11,
+    fontWeight: "900",
+    color: "#111827",
+    textAlign: "center",
+    lineHeight: 14,
+  },
+  boothCategory: {
+    fontSize: 10,
+    fontWeight: "800",
+    textAlign: "center",
+  },
+
+  zoneDivider: {
+    position: "absolute",
+    left: "30%",
+    width: "48%",
+    height: 1,
+    backgroundColor: "rgba(255,255,255,0.85)",
+  },
+
+  emptyArea: {
+    minHeight: 120,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderColor: "#CBD5E1",
+    backgroundColor: "rgba(255,255,255,0.68)",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+  },
+  emptyText: {
+    fontSize: 12,
+    color: "#94A3B8",
+    fontWeight: "700",
+    textAlign: "center",
     lineHeight: 18,
   },
-  tooltipClose: {
-    borderTopWidth: 1,
-    borderTopColor: '#F3F4F6',
-    paddingVertical: 12,
-    alignItems: 'center',
+
+  bottomInfoCard: {
+    position: "absolute",
+    left: 12,
+    right: 12,
+    bottom: 10,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    backgroundColor: "rgba(255,255,255,0.92)",
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
   },
-  tooltipCloseText: {
+  bottomInfoText: {
+    flex: 1,
+    fontSize: 11,
+    lineHeight: 16,
+    color: "#64748B",
+    fontWeight: "700",
+  },
+
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(17, 24, 39, 0.45)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 20,
+  },
+  modalCard: {
+    width: "88%",
+    maxWidth: 420,
+    maxHeight: "82%",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 22,
+    borderWidth: 2,
+    overflow: "hidden",
+    shadowColor: "#000",
+    shadowOpacity: 0.16,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  modalHeader: {
+    paddingHorizontal: 22,
+    paddingTop: 18,
+    paddingBottom: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: "#F1F5F9",
+  },
+  modalHeaderTop: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  modalTypeChip: {
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderWidth: 1,
+  },
+  modalTypeChipText: {
+    fontSize: 12,
+    fontWeight: "800",
+  },
+  modalTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    marginTop: 16,
+    marginBottom: 14,
+  },
+  modalVisualBubble: {
+    width: 62,
+    height: 62,
+    borderRadius: 22,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalTitleTextArea: {
+    flex: 1,
+    minWidth: 0,
+  },
+  modalTitle: {
+    fontSize: 23,
+    fontWeight: "900",
+    color: "#111827",
+    marginBottom: 5,
+    lineHeight: 28,
+  },
+  modalCategory: {
     fontSize: 14,
-    fontWeight: '700',
-    color: '#374151',
+    fontWeight: "900",
+  },
+  metaList: {
+    gap: 8,
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 7,
+  },
+  metaText: {
+    flex: 1,
+    fontSize: 14,
+    color: "#6B7280",
+    lineHeight: 20,
+  },
+
+  modalBody: {
+    maxHeight: 360,
+  },
+  modalBodyContent: {
+    paddingHorizontal: 22,
+    paddingVertical: 18,
+    gap: 18,
+  },
+  detailSection: {
+    gap: 9,
+  },
+  detailSectionTitle: {
+    fontSize: 17,
+    fontWeight: "900",
+    color: "#111827",
+  },
+  detailDescription: {
+    fontSize: 15,
+    lineHeight: 23,
+    color: "#4B5563",
+  },
+  detailBullet: {
+    fontSize: 15,
+    lineHeight: 23,
+    color: "#4B5563",
+  },
+
+  modalFooter: {
+    paddingHorizontal: 22,
+    paddingVertical: 16,
+    borderTopWidth: 1,
+    borderTopColor: "#F1F5F9",
+    gap: 10,
+  },
+  modalButton: {
+    width: "100%",
+    minHeight: 56,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "row",
+    gap: 6,
+  },
+  modalButtonLight: {
+    backgroundColor: "#F3F4F6",
+  },
+  modalButtonPrimary: {
+    backgroundColor: "#111827",
+  },
+  modalButtonLightText: {
+    color: "#374151",
+    fontWeight: "800",
+    fontSize: 14,
+  },
+  modalButtonPrimaryText: {
+    color: "#FFFFFF",
+    fontWeight: "900",
+    fontSize: 16,
   },
 });

--- a/frontend/components/detail/EventBoothTab.tsx
+++ b/frontend/components/detail/EventBoothTab.tsx
@@ -1,12 +1,21 @@
 // frontend/components/detail/EventBoothTab.tsx
 
 import React, { useState, useEffect, useCallback } from "react";
-import { View, Text, StyleSheet, Pressable, Platform, ToastAndroid, Alert } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Platform,
+  ToastAndroid,
+  Alert,
+} from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import BoothMap from "./BoothMap";
 import BoothDetailModal from "./BoothDetailModal";
 import BoothLayoutMap from "./BoothLayoutMap";
 import type { EventBoothItem } from "../../types/event";
+import { getBoothVisual } from "../../utils/boothVisual";
 import * as boothFavoriteService from "../../services/boothFavorite.service";
 
 export type BoothType = "food" | "experience";
@@ -44,20 +53,27 @@ export default function EventBoothTab({
   experienceArea = null,
 }: EventBoothTabProps = {}) {
   const [boothType, setBoothType] = useState<BoothType>("food");
-  const [mode, setMode] = useState<Mode>("list");
+  const [mode, setMode] = useState<Mode>("layout");
   const [selectedBooth, setSelectedBooth] = useState<Booth | null>(null);
   const [favoriteSet, setFavoriteSet] = useState<Set<string>>(new Set());
 
   const food = foodBooths && foodBooths.length > 0 ? foodBooths : [];
-  const experience = experienceBooths && experienceBooths.length > 0 ? experienceBooths : [];
+  const experience =
+    experienceBooths && experienceBooths.length > 0 ? experienceBooths : [];
   const booths = (boothType === "food" ? food : experience) as Booth[];
 
   /** 위치 보기 지도 중심: 선택한 타입(푸드/체험) 영역 위치 또는 행사 장소 */
   const mapCenter =
     mode === "map"
       ? boothType === "food"
-        ? foodArea ?? (eventLatitude != null && eventLongitude != null ? { latitude: eventLatitude, longitude: eventLongitude } : null)
-        : experienceArea ?? (eventLatitude != null && eventLongitude != null ? { latitude: eventLatitude, longitude: eventLongitude } : null)
+        ? foodArea ??
+          (eventLatitude != null && eventLongitude != null
+            ? { latitude: eventLatitude, longitude: eventLongitude }
+            : null)
+        : experienceArea ??
+          (eventLatitude != null && eventLongitude != null
+            ? { latitude: eventLatitude, longitude: eventLongitude }
+            : null)
       : null;
 
   const loadFavorites = useCallback(async () => {
@@ -81,47 +97,99 @@ export default function EventBoothTab({
   const handleToggleFavorite = useCallback(
     async (booth: Booth) => {
       if (eventId == null) return;
+
       const item: boothFavoriteService.BoothFavoriteItem = {
         eventId,
         eventTitle,
         boothName: booth.name,
         boothType: booth.type,
       };
+
       const added = await boothFavoriteService.toggleBoothFavorite(item);
       await loadFavorites();
+
       if (Platform.OS === "android") {
         ToastAndroid.show(
           added ? "부스를 즐겨찾기에 추가했어요" : "즐겨찾기를 해제했어요",
           ToastAndroid.SHORT
         );
       } else {
-        Alert.alert(added ? "부스를 즐겨찾기에 추가했어요" : "즐겨찾기를 해제했어요");
+        Alert.alert(
+          added ? "부스를 즐겨찾기에 추가했어요" : "즐겨찾기를 해제했어요"
+        );
       }
     },
     [eventId, eventTitle, loadFavorites]
   );
 
   return (
-    <View>
-      {/* 모드 토글 (배치도 / 목록) — 배치도 모드에서는 푸드트럭/체험부스 세그먼트 숨김 */}
-      <View style={styles.modeToggleRow}>
+    <View style={styles.container}>
+      {/* 모드 토글 */}
+      <View style={styles.modeToggleWrap}>
         <Pressable
-          style={[styles.modeToggleBtn, mode === "layout" && styles.modeToggleBtnActive]}
+          style={[
+            styles.modeToggleBtn,
+            mode === "layout" && styles.modeToggleBtnActive,
+          ]}
           onPress={() => setMode("layout")}
         >
-          <Text style={[styles.modeToggleText, mode === "layout" && styles.modeToggleTextActive]}>배치도</Text>
+          <Ionicons
+            name="grid-outline"
+            size={15}
+            color={mode === "layout" ? "#FFFFFF" : "#6B7280"}
+          />
+          <Text
+            style={[
+              styles.modeToggleText,
+              mode === "layout" && styles.modeToggleTextActive,
+            ]}
+          >
+            배치도
+          </Text>
         </Pressable>
+
         <Pressable
-          style={[styles.modeToggleBtn, mode === "list" && styles.modeToggleBtnActive]}
+          style={[
+            styles.modeToggleBtn,
+            mode === "list" && styles.modeToggleBtnActive,
+          ]}
           onPress={() => setMode("list")}
         >
-          <Text style={[styles.modeToggleText, mode === "list" && styles.modeToggleTextActive]}>목록</Text>
+          <Ionicons
+            name="list-outline"
+            size={15}
+            color={mode === "list" ? "#FFFFFF" : "#6B7280"}
+          />
+          <Text
+            style={[
+              styles.modeToggleText,
+              mode === "list" && styles.modeToggleTextActive,
+            ]}
+          >
+            목록
+          </Text>
         </Pressable>
+
         <Pressable
-          style={[styles.modeToggleBtn, mode === "map" && styles.modeToggleBtnActive]}
+          style={[
+            styles.modeToggleBtn,
+            mode === "map" && styles.modeToggleBtnActive,
+          ]}
           onPress={() => setMode("map")}
         >
-          <Text style={[styles.modeToggleText, mode === "map" && styles.modeToggleTextActive]}>위치</Text>
+          <Ionicons
+            name="location-outline"
+            size={15}
+            color={mode === "map" ? "#FFFFFF" : "#6B7280"}
+          />
+          <Text
+            style={[
+              styles.modeToggleText,
+              mode === "map" && styles.modeToggleTextActive,
+            ]}
+          >
+            위치
+          </Text>
         </Pressable>
       </View>
 
@@ -138,21 +206,42 @@ export default function EventBoothTab({
       {/* 위치 모드 */}
       {mode === "map" && (
         <>
-          {/* 푸드트럭/체험부스 세그먼트 */}
           <View style={styles.segmentContainer}>
             <Pressable
-              style={[styles.segmentItem, boothType === "food" && styles.segmentItemActive]}
+              style={[
+                styles.segmentItem,
+                boothType === "food" && styles.segmentItemActive,
+              ]}
               onPress={() => setBoothType("food")}
             >
-              <Text style={[styles.segmentText, boothType === "food" && styles.segmentTextActive]}>푸드트럭</Text>
+              <Text
+                style={[
+                  styles.segmentText,
+                  boothType === "food" && styles.segmentTextActive,
+                ]}
+              >
+                푸드트럭
+              </Text>
             </Pressable>
+
             <Pressable
-              style={[styles.segmentItem, boothType === "experience" && styles.segmentItemActive]}
+              style={[
+                styles.segmentItem,
+                boothType === "experience" && styles.segmentItemActive,
+              ]}
               onPress={() => setBoothType("experience")}
             >
-              <Text style={[styles.segmentText, boothType === "experience" && styles.segmentTextActive]}>체험부스</Text>
+              <Text
+                style={[
+                  styles.segmentText,
+                  boothType === "experience" && styles.segmentTextActive,
+                ]}
+              >
+                체험부스
+              </Text>
             </Pressable>
           </View>
+
           <BoothMap
             centerLatitude={mapCenter?.latitude}
             centerLongitude={mapCenter?.longitude}
@@ -163,58 +252,129 @@ export default function EventBoothTab({
       {/* 목록 모드 */}
       {mode === "list" && (
         <>
-          {/* 푸드트럭/체험부스 세그먼트 */}
           <View style={styles.segmentContainer}>
             <Pressable
-              style={[styles.segmentItem, boothType === "food" && styles.segmentItemActive]}
+              style={[
+                styles.segmentItem,
+                boothType === "food" && styles.segmentItemActive,
+              ]}
               onPress={() => setBoothType("food")}
             >
-              <Text style={[styles.segmentText, boothType === "food" && styles.segmentTextActive]}>푸드트럭</Text>
+              <Text
+                style={[
+                  styles.segmentText,
+                  boothType === "food" && styles.segmentTextActive,
+                ]}
+              >
+                푸드트럭
+              </Text>
             </Pressable>
+
             <Pressable
-              style={[styles.segmentItem, boothType === "experience" && styles.segmentItemActive]}
+              style={[
+                styles.segmentItem,
+                boothType === "experience" && styles.segmentItemActive,
+              ]}
               onPress={() => setBoothType("experience")}
             >
-              <Text style={[styles.segmentText, boothType === "experience" && styles.segmentTextActive]}>체험부스</Text>
+              <Text
+                style={[
+                  styles.segmentText,
+                  boothType === "experience" && styles.segmentTextActive,
+                ]}
+              >
+                체험부스
+              </Text>
             </Pressable>
           </View>
+
           <View style={styles.listWrapper}>
             {booths.length === 0 ? (
-              <Text style={styles.emptyText}>등록된 부스가 없습니다.</Text>
+              <View style={styles.emptyCard}>
+                <Ionicons
+                  name="information-circle-outline"
+                  size={22}
+                  color="#9CA3AF"
+                />
+                <Text style={styles.emptyText}>등록된 부스가 없습니다.</Text>
+              </View>
             ) : (
-              booths.map((booth) => (
-                <Pressable
-                  key={booth.id}
-                  style={styles.boothCard}
-                  onPress={() => setSelectedBooth(booth)}
-                >
-                  <View style={[
-                    styles.iconPlaceholder,
-                    boothType === "food"
-                      ? { backgroundColor: "#FEF0E6" }
-                      : { backgroundColor: "#EBF3FB" },
-                  ]} />
-                  <View style={{ flex: 1 }}>
-                    <Text style={styles.boothName}>{booth.name}</Text>
-                    <Text style={styles.boothLocation}>{booth.locationLabel ?? ""}</Text>
-                  </View>
-                  {eventId != null ? (
-                    <Pressable
-                      hitSlop={8}
-                      onPress={(e) => { e.stopPropagation?.(); handleToggleFavorite(booth); }}
-                      style={styles.starButton}
+              booths.map((booth) => {
+                const visual = getBoothVisual(booth, boothType);
+                const isFood = boothType === "food";
+
+                return (
+                  <Pressable
+                    key={booth.id}
+                    style={styles.boothCard}
+                    onPress={() => setSelectedBooth(booth)}
+                  >
+                    <View
+                      style={[
+                        styles.iconPlaceholder,
+                        isFood
+                          ? styles.foodIconPlaceholder
+                          : styles.expIconPlaceholder,
+                      ]}
                     >
                       <Ionicons
-                        name={isFavorite(booth) ? "star" : "star-outline"}
-                        size={24}
-                        color={isFavorite(booth) ? "#EAB308" : "#D1D5DB"}
+                        name={visual.icon}
+                        size={22}
+                        color={isFood ? "#B85721" : "#2F63A7"}
                       />
-                    </Pressable>
-                  ) : (
-                    <Ionicons name="star-outline" size={24} color="#D1D5DB" />
-                  )}
-                </Pressable>
-              ))
+                    </View>
+
+                    <View style={styles.boothTextArea}>
+                      <Text style={styles.boothName} numberOfLines={1}>
+                        {booth.name}
+                      </Text>
+
+                      <View style={styles.boothMetaRow}>
+                        <Text
+                          style={[
+                            styles.categoryChip,
+                            isFood
+                              ? styles.foodCategoryChip
+                              : styles.expCategoryChip,
+                          ]}
+                          numberOfLines={1}
+                        >
+                          {visual.label}
+                        </Text>
+
+                        {!!booth.locationLabel && (
+                          <Text style={styles.boothLocation} numberOfLines={1}>
+                            {booth.locationLabel}
+                          </Text>
+                        )}
+                      </View>
+                    </View>
+
+                    {eventId != null ? (
+                      <Pressable
+                        hitSlop={8}
+                        onPress={(e) => {
+                          e.stopPropagation?.();
+                          handleToggleFavorite(booth);
+                        }}
+                        style={styles.starButton}
+                      >
+                        <Ionicons
+                          name={isFavorite(booth) ? "star" : "star-outline"}
+                          size={22}
+                          color={isFavorite(booth) ? "#EAB308" : "#D1D5DB"}
+                        />
+                      </Pressable>
+                    ) : (
+                      <Ionicons
+                        name="star-outline"
+                        size={22}
+                        color="#D1D5DB"
+                      />
+                    )}
+                  </Pressable>
+                );
+              })
             )}
           </View>
         </>
@@ -226,7 +386,9 @@ export default function EventBoothTab({
         booth={selectedBooth}
         eventId={eventId}
         isFavorite={selectedBooth ? isFavorite(selectedBooth) : false}
-        onToggleFavorite={selectedBooth ? () => handleToggleFavorite(selectedBooth) : undefined}
+        onToggleFavorite={
+          selectedBooth ? () => handleToggleFavorite(selectedBooth) : undefined
+        }
         onClose={() => setSelectedBooth(null)}
       />
     </View>
@@ -234,50 +396,62 @@ export default function EventBoothTab({
 }
 
 const styles = StyleSheet.create({
-  modeToggleRow: {
+  container: {
+    paddingBottom: 8,
+  },
+
+  modeToggleWrap: {
     flexDirection: "row",
-    gap: 6,
+    gap: 8,
     marginTop: 12,
-    marginBottom: 8,
+    marginBottom: 10,
+    backgroundColor: "#F3F4F6",
+    borderRadius: 14,
+    padding: 4,
   },
   modeToggleBtn: {
     flex: 1,
-    paddingVertical: 7,
-    borderRadius: 8,
+    minHeight: 42,
+    borderRadius: 11,
     alignItems: "center",
-    backgroundColor: "#F3F4F6",
-    borderWidth: 1,
-    borderColor: "#E5E7EB",
+    justifyContent: "center",
+    flexDirection: "row",
+    gap: 6,
   },
   modeToggleBtnActive: {
     backgroundColor: "#111827",
-    borderColor: "#111827",
+    shadowColor: "#000",
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
   },
   modeToggleText: {
     fontSize: 13,
-    fontWeight: "600",
+    fontWeight: "700",
     color: "#6B7280",
   },
   modeToggleTextActive: {
     color: "#FFFFFF",
   },
+
   segmentContainer: {
     flexDirection: "row",
-    backgroundColor: "#f3f3f3",
+    backgroundColor: "#F3F4F6",
     borderRadius: 999,
     padding: 4,
-    marginTop: 12,
-    marginBottom: 20,
+    marginTop: 4,
+    marginBottom: 16,
   },
   segmentItem: {
     flex: 1,
     borderRadius: 999,
-    paddingVertical: 8,
+    paddingVertical: 9,
     alignItems: "center",
     justifyContent: "center",
   },
   segmentItemActive: {
-    backgroundColor: "#ffffff",
+    backgroundColor: "#FFFFFF",
     shadowColor: "#000",
     shadowOpacity: 0.05,
     shadowOffset: { width: 0, height: 1 },
@@ -286,62 +460,99 @@ const styles = StyleSheet.create({
   },
   segmentText: {
     fontSize: 13,
-    color: "#777",
+    fontWeight: "600",
+    color: "#6B7280",
   },
   segmentTextActive: {
-    fontWeight: "bold",
-    color: "#111",
+    color: "#111827",
   },
+
   listWrapper: {
-    gap: 8,
+    gap: 10,
   },
   boothCard: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderRadius: 12,
-    backgroundColor: "#ffffff",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 16,
+    backgroundColor: "#FFFFFF",
     borderWidth: 1,
-    borderColor: "#e5e5e5",
+    borderColor: "#E5E7EB",
   },
   iconPlaceholder: {
-    width: 40,
-    height: 40,
-    borderRadius: 12,
+    width: 44,
+    height: 44,
+    borderRadius: 15,
     marginRight: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+  },
+  foodIconPlaceholder: {
+    backgroundColor: "#FFF2EA",
+    borderColor: "#FFD6BE",
+  },
+  expIconPlaceholder: {
+    backgroundColor: "#EEF5FF",
+    borderColor: "#CFE1FA",
+  },
+  boothTextArea: {
+    flex: 1,
+    minWidth: 0,
   },
   boothName: {
     fontSize: 14,
-    fontWeight: "bold",
-    marginBottom: 2,
+    fontWeight: "800",
+    color: "#111827",
+    marginBottom: 6,
+  },
+  boothMetaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    minWidth: 0,
+  },
+  categoryChip: {
+    overflow: "hidden",
+    borderRadius: 999,
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    fontSize: 10,
+    fontWeight: "800",
+    maxWidth: 104,
+  },
+  foodCategoryChip: {
+    backgroundColor: "#FFE7D8",
+    color: "#B85721",
+  },
+  expCategoryChip: {
+    backgroundColor: "#E8F1FD",
+    color: "#2F63A7",
   },
   boothLocation: {
+    flex: 1,
     fontSize: 12,
-    color: "#777",
-  },
-  emptyText: {
-    fontSize: 14,
-    color: "#9CA3AF",
-    textAlign: "center",
-    paddingVertical: 24,
+    color: "#6B7280",
   },
   starButton: {
     marginLeft: 8,
     padding: 4,
   },
-  bottomButton: {
-    paddingHorizontal: 24,
-    paddingVertical: 10,
-    borderRadius: 999,
-    backgroundColor: "#111111",
+
+  emptyCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    backgroundColor: "#FFFFFF",
+    paddingVertical: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
   },
-  bottomButtonText: {
-    color: "#ffffff",
+  emptyText: {
     fontSize: 14,
-    fontWeight: "bold",
-  },
-  mapContainer: {
-    flex: 1,
+    color: "#9CA3AF",
+    textAlign: "center",
   },
 });

--- a/frontend/utils/boothVisual.ts
+++ b/frontend/utils/boothVisual.ts
@@ -1,0 +1,228 @@
+// frontend/utils/boothVisual.ts
+
+import type { ComponentProps } from "react";
+import { Ionicons } from "@expo/vector-icons";
+import type { EventBoothItem } from "../types/event";
+
+export type BoothKind = "food" | "experience";
+export type BoothIconName = ComponentProps<typeof Ionicons>["name"];
+
+export interface BoothVisual {
+  icon: BoothIconName;
+  emoji: string;
+  label: string;
+}
+
+interface BoothVisualRule extends BoothVisual {
+  keywords: string[];
+}
+
+const asIcon = (name: string) => name as BoothIconName;
+
+function containsAny(text: string, keywords: string[]) {
+  return keywords.some((keyword) => text.includes(keyword.toLowerCase()));
+}
+
+function makeSearchText(booth: Partial<EventBoothItem>) {
+  const parts = [
+    booth.name,
+    booth.locationLabel,
+    booth.time,
+    booth.host,
+    booth.description,
+    booth.externalLink,
+    ...(booth.menu ?? []),
+    ...(booth.rules ?? []),
+    ...(booth.prizes ?? []),
+  ];
+
+  return parts
+    .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+    .join(" ")
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+const FOOD_RULES: BoothVisualRule[] = [
+  {
+    keywords: ["타코", "taco", "브리또", "또띠아", "나초", "멕시"],
+    icon: asIcon("restaurant-outline"),
+    emoji: "🌮",
+    label: "타코 / 멕시칸",
+  },
+  {
+    keywords: [
+      "커피",
+      "카페",
+      "cafe",
+      "coffee",
+      "라떼",
+      "아메리카노",
+      "음료",
+      "에이드",
+      "콜라",
+      "사이다",
+      "주스",
+      "스무디",
+    ],
+    icon: asIcon("cafe-outline"),
+    emoji: "☕",
+    label: "카페 / 음료",
+  },
+  {
+    keywords: ["아이스", "젤라또", "빙수", "와플", "츄러스", "디저트", "크레페", "케이크"],
+    icon: asIcon("ice-cream-outline"),
+    emoji: "🍦",
+    label: "디저트",
+  },
+  {
+    keywords: ["피자", "pizza"],
+    icon: asIcon("pizza-outline"),
+    emoji: "🍕",
+    label: "피자",
+  },
+  {
+    keywords: ["버거", "햄버거", "burger", "샌드위치", "핫도그", "hotdog"],
+    icon: asIcon("fast-food-outline"),
+    emoji: "🍔",
+    label: "버거 / 간편식",
+  },
+  {
+    keywords: ["치킨", "닭", "강정", "꼬치", "닭꼬치"],
+    icon: asIcon("fast-food-outline"),
+    emoji: "🍗",
+    label: "치킨 / 꼬치",
+  },
+  {
+    keywords: ["떡볶이", "분식", "튀김", "순대", "어묵", "오뎅"],
+    icon: asIcon("restaurant-outline"),
+    emoji: "🍢",
+    label: "분식",
+  },
+  {
+    keywords: ["곱창", "막창", "고기", "삼겹", "갈비", "스테이크", "바비큐", "bbq", "그릴"],
+    icon: asIcon("flame-outline"),
+    emoji: "🔥",
+    label: "고기 / 그릴",
+  },
+  {
+    keywords: ["국수", "라멘", "우동", "면", "쌀국수", "짜장", "짬뽕", "파스타"],
+    icon: asIcon("restaurant-outline"),
+    emoji: "🍜",
+    label: "면 요리",
+  },
+  {
+    keywords: ["초밥", "스시", "sushi", "회", "새우", "해산물"],
+    icon: asIcon("restaurant-outline"),
+    emoji: "🍣",
+    label: "해산물 / 초밥",
+  },
+  {
+    keywords: ["밥", "덮밥", "도시락", "김밥", "볶음밥", "컵밥"],
+    icon: asIcon("restaurant-outline"),
+    emoji: "🍚",
+    label: "식사류",
+  },
+  {
+    keywords: ["푸드", "식당", "셰프", "쉐프", "맛집", "요리", "메뉴"],
+    icon: asIcon("fast-food-outline"),
+    emoji: "🍽️",
+    label: "푸드트럭",
+  },
+];
+
+const EXPERIENCE_RULES: BoothVisualRule[] = [
+  {
+    keywords: ["패션", "의류", "스타일", "옷", "ppc"],
+    icon: asIcon("shirt-outline"),
+    emoji: "👕",
+    label: "패션",
+  },
+  {
+    keywords: ["축구", "풋살", "스포츠", "운동", "오투", "농구", "야구"],
+    icon: asIcon("football-outline"),
+    emoji: "⚽",
+    label: "스포츠",
+  },
+  {
+    keywords: ["보드", "게임", "ludens", "루덴스", "플레이", "주사위"],
+    icon: asIcon("game-controller-outline"),
+    emoji: "🎲",
+    label: "게임",
+  },
+  {
+    keywords: ["경찰", "police", "방범", "안전", "순찰"],
+    icon: asIcon("shield-outline"),
+    emoji: "🛡️",
+    label: "안전 / 방범",
+  },
+  {
+    keywords: ["찬양", "엘림", "음악", "밴드", "노래", "공연", "합창"],
+    icon: asIcon("musical-notes-outline"),
+    emoji: "🎵",
+    label: "음악 / 공연",
+  },
+  {
+    keywords: ["연극", "예술", "미술", "공예", "드로잉", "그림", "디자인", "사랑방"],
+    icon: asIcon("color-palette-outline"),
+    emoji: "🎭",
+    label: "예술",
+  },
+  {
+    keywords: ["기독", "교회", "기도", "ccc", "아가페", "천주교", "하비온", "러빙", "프렌즈"],
+    icon: asIcon("heart-outline"),
+    emoji: "🤝",
+    label: "교류 / 종교",
+  },
+  {
+    keywords: ["총학생회", "학생회", "총동아리", "연합회", "jci", "youth", "여정"],
+    icon: asIcon("people-outline"),
+    emoji: "👥",
+    label: "학생단체",
+  },
+  {
+    keywords: ["봉사", "캠페인", "서포터", "친구", "상담"],
+    icon: asIcon("people-outline"),
+    emoji: "🙌",
+    label: "교류 / 봉사",
+  },
+  {
+    keywords: ["학술", "토론", "책", "독서", "스터디"],
+    icon: asIcon("book-outline"),
+    emoji: "📚",
+    label: "학술",
+  },
+];
+
+const DEFAULT_FOOD: BoothVisual = {
+  icon: asIcon("fast-food-outline"),
+  emoji: "🍽️",
+  label: "푸드트럭",
+};
+
+const DEFAULT_EXPERIENCE: BoothVisual = {
+  icon: asIcon("sparkles-outline"),
+  emoji: "✨",
+  label: "체험부스",
+};
+
+export function getBoothVisual(
+  booth: Partial<EventBoothItem> | null | undefined,
+  fallbackKind: BoothKind = "experience"
+): BoothVisual {
+  const safeBooth = booth ?? {};
+
+  const kind: BoothKind =
+    safeBooth.type === "food" || safeBooth.type === "experience"
+      ? safeBooth.type
+      : fallbackKind;
+
+  const text = makeSearchText(safeBooth);
+  const rules = kind === "food" ? FOOD_RULES : EXPERIENCE_RULES;
+  const matched = rules.find((rule) => containsAny(text, rule.keywords));
+
+  return matched ?? (kind === "food" ? DEFAULT_FOOD : DEFAULT_EXPERIENCE);
+}
+
+// default import로 잘못 가져와도 깨지지 않게 같이 export
+export default getBoothVisual;


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->
배치도 수정
## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->

- [x] 부스 카드 이모지 → Ionicons 아이콘으로 교체 (배치도/목록/모달)
- [x] 부스 이름 numberOfLines 1→2, CARD_HEIGHT 70→82 (글자 잘림 개선)
- [x] BoothLayoutMap 팝업 TouchableOpacity 중첩 제거로 스크롤 정상화
- [x] BoothDetailModal 내용 영역 ScrollView 적용 (긴 설명 스크롤 가능)
- [x] EventBoothTab 목록 모드 카드 UI 리뉴얼 (아이콘, 칩, 레이아웃)
- [x] boothVisual.ts 유틸 파일 추가 (카테고리별 아이콘/이모지/레이블)

## 체크리스트
<!-- [ ] 옆 내용을 수정해주세요 -->
- [x] 빌드가 에러 없이 수행되는가?
- [x] 불필요한 로그(console.log 등)는 없는가?
