### PR TITLE
캘린더, 게시글 등 수정

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(git -C /root/study/terraform-aws-modules diff v0.1.4..HEAD -- modules/ecs/main.tf)",
       "Bash(git *)",
       "Bash(grep -E \"\\\\.\\(ts|tsx|js|jsx\\)$\")",
-      "Bash(./gradlew compileJava)"
+      "Bash(./gradlew compileJava)",
+      "Bash(npx tsc *)"
     ]
   }
 }

--- a/frontend/app/(tabs)/calendar/index.tsx
+++ b/frontend/app/(tabs)/calendar/index.tsx
@@ -424,6 +424,7 @@ export default function CalendarScreen() {
         </View>
 
         {/* 카테고리: 윤곽선 없음, 연한 배경, 글씨 옆 동그라미 */}
+        <View style={styles.filterChipsOuter}>
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
@@ -456,6 +457,7 @@ export default function CalendarScreen() {
             );
           })}
         </ScrollView>
+        </View>
 
         {/* 요일 + 날짜 카드: 좌우 스와이프로 이전/다음 달 이동 */}
         <View style={styles.calendarCard} {...panResponder.panHandlers}>
@@ -672,9 +674,13 @@ const styles = StyleSheet.create({
     flex: 1,
     textAlign: "center",
   },
+  filterChipsOuter: {
+    height: 52,
+    marginTop: 12,
+    marginBottom: 6,
+  },
   filterChipsScroll: {
-    marginBottom: 10,
-    marginTop: 20,
+    flex: 1,
   },
   filterChipsWrap: {
     paddingHorizontal: HORIZONTAL_PADDING,

--- a/frontend/app/(tabs)/map/_components/FilterModals.tsx
+++ b/frontend/app/(tabs)/map/_components/FilterModals.tsx
@@ -464,7 +464,7 @@ const styles = StyleSheet.create({
   daysGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginBottom: 18,
+    marginBottom: 0,
   },
   dayCell: {
     width: '14.2857%',
@@ -494,7 +494,7 @@ const styles = StyleSheet.create({
   dateActionsRow: {
     flexDirection: 'row',
     gap: 12,
-    marginTop: 8,
+    marginTop: 0,
   },
   clearButton: {
     flex: 1,

--- a/frontend/app/(tabs)/map/_components/MapBottomSheet.tsx
+++ b/frontend/app/(tabs)/map/_components/MapBottomSheet.tsx
@@ -8,6 +8,8 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  Modal,
+  StatusBar,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -69,6 +71,7 @@ export function MapBottomSheet({
   const [detailLoading, setDetailLoading] = useState(false);
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
+  const [posterFullscreen, setPosterFullscreen] = useState(false);
 
   // expanded 모드 진입 시 상세 데이터 fetch + 북마크 초기화
   useEffect(() => {
@@ -268,7 +271,11 @@ export function MapBottomSheet({
           </View>
 
           {/* 미리보기: 행사 대표 포스터(상세 화면 헤더와 동일 우선순위) */}
-          <View style={styles.previewBox}>
+          <TouchableOpacity
+            style={styles.previewBox}
+            activeOpacity={0.85}
+            onPress={() => posterUri && setPosterFullscreen(true)}
+          >
             {detailLoading && !posterUri ? (
               <View style={styles.loadingSection}>
                 <ActivityIndicator size="small" color="#4C8BF5" />
@@ -280,7 +287,32 @@ export function MapBottomSheet({
                 resizeMode="cover"
               />
             )}
-          </View>
+          </TouchableOpacity>
+
+          {/* 포스터 전체화면 뷰어 */}
+          <Modal
+            visible={posterFullscreen}
+            transparent
+            animationType="fade"
+            statusBarTranslucent
+            onRequestClose={() => setPosterFullscreen(false)}
+          >
+            <StatusBar backgroundColor="rgba(0,0,0,0.95)" barStyle="light-content" />
+            <View style={styles.fullscreenOverlay}>
+              <Image
+                source={{ uri: posterUri ?? DEFAULT_POSTER_URI }}
+                style={styles.fullscreenImage}
+                resizeMode="contain"
+              />
+              <TouchableOpacity
+                style={styles.fullscreenClose}
+                onPress={() => setPosterFullscreen(false)}
+                activeOpacity={0.8}
+              >
+                <Ionicons name="close" size={24} color="#FFFFFF" />
+              </TouchableOpacity>
+            </View>
+          </Modal>
 
           {/* 하단 버튼 (길찾기 / 상세보기) */}
           <View style={styles.largeButtonRow}>
@@ -555,5 +587,26 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#FFFFFF',
     fontWeight: '600',
+  },
+  fullscreenOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.95)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fullscreenImage: {
+    width: '100%',
+    height: '100%',
+  },
+  fullscreenClose: {
+    position: 'absolute',
+    top: 48,
+    right: 20,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/frontend/app/(tabs)/map/_components/NaverMap.tsx
+++ b/frontend/app/(tabs)/map/_components/NaverMap.tsx
@@ -19,20 +19,12 @@ const BUS_STOP_MARKER = require('../../../../assets/images/bus-marker.png') as n
 const BUS_STOP_SIZE = 25;
 const MARKER_WIDTH = 36;
 const MARKER_HEIGHT = 48;
-// 바깥 테두리/흰색 바디용 스케일 (중심 기준으로 키움)
-const MARKER_BORDER_SCALE = 1.14;
-const MARKER_WHITE_SCALE = 1.10;
-// 그림자 영역을 위해 테두리 높이보다 조금 더 긴 컨테이너
+// 그림자 영역을 위해 마커보다 조금 더 긴 컨테이너
 const MARKER_SHADOW_EXTRA_HEIGHT = 6;
-const MARKER_CONTAINER_WIDTH = MARKER_WIDTH * MARKER_BORDER_SCALE;
-const MARKER_BORDER_HEIGHT = MARKER_HEIGHT * MARKER_BORDER_SCALE;
-const MARKER_CONTAINER_HEIGHT = MARKER_BORDER_HEIGHT + MARKER_SHADOW_EXTRA_HEIGHT;
-// 컨테이너 안에서 원본 마커 이미지를 "테두리 높이" 기준으로 가운데 배치
-const MARKER_IMAGE_LEFT = (MARKER_CONTAINER_WIDTH - MARKER_WIDTH) / 2;
-const MARKER_IMAGE_TOP = (MARKER_BORDER_HEIGHT - MARKER_HEIGHT) / 2;
-// 각 레이어를 얼마나 "위로" 올릴지 (px 단위 오프셋)
-const WHITE_MARKER_OFFSET_Y = 0.6;  // 가운데 흰색 마커
-const COLOR_MARKER_OFFSET_Y = 1.2;  // 맨 앞 컬러 마커 + 숫자
+const MARKER_CONTAINER_WIDTH = MARKER_WIDTH;
+const MARKER_CONTAINER_HEIGHT = MARKER_HEIGHT + MARKER_SHADOW_EXTRA_HEIGHT;
+const MARKER_IMAGE_LEFT = 0;
+const MARKER_IMAGE_TOP = 0;
 
 /** 규모(scale) → 마커 tint 색상 (규모 범례와 동일) */
 const SCALE_COLORS: Record<Event['scale'], string> = {
@@ -281,16 +273,6 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
                   </View>
                   <Image
                     source={MARKER_ICON}
-                    style={styles.markerPinImageBorder}
-                    resizeMode="contain"
-                  />
-                  <Image
-                    source={MARKER_ICON}
-                    style={styles.markerPinImageWhite}
-                    resizeMode="contain"
-                  />
-                  <Image
-                    source={MARKER_ICON}
                     style={[styles.markerPinImageEnded, { tintColor: scaleColor }]}
                     resizeMode="contain"
                   />
@@ -298,16 +280,6 @@ export const NaverMap = forwardRef<NaverMapViewRef, Props>(function NaverMap(
               ) : (
                 <>
                   <View style={styles.markerBaseShadow} />
-                  <Image
-                    source={MARKER_ICON}
-                    style={styles.markerPinImageBorder}
-                    resizeMode="contain"
-                  />
-                  <Image
-                    source={MARKER_ICON}
-                    style={styles.markerPinImageWhite}
-                    resizeMode="contain"
-                  />
                   <Image
                     source={MARKER_ICON}
                     style={[styles.markerPinImage, { tintColor: scaleColor }]}
@@ -413,42 +385,24 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     includeFontPadding: false,
   },
-  markerPinImageBorder: {
-    width: MARKER_WIDTH,
-    height: MARKER_HEIGHT,
-    position: 'absolute',
-    left: MARKER_IMAGE_LEFT,
-    top: MARKER_IMAGE_TOP,
-    tintColor: '#D1D5DB', // 조금 더 진한 회색 외곽
-    transform: [{ scale: MARKER_BORDER_SCALE }],
-  },
-  markerPinImageWhite: {
-    width: MARKER_WIDTH,
-    height: MARKER_HEIGHT,
-    position: 'absolute',
-    left: MARKER_IMAGE_LEFT,
-    top: MARKER_IMAGE_TOP - WHITE_MARKER_OFFSET_Y,
-    tintColor: '#FFFFFF', // 안쪽 흰색
-    transform: [{ scale: MARKER_WHITE_SCALE }],
-  },
   markerPinImage: {
     width: MARKER_WIDTH,
     height: MARKER_HEIGHT,
     position: 'absolute',
     left: MARKER_IMAGE_LEFT,
-    top: MARKER_IMAGE_TOP - COLOR_MARKER_OFFSET_Y,
+    top: MARKER_IMAGE_TOP,
   },
   markerPinImageEnded: {
     position: 'absolute',
     left: MARKER_IMAGE_LEFT,
-    top: MARKER_IMAGE_TOP - COLOR_MARKER_OFFSET_Y,
+    top: MARKER_IMAGE_TOP,
     width: MARKER_WIDTH,
     height: MARKER_HEIGHT,
   },
   markerNumberWrap: {
     position: 'absolute',
     left: MARKER_IMAGE_LEFT,
-    top: MARKER_IMAGE_TOP - COLOR_MARKER_OFFSET_Y,
+    top: MARKER_IMAGE_TOP,
     width: MARKER_WIDTH,
     height: MARKER_WIDTH,
     justifyContent: 'center',

--- a/frontend/app/(tabs)/mypage/participated-festivals.tsx
+++ b/frontend/app/(tabs)/mypage/participated-festivals.tsx
@@ -92,9 +92,7 @@ export default function ParticipatedFestivalsScreen() {
           </View>
         ) : (
           <ScrollView contentContainerStyle={styles.contents}>
-            <Text style={styles.listHint}>
-              구역 체류가 서버에 종료로 저장된 기록입니다. 10분만 머물어도 표시되며, 30분 이상만 보는 미션 목록은 다른 메뉴입니다.
-            </Text>
+
             {list.length === 0 ? (
               <Text style={styles.empty}>축제 구역에 참여한 기록이 없습니다.</Text>
             ) : (

--- a/frontend/app/board/write.tsx
+++ b/frontend/app/board/write.tsx
@@ -1,5 +1,5 @@
 // app/board/write.tsx
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import {
   View,
   Text,
@@ -9,7 +9,6 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  Keyboard,
   Alert,
   ActivityIndicator,
   Modal,
@@ -28,7 +27,11 @@ import { useMyUserId } from "../../hooks/useAuth";
 import { API_BASE_URL } from "../../constants/api";
 import type { Event } from "../../types/event";
 import { getDemoLocation } from "../../services/demoLocationStorage";
-import { getCurrentRegionKey, EVENT_PICKER_REGION_OPTIONS } from "../../utils/eventPickerRegion";
+import { getCurrentRegionKey } from "../../utils/eventPickerRegion";
+
+const REGION_OPTIONS = ["전체", "충주"] as const;
+const PICKER_ITEM_H = 44;
+const MONTH_OPTIONS = Array.from({ length: 12 }, (_, i) => i + 1);
 
 const CATEGORIES = ["후기", "질문", "자유"] as const;
 type Category = (typeof CATEGORIES)[number];
@@ -46,7 +49,6 @@ export default function PostWriteScreen() {
   const [category, setCategory] = useState<Category>("자유");
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [loadingEdit, setLoadingEdit] = useState(!!editId);
   /** 후기 카테고리일 때 선택한 행사 */
@@ -54,6 +56,7 @@ export default function PostWriteScreen() {
   const [selectedEventTitle, setSelectedEventTitle] = useState<string>("");
   const [eventPickerVisible, setEventPickerVisible] = useState(false);
   const [eventList, setEventList] = useState<Event[]>([]);
+
   const [eventListLoading, setEventListLoading] = useState(false);
   /** 행사 선택 필터: 지역(기본=현재 위치 도시) / 월(기본=현재 월) / 행사명 */
   const [eventPickerRegion, setEventPickerRegion] = useState<string>("");
@@ -62,21 +65,23 @@ export default function PostWriteScreen() {
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
   });
   const [eventPickerKeyword, setEventPickerKeyword] = useState<string>("");
+
+  const yearListRef = useRef<FlatList>(null);
+  const monthListRef = useRef<FlatList>(null);
+  const keywordTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const YEAR_OPTIONS = useMemo(() => {
+    const y = new Date().getFullYear();
+    return [y - 1, y, y + 1, y + 2];
+  }, []);
+
+  const pickerYear = parseInt(eventPickerMonth.split('-')[0], 10) || new Date().getFullYear();
+  const pickerMonthNum = parseInt(eventPickerMonth.split('-')[1], 10) || new Date().getMonth() + 1;
   /** 선택한 사진 URI 목록 (동영상 불가, 사진만) */
   const [selectedImageUris, setSelectedImageUris] = useState<string[]>([]);
   /** 수정 시 기존 게시글에 있던 이미지 URL (서버에 이미 저장됨) */
   const [existingImageUrls, setExistingImageUrls] = useState<string[]>([]);
 
-  useEffect(() => {
-    const show = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
-    const hide = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
-    const subShow = Keyboard.addListener(show, (e) => setKeyboardHeight(e.endCoordinates.height));
-    const subHide = Keyboard.addListener(hide, () => setKeyboardHeight(0));
-    return () => {
-      subShow.remove();
-      subHide.remove();
-    };
-  }, []);
 
   useEffect(() => {
     if (!editId) {
@@ -229,6 +234,17 @@ export default function PostWriteScreen() {
     [eventPickerRegion, eventPickerMonth, eventPickerKeyword, getMonthRange, selectedEventId]
   );
 
+  useEffect(() => {
+    if (!eventPickerVisible) return;
+    const yIdx = YEAR_OPTIONS.indexOf(pickerYear);
+    const mIdx = pickerMonthNum - 1;
+    const t = setTimeout(() => {
+      if (yIdx >= 0) yearListRef.current?.scrollToOffset({ offset: yIdx * PICKER_ITEM_H, animated: false });
+      if (mIdx >= 0) monthListRef.current?.scrollToOffset({ offset: mIdx * PICKER_ITEM_H, animated: false });
+    }, 60);
+    return () => clearTimeout(t);
+  }, [eventPickerVisible]);
+
   const openEventPicker = useCallback(async () => {
     setEventPickerVisible(true);
     let region = eventPickerRegion;
@@ -341,7 +357,7 @@ export default function PostWriteScreen() {
     <SafeAreaView style={styles.safeArea} edges={["top"]}>
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
         keyboardVerticalOffset={0}
       >
         {/* 헤더: 취소 | 새 게시물 | 공유 */}
@@ -361,10 +377,7 @@ export default function PostWriteScreen() {
 
         <ScrollView
           style={styles.scroll}
-          contentContainerStyle={[
-            styles.scrollContent,
-            keyboardHeight > 0 && { paddingBottom: keyboardHeight + 120 },
-          ]}
+          contentContainerStyle={styles.scrollContent}
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={true}
         >
@@ -506,10 +519,11 @@ export default function PostWriteScreen() {
                 </Pressable>
               </View>
               <View style={styles.eventPickerFilters}>
-                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.eventPickerFilterRow}>
+                {/* 지역: 전체 / 충주만 */}
+                <View style={styles.eventPickerFilterRow}>
                   <Text style={styles.eventPickerFilterLabel}>지역</Text>
-                  <ScrollView horizontal contentContainerStyle={styles.eventPickerChips}>
-                    {EVENT_PICKER_REGION_OPTIONS.map((r) => (
+                  <View style={styles.eventPickerChips}>
+                    {REGION_OPTIONS.map((r) => (
                       <Pressable
                         key={r}
                         style={[styles.eventPickerChip, eventPickerRegion === r && styles.eventPickerChipActive]}
@@ -521,49 +535,93 @@ export default function PostWriteScreen() {
                         <Text style={[styles.eventPickerChipText, eventPickerRegion === r && styles.eventPickerChipTextActive]}>{r}</Text>
                       </Pressable>
                     ))}
-                  </ScrollView>
-                </ScrollView>
-                <View style={styles.eventPickerFilterRow}>
-                  <Text style={styles.eventPickerFilterLabel}>월</Text>
-                  <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.eventPickerChips}>
-                    {(() => {
-                      const now = new Date();
-                      const options: string[] = [];
-                      for (let i = -6; i <= 12; i++) {
-                        const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
-                        options.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
-                      }
-                      return options.map((yyyyMm) => {
-                        const [y, m] = yyyyMm.split("-").map(Number);
-                        const label = now.getFullYear() === y ? `${m}월` : `${y}년 ${m}월`;
-                        return (
-                          <Pressable
-                            key={yyyyMm}
-                            style={[styles.eventPickerChip, eventPickerMonth === yyyyMm && styles.eventPickerChipActive]}
-                            onPress={() => {
-                              setEventPickerMonth(yyyyMm);
-                              loadEventListForPicker({ month: yyyyMm });
-                            }}
-                          >
-                            <Text style={[styles.eventPickerChipText, eventPickerMonth === yyyyMm && styles.eventPickerChipTextActive]}>{label}</Text>
-                          </Pressable>
-                        );
-                      });
-                    })()}
-                  </ScrollView>
+                  </View>
                 </View>
-                <View style={styles.eventPickerKeywordRow}>
+
+                {/* 날짜: 연도 + 월 드럼롤 피커 */}
+                <View style={styles.eventPickerFilterRow}>
+                  <Text style={styles.eventPickerFilterLabel}>날짜</Text>
+                  <View style={styles.datePickerWrapper}>
+                    <View style={styles.datePickerHighlight} pointerEvents="none" />
+                    <FlatList
+                      ref={yearListRef}
+                      data={YEAR_OPTIONS}
+                      style={styles.datePickerCol}
+                      snapToInterval={PICKER_ITEM_H}
+                      decelerationRate="fast"
+                      showsVerticalScrollIndicator={false}
+                      contentContainerStyle={{ paddingVertical: PICKER_ITEM_H }}
+                      getItemLayout={(_, i) => ({ length: PICKER_ITEM_H, offset: PICKER_ITEM_H * i, index: i })}
+                      onMomentumScrollEnd={(e) => {
+                        const idx = Math.round(e.nativeEvent.contentOffset.y / PICKER_ITEM_H);
+                        const year = YEAR_OPTIONS[idx];
+                        if (year) {
+                          const ym = `${year}-${String(pickerMonthNum).padStart(2, '0')}`;
+                          setEventPickerMonth(ym);
+                          loadEventListForPicker({ month: ym });
+                        }
+                      }}
+                      renderItem={({ item }) => (
+                        <View style={[styles.pickerItem, item === pickerYear && styles.pickerItemSelected]}>
+                          <Text style={[styles.pickerItemText, item === pickerYear && styles.pickerItemTextSelected]}>
+                            {item}년
+                          </Text>
+                        </View>
+                      )}
+                      keyExtractor={(item) => String(item)}
+                    />
+                    <View style={styles.datePickerDivider} />
+                    <FlatList
+                      ref={monthListRef}
+                      data={MONTH_OPTIONS}
+                      style={styles.datePickerCol}
+                      snapToInterval={PICKER_ITEM_H}
+                      decelerationRate="fast"
+                      showsVerticalScrollIndicator={false}
+                      contentContainerStyle={{ paddingVertical: PICKER_ITEM_H }}
+                      getItemLayout={(_, i) => ({ length: PICKER_ITEM_H, offset: PICKER_ITEM_H * i, index: i })}
+                      onMomentumScrollEnd={(e) => {
+                        const idx = Math.round(e.nativeEvent.contentOffset.y / PICKER_ITEM_H);
+                        const month = MONTH_OPTIONS[idx];
+                        if (month) {
+                          const ym = `${pickerYear}-${String(month).padStart(2, '0')}`;
+                          setEventPickerMonth(ym);
+                          loadEventListForPicker({ month: ym });
+                        }
+                      }}
+                      renderItem={({ item }) => (
+                        <View style={[styles.pickerItem, item === pickerMonthNum && styles.pickerItemSelected]}>
+                          <Text style={[styles.pickerItemText, item === pickerMonthNum && styles.pickerItemTextSelected]}>
+                            {item}월
+                          </Text>
+                        </View>
+                      )}
+                      keyExtractor={(item) => String(item)}
+                    />
+                  </View>
+                </View>
+
+                {/* 행사명: 돋보기 아이콘 검색창 */}
+                <View style={styles.eventPickerFilterRow}>
                   <Text style={styles.eventPickerFilterLabel}>행사명</Text>
-                  <TextInput
-                    style={styles.eventPickerKeywordInput}
-                    placeholder="행사명 검색"
-                    placeholderTextColor="#9CA3AF"
-                    value={eventPickerKeyword}
-                    onChangeText={setEventPickerKeyword}
-                  />
-                  <Pressable style={styles.eventPickerSearchBtn} onPress={loadEventListForPicker} disabled={eventListLoading}>
-                    <Text style={styles.eventPickerSearchBtnText}>검색</Text>
-                  </Pressable>
+                  <View style={styles.eventPickerKeywordWrap}>
+                    <Ionicons name="search-outline" size={16} color="#9CA3AF" style={styles.keywordSearchIcon} />
+                    <TextInput
+                      style={styles.eventPickerKeywordInput}
+                      placeholder="행사명 검색"
+                      placeholderTextColor="#9CA3AF"
+                      value={eventPickerKeyword}
+                      onChangeText={(text) => {
+                        setEventPickerKeyword(text);
+                        if (keywordTimeoutRef.current) clearTimeout(keywordTimeoutRef.current);
+                        keywordTimeoutRef.current = setTimeout(() => {
+                          loadEventListForPicker({ keyword: text });
+                        }, 500);
+                      }}
+                      onSubmitEditing={() => loadEventListForPicker()}
+                      returnKeyType="search"
+                    />
+                  </View>
                 </View>
               </View>
               {eventListLoading ? (
@@ -595,8 +653,8 @@ export default function PostWriteScreen() {
           </Pressable>
         </Modal>
 
-        {/* 사진 - 키보드 없을 땐 하단, 키보드 뜨면 키보드 위에 여유 간격 */}
-        <View style={[styles.attachRow, { bottom: keyboardHeight > 0 ? keyboardHeight + 20 : 0 }]}>
+        {/* 사진 버튼 - 키보드 위에 고정 */}
+        <View style={styles.attachRow}>
           <Pressable
             style={styles.attachBtn}
             onPress={openImagePicker}
@@ -693,9 +751,6 @@ const styles = StyleSheet.create({
     borderRadius: 14,
   },
   attachRow: {
-    position: "absolute",
-    left: 0,
-    right: 0,
     flexDirection: "row",
     gap: 16,
     paddingHorizontal: 16,
@@ -703,8 +758,6 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: "#E5E7EB",
     backgroundColor: "#FFFFFF",
-    zIndex: 10,
-    elevation: 10,
   },
   attachBtn: { flexDirection: "row", alignItems: "center", gap: 8, paddingVertical: 8, paddingHorizontal: 4 },
   attachText: { fontSize: 14, color: "#6B7280" },
@@ -745,12 +798,12 @@ const styles = StyleSheet.create({
   },
   modalTitle: { fontSize: 17, fontWeight: "600", color: "#111827" },
   modalClose: { fontSize: 16, color: "#4C8BF5" },
-  eventPickerFilters: { paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: "#E5E7EB", gap: 10 },
-  eventPickerFilterRow: { flexDirection: "row", alignItems: "center", marginBottom: 6 },
+  eventPickerFilters: { paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: "#E5E7EB", gap: 12 },
+  eventPickerFilterRow: { flexDirection: "row", alignItems: "center" },
   eventPickerFilterLabel: { fontSize: 13, color: "#6B7280", width: 44, marginRight: 8 },
-  eventPickerChips: { flexDirection: "row", gap: 8, paddingVertical: 4 },
+  eventPickerChips: { flexDirection: "row", gap: 8, paddingVertical: 2 },
   eventPickerChip: {
-    paddingHorizontal: 12,
+    paddingHorizontal: 14,
     paddingVertical: 8,
     borderRadius: 999,
     borderWidth: 1,
@@ -760,13 +813,53 @@ const styles = StyleSheet.create({
   eventPickerChipActive: { backgroundColor: "#4C8BF5", borderColor: "#4C8BF5" },
   eventPickerChipText: { fontSize: 13, color: "#4B5563", fontWeight: "500" },
   eventPickerChipTextActive: { color: "#FFFFFF" },
-  eventPickerKeywordRow: { flexDirection: "row", alignItems: "center", gap: 8, marginTop: 4 },
-  eventPickerKeywordInput: {
+  // 날짜 드럼롤 피커
+  datePickerWrapper: {
     flex: 1,
+    flexDirection: "row",
+    height: PICKER_ITEM_H * 3,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    overflow: "hidden",
+    backgroundColor: "#F9FAFB",
+  },
+  datePickerCol: { flex: 1 },
+  datePickerDivider: { width: 1, backgroundColor: "#E5E7EB" },
+  datePickerHighlight: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    top: PICKER_ITEM_H,
+    height: PICKER_ITEM_H,
+    backgroundColor: "rgba(76,139,245,0.08)",
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: "#4C8BF5",
+    zIndex: 1,
+  },
+  pickerItem: {
+    height: PICKER_ITEM_H,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pickerItemSelected: {},
+  pickerItemText: { fontSize: 14, color: "#9CA3AF" },
+  pickerItemTextSelected: { fontSize: 15, fontWeight: "700", color: "#111827" },
+  // 행사명 검색창 (돋보기 아이콘 내장)
+  eventPickerKeywordWrap: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
     borderWidth: 1,
     borderColor: "#D1D5DB",
     borderRadius: 10,
-    paddingHorizontal: 12,
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 10,
+  },
+  keywordSearchIcon: { marginRight: 6 },
+  eventPickerKeywordInput: {
+    flex: 1,
     paddingVertical: 10,
     fontSize: 14,
     color: "#111827",

--- a/frontend/app/event/[id].tsx
+++ b/frontend/app/event/[id].tsx
@@ -69,11 +69,11 @@ export default function EventDetailScreen() {
   }>();
   const { detail: event, loading, error, refetch: refetchDetail } = useEventDetail(id, source ?? "detail");
   const initialTab: TabKey =
-    tabParam === "booths"
-      ? "booths"
+    tabParam === "news"
+      ? "news"
       : tabParam === "timeline"
         ? "timeline"
-        : "news";
+        : "booths";
 
   const extra = useMemo(
     () => parseEventExtra(event?.extraJson ?? null),

--- a/frontend/app/notification-history.tsx
+++ b/frontend/app/notification-history.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import {
@@ -44,7 +45,7 @@ export default function NotificationHistoryScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
           <Ionicons name="chevron-back" size={24} color="#333" />
@@ -91,7 +92,7 @@ export default function NotificationHistoryScreen() {
           )}
         />
       )}
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -100,7 +101,7 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingTop: 52,
+    paddingTop: 12,
     paddingBottom: 12,
     paddingHorizontal: 16,
     borderBottomWidth: 1,

--- a/frontend/app/notification-settings.tsx
+++ b/frontend/app/notification-settings.tsx
@@ -44,11 +44,12 @@ export default function NotificationSettingsScreen() {
   const [regionKey, setRegionKey] = useState<string | null>(null);
   const [regionModalVisible, setRegionModalVisible] = useState(false);
   const [regionLoading, setRegionLoading] = useState(false);
-  const [bookedDaysBefore, setBookedDaysBefore] = useState<number>(1);
-  const [regionDaysBefore, setRegionDaysBefore] = useState<number>(1);
-  const [daysModalTarget, setDaysModalTarget] = useState<'booked' | 'region'>('booked');
-  const [daysModalVisible, setDaysModalVisible] = useState(false);
-  const [regionMoreVisible, setRegionMoreVisible] = useState(false);
+  // 알림 시점 고정: 1일 전 오전 9시
+  // const [bookedDaysBefore, setBookedDaysBefore] = useState<number>(1);
+  // const [regionDaysBefore, setRegionDaysBefore] = useState<number>(1);
+  // const [daysModalTarget, setDaysModalTarget] = useState<'booked' | 'region'>('booked');
+  // const [daysModalVisible, setDaysModalVisible] = useState(false);
+  // const [regionMoreVisible, setRegionMoreVisible] = useState(false);
 
   const handleBack = useCallback(() => {
     router.back();
@@ -57,33 +58,34 @@ export default function NotificationSettingsScreen() {
   useEffect(() => {
     (async () => {
       try {
-        const [push, reminder, booked, region, rKey, bookedDays, regionDays] =
+        const [push, reminder, booked, region, rKey] =
           await Promise.all([
           AsyncStorage.getItem(STORAGE_KEYS.pushEnabled),
           AsyncStorage.getItem(STORAGE_KEYS.eventReminder),
           AsyncStorage.getItem(STORAGE_KEYS.eventReminderBooked),
           AsyncStorage.getItem(STORAGE_KEYS.eventReminderRegion),
           AsyncStorage.getItem(STORAGE_KEYS.eventReminderRegionKey),
-          AsyncStorage.getItem(STORAGE_KEYS.eventReminderBookedDaysBefore),
-          AsyncStorage.getItem(STORAGE_KEYS.eventReminderRegionDaysBefore),
+          // AsyncStorage.getItem(STORAGE_KEYS.eventReminderBookedDaysBefore),
+          // AsyncStorage.getItem(STORAGE_KEYS.eventReminderRegionDaysBefore),
         ]);
         if (push !== null) setPushEnabled(push === 'true');
         if (reminder !== null) setEventReminderOn(reminder === 'true');
         if (booked !== null) setBookedOn(booked === 'true');
         if (region !== null) setRegionOn(region === 'true');
         if (rKey != null && rKey !== '') setRegionKey(rKey);
-        if (bookedDays != null && bookedDays !== '') {
-          const parsed = parseInt(bookedDays, 10);
-          if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 30) {
-            setBookedDaysBefore(parsed);
-          }
-        }
-        if (regionDays != null && regionDays !== '') {
-          const parsed = parseInt(regionDays, 10);
-          if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 30) {
-            setRegionDaysBefore(parsed);
-          }
-        }
+        // 알림 시점 고정: 1일 전 오전 9시 (선택 기능 비활성화)
+        // if (bookedDays != null && bookedDays !== '') {
+        //   const parsed = parseInt(bookedDays, 10);
+        //   if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 30) {
+        //     setBookedDaysBefore(parsed);
+        //   }
+        // }
+        // if (regionDays != null && regionDays !== '') {
+        //   const parsed = parseInt(regionDays, 10);
+        //   if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 30) {
+        //     setRegionDaysBefore(parsed);
+        //   }
+        // }
         if (isLoggedIn) {
           try {
             const serverSettings = await notificationService.getNotificationSettings();
@@ -260,37 +262,40 @@ export default function NotificationSettingsScreen() {
     }
   };
 
-  const openDaysModal = (target: 'booked' | 'region') => {
-    if (!pushEnabled || !eventReminderOn) return;
-    if (target === 'booked' && !bookedOn) return;
-    if (target === 'region' && !regionOn) return;
-    setDaysModalTarget(target);
-    setDaysModalVisible(true);
-  };
+  // 알림 시점 선택 비활성화 (1일 전 오전 9시 고정)
+  // const openDaysModal = (target: 'booked' | 'region') => {
+  //   if (!pushEnabled || !eventReminderOn) return;
+  //   if (target === 'booked' && !bookedOn) return;
+  //   if (target === 'region' && !regionOn) return;
+  //   setDaysModalTarget(target);
+  //   setDaysModalVisible(true);
+  // };
 
-  const handleSelectDaysBefore = async (value: number) => {
-    setDaysModalVisible(false);
-    const safe = Math.max(1, Math.min(30, Math.floor(value) || 1));
-    if (daysModalTarget === 'booked') {
-      setBookedDaysBefore(safe);
-      try {
-        await AsyncStorage.setItem(STORAGE_KEYS.eventReminderBookedDaysBefore, String(safe));
-      } catch {}
-    } else {
-      setRegionDaysBefore(safe);
-      try {
-        await AsyncStorage.setItem(STORAGE_KEYS.eventReminderRegionDaysBefore, String(safe));
-      } catch {}
-    }
-  };
+  // const handleSelectDaysBefore = async (value: number) => {
+  //   setDaysModalVisible(false);
+  //   const safe = Math.max(1, Math.min(30, Math.floor(value) || 1));
+  //   if (daysModalTarget === 'booked') {
+  //     setBookedDaysBefore(safe);
+  //     try {
+  //       await AsyncStorage.setItem(STORAGE_KEYS.eventReminderBookedDaysBefore, String(safe));
+  //     } catch {}
+  //   } else {
+  //     setRegionDaysBefore(safe);
+  //     try {
+  //       await AsyncStorage.setItem(STORAGE_KEYS.eventReminderRegionDaysBefore, String(safe));
+  //     } catch {}
+  //   }
+  // };
 
-  const bookedDaysLabel =
-    (bookedDaysBefore === 1 ? '행사 1일 전' : `행사 ${bookedDaysBefore}일 전`) +
-    ' 오전 9시에 알림';
-
-  const regionDaysLabel =
-    (regionDaysBefore === 1 ? '행사 1일 전' : `행사 ${regionDaysBefore}일 전`) +
-    ' 오전 9시에 알림';
+  // 알림 시점 고정: 1일 전 오전 9시
+  const bookedDaysLabel = '행사 1일 전 오전 9시에 알림';
+  const regionDaysLabel = '행사 1일 전 오전 9시에 알림';
+  // const bookedDaysLabel =
+  //   (bookedDaysBefore === 1 ? '행사 1일 전' : `행사 ${bookedDaysBefore}일 전`) +
+  //   ' 오전 9시에 알림';
+  // const regionDaysLabel =
+  //   (regionDaysBefore === 1 ? '행사 1일 전' : `행사 ${regionDaysBefore}일 전`) +
+  //   ' 오전 9시에 알림';
 
   return (
     <>
@@ -351,6 +356,7 @@ export default function NotificationSettingsScreen() {
                         trackColor={{ false: '#E5E7EB', true: '#93C5FD' }}
                         thumbColor="#FFFFFF"
                       />
+                      {/* 알림 시점 선택 버튼 비활성화 (1일 전 오전 9시 고정)
                       <Pressable
                         onPress={() => openDaysModal('booked')}
                         disabled={subDisabled}
@@ -363,6 +369,7 @@ export default function NotificationSettingsScreen() {
                           color={subDisabled || !bookedOn ? '#9CA3AF' : '#4C8BF5'}
                         />
                       </Pressable>
+                      */}
                     </View>
                   </View>
                   <View style={[styles.subRow, styles.rowBorder, subDisabled && styles.rowDisabled]}>
@@ -378,6 +385,7 @@ export default function NotificationSettingsScreen() {
                         trackColor={{ false: '#E5E7EB', true: '#93C5FD' }}
                         thumbColor="#FFFFFF"
                       />
+                      {/* 알림 시점 선택 버튼 비활성화 (1일 전 오전 9시 고정)
                       <Pressable
                         onPress={() => openDaysModal('region')}
                         disabled={subDisabled}
@@ -390,6 +398,7 @@ export default function NotificationSettingsScreen() {
                           color={subDisabled || !regionOn ? '#9CA3AF' : '#4C8BF5'}
                         />
                       </Pressable>
+                      */}
                     </View>
                   </View>
                   {/* 지역 선택 UI - 추후 지역 확장 시 활성화 예정
@@ -450,6 +459,7 @@ export default function NotificationSettingsScreen() {
           </Pressable>
         </Modal>
 
+        {/* 알림 시점 선택 모달 비활성화 (1일 전 오전 9시 고정)
         <Modal
           visible={daysModalVisible}
           transparent
@@ -486,7 +496,9 @@ export default function NotificationSettingsScreen() {
             </View>
           </Pressable>
         </Modal>
+        */}
 
+        {/* 지역 더보기 메뉴 비활성화 (알림 시점 설정 제거로 불필요)
         <Modal
           visible={regionMoreVisible}
           transparent
@@ -517,6 +529,7 @@ export default function NotificationSettingsScreen() {
             </View>
           </Pressable>
         </Modal>
+        */}
       </SafeAreaView>
     </>
   );

--- a/frontend/components/detail/EventDetailHeader.tsx
+++ b/frontend/components/detail/EventDetailHeader.tsx
@@ -14,6 +14,8 @@ import {
   Alert,
   ActivityIndicator,
   Linking,
+  Modal,
+  StatusBar,
 } from "react-native";
 import * as Location from "expo-location";
 import * as Notifications from "expo-notifications";
@@ -315,9 +317,28 @@ export default function EventDetailHeader({ id, event, loading, error, onShare, 
     scheduleReminder();
   };
 
+  const [posterFullscreen, setPosterFullscreen] = useState(false);
+
   return (
     <View style={styles.container}>
-      <Image source={{ uri: posterUri }} style={styles.poster} resizeMode="cover" />
+      <Pressable onPress={() => setPosterFullscreen(true)}>
+        <Image source={{ uri: posterUri }} style={styles.poster} resizeMode="cover" />
+      </Pressable>
+
+      <Modal
+        visible={posterFullscreen}
+        transparent
+        animationType="fade"
+        statusBarTranslucent
+        onRequestClose={() => setPosterFullscreen(false)}
+      >
+        <View style={styles.fullscreenOverlay}>
+          <Image source={{ uri: posterUri }} style={styles.fullscreenImage} resizeMode="contain" />
+          <Pressable style={styles.fullscreenClose} onPress={() => setPosterFullscreen(false)} hitSlop={10}>
+            <Ionicons name="close" size={24} color="#FFFFFF" />
+          </Pressable>
+        </View>
+      </Modal>
 
       <View style={[styles.iconRow, { top: insets.top + 4 }]}>
         <Pressable onPress={() => router.back()} style={styles.iconButton} hitSlop={10}>
@@ -544,5 +565,26 @@ const styles = StyleSheet.create({
   errorSub: {
     fontSize: 14,
     color: "#6B7280",
+  },
+  fullscreenOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.95)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  fullscreenImage: {
+    width: "100%",
+    height: "100%",
+  },
+  fullscreenClose: {
+    position: "absolute",
+    top: 48,
+    right: 20,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
   },
 });


### PR DESCRIPTION
## 개요
<!-- 변경 사항을 간단히 요약해주세요 -->
- UI/UX 개선 및 버그 수정 — 포스터 전체화면, 게시글 작성 키보드 버그, 알림 설정 단순화, 행사 검색 필터 개선 외

## 관련 이슈
<!-- 이슈 완료 시 -->
- Closes #이슈번호

<!-- 이슈 미완료 시 -->
- Refs #이슈번호

## 작업 내용
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 지도 바텀시트 포스터 클릭 시 전체화면 뷰어 추가 (X 버튼으로 닫기)
- [ ] 행사 상세 포스터 클릭 시 전체화면 뷰어 추가 (X 버튼으로 닫기)
- [ ] 게시글 작성 화면에서 키보드 올라올 때 "새 게시물" 헤더가 튀어오르는 버그 수정
- [ ] 게시글 작성 행사 선택 모달 — 지역 필터를 "전체"/"충주"만 남기고 나머지 제거
- [ ] 게시글 작성 행사 선택 모달 — 월 선택을 연도+월 드럼롤 스크롤 피커로 교체
- [ ] 게시글 작성 행사 선택 모달 — 행사명 검색 버튼 제거 후 검색창 내 돋보기 아이콘 적용 (디바운스 자동검색)
- [ ] 알림 설정 — 알림 시점 선택 UI 제거, "행사 1일 전 오전 9시" 고정 텍스트로 단순화
- [ ] 알림 기록 화면 상단 여백 과다 문제 수정 (SafeAreaView 적용)
- [ ] 참여한 축제 화면 상단 안내 문구 제거
- [ ] 지도 날짜 필터 — 캘린더 그리드와 하단 버튼 사이 여백 제거
- [ ] 캘린더 탭 필터 칩 ScrollView 높이 명시로 레이아웃 갭 수정

## 체크리스트
<!-- [ ] 옆 내용을 수정해주세요 -->
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
