### PR TITLE
탭 수정, 달력 좌우스크롤, 축제완료 푸시 알림, 필터칩 회색배경 제거

### DIFF
--- a/backend/src/main/java/com/dailo/backend/entity/StaySession.java
+++ b/backend/src/main/java/com/dailo/backend/entity/StaySession.java
@@ -44,6 +44,9 @@ public class StaySession {
 
     private LocalDateTime lastPingTime;
 
+    /** 30분 체류 미션 알림 발송 시각 (null = 미발송) */
+    private LocalDateTime missionNotifiedAt;
+
     @Builder
     public StaySession(Member member, Event event, Double lat, Double lng) {
         this.member = member;
@@ -68,5 +71,9 @@ public class StaySession {
         this.lastLatitude = lat;
         this.lastLongitude = lng;
         this.lastPingTime = LocalDateTime.now();
+    }
+
+    public void markMissionNotified() {
+        this.missionNotifiedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/dailo/backend/repository/StaySessionRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/StaySessionRepository.java
@@ -24,4 +24,8 @@ public interface StaySessionRepository extends JpaRepository<StaySession, Long> 
     /** 구역 안에 있지만 참여 완료 기준 시간 이상 체류 중인 PENDING 세션 */
     @Query(value = "SELECT * FROM stay_session WHERE member_id = :memberId AND status = 'PENDING' AND TIMESTAMPDIFF(MINUTE, start_time, NOW()) >= :minMinutes ORDER BY start_time DESC", nativeQuery = true)
     List<StaySession> findPendingWithMinDuration(@Param("memberId") Long memberId, @Param("minMinutes") long minMinutes);
+
+    /** 30분 이상 체류 중이지만 미션 알림을 아직 발송하지 않은 전체 PENDING 세션 */
+    @Query(value = "SELECT * FROM stay_session WHERE status = 'PENDING' AND TIMESTAMPDIFF(MINUTE, start_time, NOW()) >= :minMinutes AND mission_notified_at IS NULL", nativeQuery = true)
+    List<StaySession> findPendingNeedingMissionNotification(@Param("minMinutes") long minMinutes);
 }

--- a/backend/src/main/java/com/dailo/backend/service/StaySessionScheduler.java
+++ b/backend/src/main/java/com/dailo/backend/service/StaySessionScheduler.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -18,12 +19,13 @@ import java.util.List;
 public class StaySessionScheduler {
 
     private final StaySessionRepository staySessionRepository;
+    private final NotificationService notificationService;
 
-    // ping이 3분 이상 안 오면 자동 종료
     private static final long PING_TIMEOUT_MINUTES = 3;
+    private static final long MISSION_MINUTES = 30;
 
-    // 1분마다 체크
     @Scheduled(fixedRate = 60_000)
+    @Transactional
     public void expireInactiveSessions() {
         List<StaySession> pendings = staySessionRepository.findByStatus(StayStatus.PENDING);
         LocalDateTime now = LocalDateTime.now();
@@ -36,6 +38,28 @@ public class StaySessionScheduler {
             if (minutes >= PING_TIMEOUT_MINUTES) {
                 s.completeSession();
                 log.info("PING timeout auto-complete: sessionId={}", s.getId());
+            }
+        }
+    }
+
+    /** 30분 체류 미션 달성 시 푸시 알림 발송 (1분마다 체크) */
+    @Scheduled(fixedRate = 60_000)
+    @Transactional
+    public void sendMissionCompletionNotifications() {
+        List<StaySession> sessions = staySessionRepository.findPendingNeedingMissionNotification(MISSION_MINUTES);
+
+        for (StaySession s : sessions) {
+            String eventTitle = s.getEvent().getTitle();
+            String title = "🎉 체류 미션 완료!";
+            String body = String.format("[%s] 구역에 30분 이상 머무셨어요! 미션을 달성했습니다.", eventTitle);
+
+            try {
+                notificationService.sendPushNotification(s.getMember(), title, body);
+                s.markMissionNotified();
+                log.info("미션 완료 알림 발송: sessionId={}, memberId={}, event={}",
+                        s.getId(), s.getMember().getId(), eventTitle);
+            } catch (Exception e) {
+                log.error("미션 완료 알림 발송 실패: sessionId={}, error={}", s.getId(), e.getMessage());
             }
         }
     }

--- a/frontend/app/(tabs)/board/_layout.tsx
+++ b/frontend/app/(tabs)/board/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function BoardLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+    </Stack>
+  );
+}

--- a/frontend/app/(tabs)/calendar/_layout.tsx
+++ b/frontend/app/(tabs)/calendar/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function CalendarLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+    </Stack>
+  );
+}

--- a/frontend/app/(tabs)/calendar/index.tsx
+++ b/frontend/app/(tabs)/calendar/index.tsx
@@ -423,134 +423,127 @@ export default function CalendarScreen() {
           </View>
         </View>
 
-        {/* 달력 영역만 스크롤 (전체 흰 배경) */}
+        {/* 카테고리: 윤곽선 없음, 연한 배경, 글씨 옆 동그라미 */}
         <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={[styles.scrollContent, { paddingBottom: 24 + SHEET_HEIGHTS[sheetLevel] }]}
-          showsVerticalScrollIndicator={false}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={[styles.filterChipsWrap, { justifyContent: "center" }]}
+          style={styles.filterChipsScroll}
         >
-          {/* 카테고리: 윤곽선 없음, 연한 배경, 글씨 옆 동그라미 (사진처럼) */}
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={[styles.filterChipsWrap, { justifyContent: "center" }]}
-            style={styles.filterChipsScroll}
-          >
-            {FILTER_CATEGORIES.map((cat) => {
-              const selected = selectedCategory === cat.id;
-              return (
-                <Pressable
-                  key={cat.id}
-                  onPress={() =>
-                    setSelectedCategory(selected ? null : cat.id)
-                  }
+          {FILTER_CATEGORIES.map((cat) => {
+            const selected = selectedCategory === cat.id;
+            return (
+              <Pressable
+                key={cat.id}
+                onPress={() =>
+                  setSelectedCategory(selected ? null : cat.id)
+                }
+                style={[
+                  styles.filterChip,
+                  { backgroundColor: selected ? cat.color : cat.bgLight },
+                ]}
+              >
+                <View style={[styles.filterChipCircle, { backgroundColor: cat.color }]} />
+                <Text
                   style={[
-                    styles.filterChip,
-                    { backgroundColor: selected ? cat.color : cat.bgLight },
+                    styles.filterChipText,
+                    selected && styles.filterChipTextSelected,
                   ]}
                 >
-                  <View style={[styles.filterChipCircle, { backgroundColor: cat.color }]} />
-                  <Text
-                    style={[
-                      styles.filterChipText,
-                      selected && styles.filterChipTextSelected,
-                    ]}
-                  >
-                    {cat.label}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
+                  {cat.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
 
-          {/* 요일 + 날짜 카드: 좌우 스와이프로 이전/다음 달 이동 */}
-          <View style={styles.calendarCard} {...panResponder.panHandlers}>
-            <View style={styles.weekdayRow}>
-              {WEEKDAYS.map((w, i) => (
-                <View key={w} style={styles.weekdayCell}>
-                  <Text
-                    style={[
-                      styles.weekdayText,
-                      i === 0 && styles.sundayText,
-                      i === 6 && styles.saturdayText,
-                    ]}
-                  >
-                    {w}
-                  </Text>
-                </View>
-              ))}
-            </View>
-
-            {/* 달력 그리드 (요일과 같은 열 정렬) */}
-            <View style={styles.calendarGrid}>
-            {weeks.map((week, rowIndex) => (
-              <View key={rowIndex} style={styles.weekRow}>
-                {week.map((cell, colIndex) => {
-                  const todayCell = isToday(cell);
-                  const isSelected =
-                    cell.currentMonth && cell.day === selectedDay;
-                  const dayEvents = cell.currentMonth
-                    ? eventsByDayForDots[cell.day] ?? []
-                  : [];
-
-                  return (
-                    <Pressable
-                      key={`${rowIndex}-${colIndex}`}
-                      style={styles.dayCellWrapper}
-                      onPress={() => handleDayPress(cell)}
-                    >
-                      <View
-                        style={[
-                          styles.dayCell,
-                          !cell.currentMonth && styles.dayOutsideMonth,
-                        ]}
-                      >
-                        <View style={styles.dayNumberSlot}>
-                          {todayCell && (
-                            <View style={[StyleSheet.absoluteFillObject, styles.todayBadgeFill]} />
-                          )}
-                          {!todayCell && isSelected && (
-                            <View style={[StyleSheet.absoluteFillObject, styles.selectedDayBoxSquare]} />
-                          )}
-                          <Text
-                            style={[
-                              styles.dayText,
-                              todayCell && styles.todayText,
-                              !todayCell && isSelected && styles.selectedDayText,
-                              !cell.currentMonth && styles.dayTextOutside,
-                              !todayCell && colIndex === 0 && styles.sundayText,
-                              !todayCell && colIndex === 6 && styles.saturdayText,
-                            ]}
-                          >
-                            {cell.day}
-                          </Text>
-                        </View>
-                        {dayEvents.length > 0 && cell.currentMonth && (
-                          <View style={styles.eventLines}>
-                            {dayEvents.slice(0, 3).map((ev) => (
-                              <View key={ev.id} style={styles.eventLineRow}>
-                                <View
-                                  style={[
-                                    styles.eventLine,
-                                    { backgroundColor: getEventColor(ev) },
-                                  ]}
-                                />
-                              </View>
-                            ))}
-                            {dayEvents.length > 3 && (
-                              <Text style={styles.eventLinePlus}>+</Text>
-                            )}
-                          </View>
-                        )}
-                      </View>
-                    </Pressable>
-                  );
-                })}
+        {/* 요일 + 날짜 카드: 좌우 스와이프로 이전/다음 달 이동 */}
+        <View style={styles.calendarCard} {...panResponder.panHandlers}>
+          <View style={styles.weekdayRow}>
+            {WEEKDAYS.map((w, i) => (
+              <View key={w} style={styles.weekdayCell}>
+                <Text
+                  style={[
+                    styles.weekdayText,
+                    i === 0 && styles.sundayText,
+                    i === 6 && styles.saturdayText,
+                  ]}
+                >
+                  {w}
+                </Text>
               </View>
             ))}
-            </View>
           </View>
-        </ScrollView>
+
+          {/* 달력 그리드 (요일과 같은 열 정렬) */}
+          <View style={styles.calendarGrid}>
+          {weeks.map((week, rowIndex) => (
+            <View key={rowIndex} style={styles.weekRow}>
+              {week.map((cell, colIndex) => {
+                const todayCell = isToday(cell);
+                const isSelected =
+                  cell.currentMonth && cell.day === selectedDay;
+                const dayEvents = cell.currentMonth
+                  ? eventsByDayForDots[cell.day] ?? []
+                : [];
+
+                return (
+                  <Pressable
+                    key={`${rowIndex}-${colIndex}`}
+                    style={styles.dayCellWrapper}
+                    onPress={() => handleDayPress(cell)}
+                  >
+                    <View
+                      style={[
+                        styles.dayCell,
+                        !cell.currentMonth && styles.dayOutsideMonth,
+                      ]}
+                    >
+                      <View style={styles.dayNumberSlot}>
+                        {todayCell && (
+                          <View style={[StyleSheet.absoluteFillObject, styles.todayBadgeFill]} />
+                        )}
+                        {!todayCell && isSelected && (
+                          <View style={[StyleSheet.absoluteFillObject, styles.selectedDayBoxSquare]} />
+                        )}
+                        <Text
+                          style={[
+                            styles.dayText,
+                            todayCell && styles.todayText,
+                            !todayCell && isSelected && styles.selectedDayText,
+                            !cell.currentMonth && styles.dayTextOutside,
+                            !todayCell && colIndex === 0 && styles.sundayText,
+                            !todayCell && colIndex === 6 && styles.saturdayText,
+                          ]}
+                        >
+                          {cell.day}
+                        </Text>
+                      </View>
+                      {dayEvents.length > 0 && cell.currentMonth && (
+                        <View style={styles.eventLines}>
+                          {dayEvents.slice(0, 3).map((ev) => (
+                            <View key={ev.id} style={styles.eventLineRow}>
+                              <View
+                                style={[
+                                  styles.eventLine,
+                                  { backgroundColor: getEventColor(ev) },
+                                ]}
+                              />
+                            </View>
+                          ))}
+                          {dayEvents.length > 3 && (
+                            <Text style={styles.eventLinePlus}>+</Text>
+                          )}
+                        </View>
+                      )}
+                    </View>
+                  </Pressable>
+                );
+              })}
+            </View>
+          ))}
+          </View>
+        </View>
 
         {/* 하단 시트: 터치로 위로 당기면 확장되어 카드 전체 표시 */}
         <Animated.View
@@ -679,18 +672,9 @@ const styles = StyleSheet.create({
     flex: 1,
     textAlign: "center",
   },
-  scroll: {
-    flex: 1,
-  },
-  scrollContent: {
-    paddingHorizontal: HORIZONTAL_PADDING,
-    paddingTop: 20,
-    backgroundColor: "#FFFFFF",
-  },
   filterChipsScroll: {
     marginBottom: 10,
-    marginTop: 0,
-    marginHorizontal: -HORIZONTAL_PADDING,
+    marginTop: 20,
   },
   filterChipsWrap: {
     paddingHorizontal: HORIZONTAL_PADDING,
@@ -724,7 +708,7 @@ const styles = StyleSheet.create({
   },
   calendarCard: {
     paddingVertical: 8,
-    paddingHorizontal: 8,
+    paddingHorizontal: HORIZONTAL_PADDING,
     marginBottom: 16,
   },
   weekdayRow: {

--- a/frontend/app/(tabs)/map/_components/FilterChips.tsx
+++ b/frontend/app/(tabs)/map/_components/FilterChips.tsx
@@ -112,6 +112,7 @@ export function FilterChips({
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.container}
+        style={styles.scrollView}
       >
         {onPressStatus != null ? (
           <Chip
@@ -210,6 +211,7 @@ export function FilterChips({
 
 const styles = StyleSheet.create({
   wrapper: { zIndex: 2, backgroundColor: 'transparent' },
+  scrollView: { backgroundColor: 'transparent' },
   iconWrap: {
     borderWidth: 1,
     borderColor: '#FFFFFF',

--- a/frontend/app/(tabs)/map/_layout.tsx
+++ b/frontend/app/(tabs)/map/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function MapLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+    </Stack>
+  );
+}

--- a/frontend/components/AppStartupPopupModal.tsx
+++ b/frontend/components/AppStartupPopupModal.tsx
@@ -111,7 +111,7 @@ export default function AppStartupPopupModal() {
               )}
             </Pressable>
           ) : popups.length > 1 ? (
-            <View style={styles.linkBar}>
+            <View style={[styles.linkBar, styles.linkBarCenter]}>
               <Text style={styles.indicator}>
                 {currentIndex + 1}/{popups.length}
               </Text>
@@ -158,21 +158,26 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   linkBar: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
+    justifyContent: 'center',
     paddingHorizontal: 16,
     paddingVertical: 12,
     backgroundColor: '#1F1F1F',
+  },
+  linkBarCenter: {
+    // 인디케이터만 있을 때도 동일 레이아웃
   },
   linkBarText: {
     fontSize: 14,
     fontWeight: '600',
     color: '#FFFFFF',
+    textAlign: 'center',
   },
   indicator: {
     fontSize: 13,
     color: '#CCCCCC',
+    position: 'absolute',
+    right: 16,
   },
   buttonRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## 개요
UI/UX 개선 및 신규 기능 추가 (팝업 텍스트 정렬, 탭바 라우팅 수정, 달력 스와이프, 체류 미션 알림, 지도 필터칩 배경 제거)

## 관련 이슈
- Refs #이슈번호

## 작업 내용
- [x] 팝업 모달 "자세히 보기" 텍스트 가운데 정렬
- [x] 커스텀 탭바 제거 및 Expo Router v6 route 이름 통일 (`calendar`, `map`, `board` 폴더에 `_layout.tsx` 추가)
- [x] 달력 탭 좌우 스와이프로 월 이동 (ScrollView 충돌 제거)
- [x] 축제 구역 30분 체류 시 미션 완료 푸시 알림 발송 (`StaySession.missionNotifiedAt` 필드 추가, 스케줄러 구현)
- [x] 지도 필터 칩 ScrollView iOS 회색 배경 제거

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
