### PR TITLE
채팅창, 여백 등 수정

### DIFF
--- a/backend/src/main/java/com/dailo/backend/config/EventSeedRunner.java
+++ b/backend/src/main/java/com/dailo/backend/config/EventSeedRunner.java
@@ -43,10 +43,18 @@ public class EventSeedRunner implements ApplicationRunner {
         }
 
         // 2. 신규 통합 축제: Gate to YEOJEONG (2026-04-30)
-        if (!eventRepository.existsByTitleContaining("Gate to YEOJEONG")) {
-            eventRepository.save(buildGateToYeojeongFestival());
-            log.info("시드 데이터 저장: 국립한국교통대 동아리 축제 Gate to YEOJEONG");
-        }
+        // 이미 존재하면 extraJson(타임테이블) 갱신, 없으면 신규 등록
+        eventRepository.findFirstByTitleContaining("Gate to YEOJEONG").ifPresentOrElse(
+            existing -> {
+                existing.setExtraJson(buildGateToYeojeongFestival().getExtraJson());
+                eventRepository.save(existing);
+                log.info("시드 데이터 갱신: 국립한국교통대 동아리 축제 Gate to YEOJEONG (extraJson 업데이트)");
+            },
+            () -> {
+                eventRepository.save(buildGateToYeojeongFestival());
+                log.info("시드 데이터 저장: 국립한국교통대 동아리 축제 Gate to YEOJEONG");
+            }
+        );
 
         // 3. 기존 대학교 및 지역 시드 데이터 (중복 확인 후 삽입)
         if (!eventRepository.existsByTitleContaining("한국교통대 대축제")) {
@@ -81,15 +89,16 @@ public class EventSeedRunner implements ApplicationRunner {
             +   "{\"id\":\"t2\",\"startTime\":\"13:00\",\"endTime\":\"17:30\",\"title\":\"동아리 부스 운영\",\"details\":[\"체험 이벤트\",\"경품 증정\"]},"
             +   "{\"id\":\"t3\",\"startTime\":\"17:00\",\"endTime\":\"20:00\",\"title\":\"동아리 공연\","
             +   "\"performers\":["
-            +     "{\"name\":\"포세이돈\",\"genre\":\"밴드\",\"setlist\":[\"Get your Gun - 브로큰발렌타인\",\"Ao to natsu - Mrs. Greenapple\",\"Poker Face - 브로큰발렌타인\"]},"
-            +     "{\"name\":\"어울림\",\"genre\":\"밴드\",\"setlist\":[\"흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야 - 장범준\",\"나에게로 떠나는 여행 - 버즈\",\"사랑 Two - YB\"]},"
-            +     "{\"name\":\"소리담\",\"genre\":\"밴드\",\"setlist\":[\"Tokyo Inn - 혁오\",\"춤을 춰요 - 라쿠나\",\"Highlight - 터치드\"]},"
-            +     "{\"name\":\"MUSE\",\"genre\":\"밴드\",\"setlist\":[\"antifreeze - 검정치마\",\"에잇 - 아이유\",\"우리의 꿈 - 코요태\"]},"
-            +     "{\"name\":\"식스라인\",\"genre\":\"밴드\",\"setlist\":[\"Pain - 하현상\",\"금붕어 - 한로로\",\"See your eyes - 잔나비\",\"어리고 부끄럽고 바보 같은 - Xdinary Heroes\"]},"
-            +     "{\"name\":\"신문고\",\"genre\":\"밴드\",\"setlist\":[\"데칼코마니 - 마마무\",\"Loveholic - 러브홀릭\",\"나에게로 떠나는 여행 - 버즈\"]},"
-            +     "{\"name\":\"4D\",\"genre\":\"댄스\",\"setlist\":[\"내일에서 기다릴게 - 투모로우바이투게더\",\"404 - 키키\",\"할리우드 액션 - 보이넥스트도어\",\"아브라카타브라 - 미야오\",\"페이머스 - 올데이프로젝트\",\"퓨어허니 - 비욘세\",\"마음에 따라 뛰는건 멋지지않아 - 투어스\"]},"
-            +     "{\"name\":\"피날레\",\"genre\":\"댄스\",\"setlist\":[\"THAT'S A NO NO - ITZY\",\"Loving U - 씨스타\",\"10 Minutes - 이효리\",\"다시 만난 오늘 - TWS\",\"ZOO - NCT & aespa\",\"Supersonic - fromis_9\",\"Friday Night - Young Gunz\",\"짧은 치마 - AOA\"]},"
-            +     "{\"name\":\"바이탈싸인\",\"genre\":\"힙합/댄스\",\"setlist\":[\"404 - 키키\",\"Love me right + 으르렁 - EXO\",\"Bad girl good girl + 보핍보핍 (KISS OF LIFE ver.)\"]}"
+            +     "{\"name\":\"포세이돈\",\"genre\":\"밴드\",\"startTime\":\"17:10\",\"setlist\":[\"Get your Gun - 브로큰발렌타인\",\"Ao to natsu - Mrs. Greenapple\",\"Poker Face - 브로큰발렌타인\"]},"
+            +     "{\"name\":\"어울림\",\"genre\":\"밴드\",\"startTime\":\"17:27\",\"setlist\":[\"흔들리는 꽃들 속에서 네 샴푸향이 느껴진거야 - 장범준\",\"나에게로 떠나는 여행 - 버즈\",\"사랑 Two - YB\"]},"
+            +     "{\"name\":\"소리담\",\"genre\":\"밴드\",\"startTime\":\"17:44\",\"setlist\":[\"Tokyo Inn - 혁오\",\"춤을 춰요 - 라쿠나\",\"Highlight - 터치드\"]},"
+            +     "{\"name\":\"식스라인\",\"genre\":\"밴드\",\"startTime\":\"18:01\",\"setlist\":[\"Pain - 하현상\",\"금붕어 - 한로로\",\"See your eyes - 잔나비\",\"어리고 부끄럽고 바보 같은 - Xdinary Heroes\"]},"
+            +     "{\"name\":\"신문고\",\"genre\":\"밴드\",\"startTime\":\"18:23\",\"setlist\":[\"데칼코마니 - 마마무\",\"Loveholic - 러브홀릭\",\"나에게로 떠나는 여행 - 버즈\"]},"
+            +     "{\"name\":\"MUSE\",\"genre\":\"밴드\",\"startTime\":\"18:40\",\"setlist\":[\"antifreeze - 검정치마\",\"에잇 - 아이유\",\"우리의 꿈 - 코요태\"]},"
+            +     "{\"name\":\"밴드 동아리 연합\",\"genre\":\"밴드 연합\",\"startTime\":\"18:57\",\"setlist\":[]},"
+            +     "{\"name\":\"4D\",\"genre\":\"댄스\",\"startTime\":\"19:14\",\"setlist\":[\"내일에서 기다릴게 - 투모로우바이투게더\",\"404 - 키키\",\"할리우드 액션 - 보이넥스트도어\",\"아브라카타브라 - 미야오\",\"페이머스 - 올데이프로젝트\",\"퓨어허니 - 비욘세\",\"마음에 따라 뛰는건 멋지지않아 - 투어스\"]},"
+            +     "{\"name\":\"피날레\",\"genre\":\"댄스\",\"startTime\":\"19:31\",\"setlist\":[\"THAT'S A NO NO - ITZY\",\"Loving U - 씨스타\",\"10 Minutes - 이효리\",\"다시 만난 오늘 - TWS\",\"ZOO - NCT & aespa\",\"Supersonic - fromis_9\",\"Friday Night - Young Gunz\",\"짧은 치마 - AOA\"]},"
+            +     "{\"name\":\"바이탈싸인\",\"genre\":\"힙합/댄스\",\"startTime\":\"19:53\",\"setlist\":[\"404 - 키키\",\"Love me right + 으르렁 - EXO\",\"Bad girl good girl + 보핍보핍 (KISS OF LIFE ver.)\"]}"
             +   "]}"
             + "],"
             + "\"foodBooths\":["

--- a/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/EventRepository.java
@@ -85,6 +85,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     /** 시드 데이터 중복 방지: 제목에 해당 문자열이 포함된 이벤트 존재 여부 */
     boolean existsByTitleContaining(String keyword);
 
+    /** 시드 데이터 업데이트: 제목에 해당 문자열이 포함된 첫 번째 이벤트 조회 */
+    java.util.Optional<Event> findFirstByTitleContaining(String keyword);
+
     /** 제목이 정확히 일치하는 이벤트 목록 (이전 시드 삭제용) */
     List<Event> findByTitleIn(List<String> titles);
 

--- a/backend/src/main/java/com/dailo/backend/service/AdminEventService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AdminEventService.java
@@ -101,7 +101,7 @@ public class AdminEventService {
                 request.getDescription(),
                 request.getHostContact(),
                 request.getFilterGroup(),
-                request.getZonePolygon()
+                request.getZonePolygon() != null ? request.getZonePolygon() : event.getZonePolygon()
         );
         if (request.getExtraJson() != null) {
             event.setExtraJson(request.getExtraJson());

--- a/backend/src/main/resources/static/api/admin/web/index.html
+++ b/backend/src/main/resources/static/api/admin/web/index.html
@@ -243,6 +243,7 @@
   </div>
   <div class="fg"><label>설명</label><textarea id="eventDesc"></textarea></div>
   <div class="fg"><label>주최자 연락처</label><input type="text" id="eventContact"></div>
+  <div class="fg"><label>타임테이블/부스 JSON (extraJson)</label><textarea id="eventExtraJson" style="font-family:monospace;font-size:12px;height:200px;white-space:pre"></textarea></div>
   <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('eventModal')">취소</button><button class="btn btn-p btn-sm" onclick="saveEvent()">저장</button></div>
 </div></div>
 

--- a/backend/src/main/resources/static/api/admin/web/js/app.js
+++ b/backend/src/main/resources/static/api/admin/web/js/app.js
@@ -169,6 +169,10 @@ function openEventModal(id, data) {
   document.getElementById('eventFilter').value = data?.filterGroup || '';
   document.getElementById('eventDesc').value = data?.description || '';
   document.getElementById('eventContact').value = data?.hostContact || '';
+  const rawExtra = data?.extraJson;
+  document.getElementById('eventExtraJson').value = rawExtra
+    ? (typeof rawExtra === 'string' ? rawExtra : JSON.stringify(rawExtra, null, 2))
+    : '';
   document.getElementById('eventThumbKey').value = data?.thumbnailKey || data?.thumbnailUrl || '';
   const preview = document.getElementById('eventThumbPreview');
   const placeholder = document.getElementById('eventDropPlaceholder');
@@ -210,6 +214,7 @@ async function saveEvent() {
     thumbnailUrl: document.getElementById('eventThumbKey').value || null,
     description: document.getElementById('eventDesc').value || null,
     hostContact: document.getElementById('eventContact').value || null,
+    extraJson: document.getElementById('eventExtraJson').value.trim() || null,
   };
   try {
     if (id) await api(`/api/admin/events/${id}`, { method: 'PUT', body: JSON.stringify(body) });

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -41,8 +41,9 @@ function CustomTabBar({ state, navigation }: BottomTabBarProps) {
     return route ? { config, route } : null;
   }).filter(Boolean) as { config: (typeof TAB_CONFIG)[number]; route: (typeof state.routes)[number] }[];
 
+  const bottomPad = Platform.OS === 'ios' ? Math.max(insets.bottom - 12, 4) : insets.bottom;
   return (
-    <View style={[styles.tabBar, { paddingBottom: insets.bottom, height: 60 + insets.bottom }]}>
+    <View style={[styles.tabBar, { paddingBottom: bottomPad, height: 60 + bottomPad }]}>
       {tabs.map(({ config, route }) => {
         const routeIndex = state.routes.findIndex((r) => r.key === route.key);
         const isFocused = state.index === routeIndex;

--- a/frontend/app/(tabs)/home/event-list.tsx
+++ b/frontend/app/(tabs)/home/event-list.tsx
@@ -423,7 +423,7 @@ export default function EventListScreen() {
                 >
                   <Image
                     source={{
-                      uri: event.thumbnailUrl ?? "https://via.placeholder.com/200x300.png?text=Poster",
+                      uri: event.thumbnailUrl?.trim() || "https://via.placeholder.com/200x300.png?text=Poster",
                     }}
                     style={styles.eventImage}
                   />

--- a/frontend/app/(tabs)/home/index.tsx
+++ b/frontend/app/(tabs)/home/index.tsx
@@ -350,7 +350,7 @@ export default function HomeScreen() {
                     >
                       <Image
                         source={{
-                          uri: item.thumbnailUrl ?? "https://via.placeholder.com/700x380.png?text=Poster",
+                          uri: item.thumbnailUrl?.trim() || "https://via.placeholder.com/700x380.png?text=Poster",
                         }}
                         style={styles.bannerImage}
                       />
@@ -394,12 +394,7 @@ export default function HomeScreen() {
               <Text style={styles.sectionTitleAccent}>인기</Text> 게시물
             </Text>
             <Pressable
-              onPress={() => {
-                (navigation as { navigate: (name: string, params?: object) => void }).navigate(
-                  "board/index",
-                  { sort: "popular" }
-                );
-              }}
+              onPress={() => router.push("/(tabs)/board?sort=popular" as import("expo-router").Href)}
             >
               <Text style={styles.sectionMore}>더 보기 &gt;</Text>
             </Pressable>
@@ -535,7 +530,7 @@ export default function HomeScreen() {
                   >
                     <Image
                       source={{
-                        uri: event.thumbnailUrl ?? "https://via.placeholder.com/200x300.png?text=Poster",
+                        uri: event.thumbnailUrl?.trim() || "https://via.placeholder.com/200x300.png?text=Poster",
                       }}
                       style={styles.eventImage}
                     />

--- a/frontend/app/(tabs)/map/_components/FilterChips.tsx
+++ b/frontend/app/(tabs)/map/_components/FilterChips.tsx
@@ -107,13 +107,12 @@ export function FilterChips({
   const scaleLabel = selectedScaleSummary || '규모';
 
   return (
-    <View style={styles.wrapper}>
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.container}
-        style={styles.scrollView}
-      >
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.container}
+      style={styles.scrollView}
+    >
         {onPressStatus != null ? (
           <Chip
             label={statusLabel}
@@ -204,13 +203,11 @@ export function FilterChips({
           onPress={onPressScale}
           selected={!!selectedScaleSummary}
         />
-      </ScrollView>
-    </View>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  wrapper: { zIndex: 2, backgroundColor: 'transparent' },
   scrollView: { backgroundColor: 'transparent' },
   iconWrap: {
     borderWidth: 1,
@@ -238,6 +235,7 @@ const styles = StyleSheet.create({
     paddingTop: 0,
     paddingBottom: 6,
     gap: 6,
+    backgroundColor: 'transparent',
   },
   chip: {
     height: 36,

--- a/frontend/app/(tabs)/mypage/liked-festivals.tsx
+++ b/frontend/app/(tabs)/mypage/liked-festivals.tsx
@@ -91,7 +91,7 @@ export default function LikedFestivalsScreen() {
       >
         <Image
           source={{
-            uri: item.thumbnailUrl ?? "https://via.placeholder.com/80x80.png?text=+",
+            uri: item.thumbnailUrl?.trim() || "https://via.placeholder.com/80x80.png?text=+",
           }}
           style={styles.thumb}
         />

--- a/frontend/app/(tabs)/mypage/location-permission.tsx
+++ b/frontend/app/(tabs)/mypage/location-permission.tsx
@@ -1,32 +1,48 @@
 // app/(tabs)/mypage/location-permission.tsx - 위치 권한
-import React from 'react';
-import { View, Text, StyleSheet, ScrollView, Pressable, Linking, Alert } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { View, Text, StyleSheet, Pressable, Linking, Alert, ActivityIndicator } from 'react-native';
 import { Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as Location from 'expo-location';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSafeBack } from '../../../hooks/useSafeBack';
+
+type PermStatus = 'granted' | 'denied' | 'undetermined' | 'loading';
 
 export default function LocationPermissionScreen() {
   const safeBack = useSafeBack();
-  const openAppSettings = () => {
-    Linking.openSettings().catch(() => {
-      Alert.alert('안내', '설정 앱을 열 수 없습니다.');
-    });
-  };
+  const [status, setStatus] = useState<PermStatus>('loading');
 
-  const checkPermission = async () => {
-    const { status } = await Location.getForegroundPermissionsAsync();
-    if (status === Location.PermissionStatus.GRANTED) {
-      Alert.alert('위치 권한', '위치 권한이 허용되어 있습니다.');
-    } else {
+  const checkStatus = useCallback(async () => {
+    setStatus('loading');
+    try {
+      const { status: s } = await Location.getForegroundPermissionsAsync();
+      setStatus(s as PermStatus);
+    } catch {
+      setStatus('undetermined');
+    }
+  }, []);
+
+  useFocusEffect(useCallback(() => { checkStatus(); }, [checkStatus]));
+
+  const handleRequest = async () => {
+    const { status: s } = await Location.requestForegroundPermissionsAsync();
+    setStatus(s as PermStatus);
+    if (s !== Location.PermissionStatus.GRANTED) {
       Alert.alert(
-        '위치 권한',
-        '위치 권한이 허용되지 않았습니다. 지도에서 현재 위치·주변 행사 보기를 사용하려면 설정에서 허용해 주세요.',
-        [{ text: '취소', style: 'cancel' }, { text: '설정 열기', onPress: openAppSettings }]
+        '위치 권한 필요',
+        '설정 앱에서 위치 권한을 허용해 주세요.',
+        [{ text: '취소', style: 'cancel' }, { text: '설정 열기', onPress: () => Linking.openSettings() }]
       );
     }
   };
+
+  const handleOpenSettings = () => {
+    Linking.openSettings().catch(() => Alert.alert('안내', '설정 앱을 열 수 없습니다.'));
+  };
+
+  const isGranted = status === 'granted';
 
   return (
     <>
@@ -43,74 +59,135 @@ export default function LocationPermissionScreen() {
         }}
       />
       <SafeAreaView style={styles.safeArea} edges={['left', 'right', 'bottom']}>
-        <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-          <View style={styles.iconWrap}>
-            <Ionicons name="location-outline" size={48} color="#4C8BF5" />
+        <View style={styles.container}>
+
+          {/* 상태 카드 */}
+          <View style={[styles.statusCard, isGranted ? styles.statusCardOn : styles.statusCardOff]}>
+            <View style={[styles.statusIconWrap, isGranted ? styles.statusIconOn : styles.statusIconOff]}>
+              {status === 'loading' ? (
+                <ActivityIndicator size="small" color={isGranted ? '#10B981' : '#F59E0B'} />
+              ) : (
+                <Ionicons
+                  name={isGranted ? 'location' : 'location-outline'}
+                  size={28}
+                  color={isGranted ? '#10B981' : '#F59E0B'}
+                />
+              )}
+            </View>
+            <View style={styles.statusTextWrap}>
+              <Text style={styles.statusLabel}>위치 권한</Text>
+              <Text style={[styles.statusValue, isGranted ? styles.statusValueOn : styles.statusValueOff]}>
+                {status === 'loading' ? '확인 중...' : isGranted ? '허용됨' : '거부됨'}
+              </Text>
+            </View>
+            <View style={[styles.statusBadge, isGranted ? styles.statusBadgeOn : styles.statusBadgeOff]}>
+              <Ionicons
+                name={isGranted ? 'checkmark-circle' : 'close-circle'}
+                size={20}
+                color={isGranted ? '#10B981' : '#EF4444'}
+              />
+            </View>
           </View>
-          <Text style={styles.title}>위치 권한이 필요해요</Text>
-          <Text style={styles.description}>
-            지도에서 현재 위치 버튼 사용, 주변 행사 보기, 축제 구역 진입 알림 등을 위해 위치 권한을 허용해 주세요.
-          </Text>
-          <View style={styles.bullets}>
-            <Text style={styles.bullet}>• 현재 위치 기준으로 주변 행사를 볼 수 있어요</Text>
-            <Text style={styles.bullet}>• 축제 구역에 들어가면 참여 상태가 자동으로 기록돼요</Text>
+
+          {/* 설명 */}
+          <View style={styles.infoBox}>
+            <InfoRow icon="map-outline" text="지도에서 현재 위치 및 주변 행사를 볼 수 있어요" />
+            <InfoRow icon="walk-outline" text="축제 구역에 들어가면 참여 상태가 자동 기록돼요" />
+            <InfoRow icon="navigate-outline" text="현재 위치 기준 길 안내를 사용할 수 있어요" />
           </View>
-          <Pressable style={styles.primaryButton} onPress={openAppSettings}>
-            <Text style={styles.primaryButtonText}>설정에서 권한 변경</Text>
+
+          {/* 액션 버튼 */}
+          {!isGranted && status !== 'loading' && (
+            <Pressable style={styles.primaryButton} onPress={handleRequest}>
+              <Ionicons name="location" size={18} color="#FFFFFF" style={{ marginRight: 8 }} />
+              <Text style={styles.primaryButtonText}>위치 권한 허용하기</Text>
+            </Pressable>
+          )}
+
+          <Pressable style={styles.secondaryButton} onPress={handleOpenSettings}>
+            <Ionicons name="settings-outline" size={16} color="#6B7280" style={{ marginRight: 6 }} />
+            <Text style={styles.secondaryButtonText}>시스템 설정에서 변경</Text>
           </Pressable>
-          <Pressable style={styles.secondaryButton} onPress={checkPermission}>
-            <Text style={styles.secondaryButtonText}>권한 상태 확인</Text>
-          </Pressable>
-        </ScrollView>
+
+        </View>
       </SafeAreaView>
     </>
   );
 }
 
+function InfoRow({ icon, text }: { icon: keyof typeof Ionicons.glyphMap; text: string }) {
+  return (
+    <View style={styles.infoRow}>
+      <Ionicons name={icon} size={16} color="#4C8BF5" style={styles.infoIcon} />
+      <Text style={styles.infoText}>{text}</Text>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   headerBackButton: { paddingLeft: 4, paddingRight: 10 },
-  safeArea: { flex: 1, backgroundColor: '#F9FAFB' },
-  container: { flex: 1 },
-  content: { padding: 24, paddingBottom: 32 },
-  iconWrap: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: '#EFF6FF',
+  safeArea: { flex: 1, backgroundColor: '#F3F4F6' },
+  container: { flex: 1, padding: 20, gap: 16 },
+
+  statusCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 16,
+    padding: 20,
+    gap: 16,
+  },
+  statusCardOn: { backgroundColor: '#F0FDF4', borderWidth: 1, borderColor: '#BBF7D0' },
+  statusCardOff: { backgroundColor: '#FFFBEB', borderWidth: 1, borderColor: '#FDE68A' },
+
+  statusIconWrap: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
     alignItems: 'center',
     justifyContent: 'center',
-    alignSelf: 'center',
-    marginBottom: 20,
   },
-  title: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: '#111827',
-    textAlign: 'center',
-    marginBottom: 12,
+  statusIconOn: { backgroundColor: '#DCFCE7' },
+  statusIconOff: { backgroundColor: '#FEF3C7' },
+
+  statusTextWrap: { flex: 1 },
+  statusLabel: { fontSize: 13, color: '#6B7280', marginBottom: 4 },
+  statusValue: { fontSize: 17, fontWeight: '700' },
+  statusValueOn: { color: '#10B981' },
+  statusValueOff: { color: '#D97706' },
+
+  statusBadge: { padding: 4 },
+  statusBadgeOn: {},
+  statusBadgeOff: {},
+
+  infoBox: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 14,
+    padding: 18,
+    gap: 14,
   },
-  description: {
-    fontSize: 14,
-    color: '#6B7280',
-    lineHeight: 22,
-    textAlign: 'center',
-    marginBottom: 20,
-  },
-  bullets: { marginBottom: 24 },
-  bullet: {
-    fontSize: 13,
-    color: '#4B5563',
-    lineHeight: 22,
-    marginBottom: 4,
-  },
+  infoRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+  infoIcon: { marginTop: 1 },
+  infoText: { flex: 1, fontSize: 14, color: '#374151', lineHeight: 20 },
+
   primaryButton: {
+    flexDirection: 'row',
     backgroundColor: '#4C8BF5',
-    paddingVertical: 14,
-    borderRadius: 12,
+    paddingVertical: 15,
+    borderRadius: 14,
     alignItems: 'center',
-    marginBottom: 10,
+    justifyContent: 'center',
   },
-  primaryButtonText: { fontSize: 15, fontWeight: '600', color: '#FFFFFF' },
-  secondaryButton: { paddingVertical: 14, alignItems: 'center' },
-  secondaryButtonText: { fontSize: 14, color: '#6B7280' },
+  primaryButtonText: { fontSize: 15, fontWeight: '700', color: '#FFFFFF' },
+
+  secondaryButton: {
+    flexDirection: 'row',
+    paddingVertical: 14,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  secondaryButtonText: { fontSize: 14, color: '#6B7280', fontWeight: '500' },
 });

--- a/frontend/app/(tabs)/mypage/saved-festivals.tsx
+++ b/frontend/app/(tabs)/mypage/saved-festivals.tsx
@@ -45,12 +45,7 @@ function formatTimeRange(startIso: string, endIso?: string): string {
 export default function SavedFestivalsScreen() {
   const { from } = useLocalSearchParams<{ from?: string }>();
   const goBack = () => {
-    if (from === 'map') {
-      router.replace('/(tabs)/mypage');
-      router.replace('/(tabs)/map');
-    } else {
-      router.replace('/(tabs)/mypage');
-    }
+    router.back();
   };
   const [list, setList] = useState<scrapService.ScrapEventItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -222,7 +217,7 @@ export default function SavedFestivalsScreen() {
                       >
                         <Image
                           source={{
-                            uri: item.thumbnailUrl ?? "https://via.placeholder.com/200x300.png?text=Poster",
+                            uri: item.thumbnailUrl?.trim() || "https://via.placeholder.com/200x300.png?text=Poster",
                           }}
                           style={styles.eventImage}
                         />

--- a/frontend/app/(tabs)/mypage/saved-reminders.tsx
+++ b/frontend/app/(tabs)/mypage/saved-reminders.tsx
@@ -127,7 +127,7 @@ export default function SavedRemindersScreen() {
     <SafeAreaView style={styles.safeArea} edges={["top", "left", "right", "bottom"]}>
       <View style={styles.container}>
         <View style={styles.header}>
-          <Pressable style={styles.headerBack} onPress={() => router.replace("/(tabs)/mypage")}>
+          <Pressable style={styles.headerBack} onPress={() => router.back()}>
             <Ionicons name="arrow-back" size={22} color="#111827" />
           </Pressable>
           <View style={styles.headerTitleWrap} pointerEvents="box-none">
@@ -204,7 +204,7 @@ export default function SavedRemindersScreen() {
                         >
                           <Image
                             source={{
-                              uri: item.thumbnailUrl ?? "https://via.placeholder.com/200x300.png?text=Poster",
+                              uri: item.thumbnailUrl?.trim() || "https://via.placeholder.com/200x300.png?text=Poster",
                             }}
                             style={styles.eventImage}
                           />

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,13 +1,17 @@
 // app/_layout.tsx
 import React, { useEffect } from 'react';
-import { AppState, BackHandler } from 'react-native';
+import { Alert, AppState, BackHandler } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import Constants from 'expo-constants';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AuthProvider } from '../contexts/AuthContext';
 import { AuthDeepLinkHandler } from '../components/AuthDeepLinkHandler';
 import AppStartupPopupModal from '../components/AppStartupPopupModal';
+
+const NOTIF_PROMPT_KEY = '@app/notification_prompt_shown';
+const PUSH_ENABLED_KEY = '@mypage/notification_push_enabled';
 import { reconcileFestivalParticipationIfOutsideZone } from '../services/festivalParticipationReconcile';
 import { flushPendingStaySyncQueue } from '../services/staySessionSync';
 import { saveNotificationRecord } from '../services/notificationHistory.service';
@@ -53,6 +57,40 @@ export default function RootLayout() {
     const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
     return () => subscription.remove();
   }, [segments, router]);
+
+  // 첫 실행 시 알림 허용 여부 묻기
+  useEffect(() => {
+    (async () => {
+      try {
+        const shown = await AsyncStorage.getItem(NOTIF_PROMPT_KEY);
+        if (shown) return;
+        await AsyncStorage.setItem(NOTIF_PROMPT_KEY, 'true');
+        // 아직 설정값이 없는 경우에만 묻기
+        const existing = await AsyncStorage.getItem(PUSH_ENABLED_KEY);
+        if (existing !== null) return;
+        Alert.alert(
+          '알림 설정',
+          '새로운 행사와 소식을 알림으로 받아보시겠어요?',
+          [
+            {
+              text: '나중에',
+              style: 'cancel',
+              onPress: async () => {
+                await AsyncStorage.setItem(PUSH_ENABLED_KEY, 'false');
+              },
+            },
+            {
+              text: '알림 허용',
+              onPress: async () => {
+                const { status } = await Notifications.requestPermissionsAsync();
+                await AsyncStorage.setItem(PUSH_ENABLED_KEY, status === 'granted' ? 'true' : 'false');
+              },
+            },
+          ],
+        );
+      } catch {}
+    })();
+  }, []);
 
   useEffect(() => {
     const sub = Notifications.addNotificationReceivedListener((notification) => {

--- a/frontend/app/board/chat/[id].tsx
+++ b/frontend/app/board/chat/[id].tsx
@@ -1,13 +1,16 @@
 // app/board/chat/[id].tsx - 채팅화면 (1:1 대화, 백엔드 메시지 히스토리 연동)
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
-import React, { useCallback, useEffect, useState } from "react";
+import * as ImagePicker from "expo-image-picker";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
   Image,
+  Keyboard,
   KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -15,7 +18,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import * as authService from "../../../services/auth.service";
 import * as blockService from "../../../services/block.service";
 import * as chatService from "../../../services/chat.service";
@@ -25,6 +28,7 @@ type Message = {
   id: string;
   isMe: boolean;
   text: string;
+  imageUrl?: string;
   time?: string;
   createdAt?: string;
 };
@@ -54,10 +58,10 @@ function formatMessageTime(iso?: string): string {
       parsedDate = new Date(iso);
 
     } 
-    // 🔥 타임존 없는 경우 → 서버 시간을 UTC로 간주
+    // 🔥 타임존 없는 경우 → 서버 시간을 KST(+09:00)로 간주
     else {
 
-      parsedDate = new Date(iso + "Z");
+      parsedDate = new Date(iso + "+09:00");
 
     }
     const h = parsedDate.getHours();
@@ -76,6 +80,11 @@ export default function ChatRoomScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const roomId = id ? Number(id) : 0;
+  const insets = useSafeAreaInsets();
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollToEnd = useCallback((animated = true) => {
+    scrollRef.current?.scrollToEnd({ animated });
+  }, []);
   const [input, setInput] = useState("");
   const [room, setRoom] = useState<chatService.ChatRoomResponse | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
@@ -131,7 +140,8 @@ export default function ChatRoomScreen() {
       const raw = (msgData.content ?? []).map((m) => ({
         id: String(m.id),
         isMe: m.senderId === myId,
-        text: m.content ?? "",
+        text: m.messageType === 'IMAGE' ? '' : (m.content ?? ""),
+        imageUrl: m.messageType === 'IMAGE' ? (m.content ?? undefined) : undefined,
         time: formatMessageTime(m.createdAt),
         createdAt: m.createdAt,
       }));
@@ -147,6 +157,20 @@ export default function ChatRoomScreen() {
   useEffect(() => {
     fetchRoomAndMessages();
   }, [fetchRoomAndMessages]);
+
+  // 메시지 목록 변경 시 맨 아래로 스크롤
+  useEffect(() => {
+    if (messages.length > 0) {
+      const t = setTimeout(() => scrollToEnd(false), 80);
+      return () => clearTimeout(t);
+    }
+  }, [messages, scrollToEnd]);
+
+  // 키보드가 올라올 때 맨 아래로 스크롤
+  useEffect(() => {
+    const sub = Keyboard.addListener("keyboardDidShow", () => scrollToEnd(true));
+    return () => sub.remove();
+  }, [scrollToEnd]);
 
   // 앱 재진입·다시 들어올 때마다 서버에서 메시지 다시 로드 (채팅 기록 유지)
   useFocusEffect(
@@ -189,6 +213,45 @@ export default function ChatRoomScreen() {
     } catch {
       setMessages((prev) => prev.filter((m) => m.id !== optimisticId));
       Alert.alert("오류", "메시지 전송에 실패했습니다.");
+    }
+  };
+
+  const [imageUploading, setImageUploading] = useState(false);
+
+  const handleSendImage = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('권한 필요', '사진 전송을 위해 갤러리 접근 권한이 필요합니다.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.8,
+      allowsEditing: false,
+    });
+    if (result.canceled || !result.assets?.[0]?.uri) return;
+    const uri = result.assets[0].uri;
+    const optimisticId = `img${Date.now()}`;
+    const now = new Date().toISOString();
+    setMessages((prev) => [
+      ...prev,
+      { id: optimisticId, isMe: true, text: '', imageUrl: uri, time: formatMessageTime(now), createdAt: now },
+    ]);
+    setImageUploading(true);
+    try {
+      const sent = await chatService.sendChatImage(roomId, uri);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === optimisticId
+            ? { id: String(sent.id), isMe: true, text: '', imageUrl: sent.content ?? uri, time: formatMessageTime(sent.createdAt), createdAt: sent.createdAt }
+            : m,
+        ),
+      );
+    } catch {
+      setMessages((prev) => prev.filter((m) => m.id !== optimisticId));
+      Alert.alert('오류', '사진 전송에 실패했습니다.');
+    } finally {
+      setImageUploading(false);
     }
   };
 
@@ -251,7 +314,7 @@ export default function ChatRoomScreen() {
     <SafeAreaView style={styles.safeArea} edges={["top"]}>
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior="padding"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={0}
       >
         <View style={styles.header}>
@@ -317,10 +380,12 @@ export default function ChatRoomScreen() {
           </View>
         ) : (
           <ScrollView
+            ref={scrollRef}
             style={styles.scroll}
             contentContainerStyle={styles.scrollContent}
             keyboardShouldPersistTaps="handled"
             showsVerticalScrollIndicator={false}
+            onContentSizeChange={() => scrollToEnd(false)}
           >
             {messages.map((msg, index) => {
               const isLastOtherInRow =
@@ -354,9 +419,13 @@ export default function ChatRoomScreen() {
                           <Text style={styles.messageTime}>{msg.time}</Text>
                         ) : null}
                       </View>
-                      <View style={styles.myBubble}>
-                        <Text style={styles.myText}>{msg.text}</Text>
-                      </View>
+                      {msg.imageUrl ? (
+                        <Image source={{ uri: msg.imageUrl }} style={styles.chatImage} resizeMode="cover" />
+                      ) : (
+                        <View style={styles.myBubble}>
+                          <Text style={styles.myText}>{msg.text}</Text>
+                        </View>
+                      )}
                     </View>
                   ) : (
                     <View
@@ -366,13 +435,21 @@ export default function ChatRoomScreen() {
                       ]}
                     >
                       {isLastOtherInRow ? (
-                        <View style={styles.otherAvatar} />
+                        partnerImageUri ? (
+                          <Image source={{ uri: partnerImageUri }} style={styles.otherAvatar} />
+                        ) : (
+                          <View style={styles.otherAvatar} />
+                        )
                       ) : (
                         <View style={styles.otherAvatarPlaceholder} />
                       )}
-                      <View style={styles.otherBubble}>
-                        <Text style={styles.otherText}>{msg.text}</Text>
-                      </View>
+                      {msg.imageUrl ? (
+                        <Image source={{ uri: msg.imageUrl }} style={styles.chatImage} resizeMode="cover" />
+                      ) : (
+                        <View style={styles.otherBubble}>
+                          <Text style={styles.otherText}>{msg.text}</Text>
+                        </View>
+                      )}
                       {msg.time ? (
                         <Text style={styles.messageTime}>{msg.time}</Text>
                       ) : null}
@@ -386,15 +463,17 @@ export default function ChatRoomScreen() {
 
         {/* 입력 영역 */}
         {partnerLeft ? (
-          <View style={styles.partnerLeftBanner}>
+          <View style={[styles.partnerLeftBanner, Platform.OS === 'ios' && { paddingBottom: insets.bottom + 14 }]}>
             <Text style={styles.partnerLeftText}>
               상대방이 채팅방을 나갔습니다.
             </Text>
           </View>
         ) : (
-          <View style={styles.inputRow}>
-            <Pressable style={styles.inputIcon}>
-              <Ionicons name="image-outline" size={24} color="#4C8BF5" />
+          <View style={[styles.inputRow, Platform.OS === 'ios' && { paddingBottom: insets.bottom + 10 }]}>
+            <Pressable style={styles.inputIcon} onPress={handleSendImage} disabled={imageUploading}>
+              {imageUploading
+                ? <ActivityIndicator size="small" color="#4C8BF5" />
+                : <Ionicons name="image-outline" size={24} color="#4C8BF5" />}
             </Pressable>
             <TextInput
               style={styles.input}
@@ -526,6 +605,7 @@ const styles = StyleSheet.create({
   },
   sendBtn: { padding: 4, marginBottom: 4 },
   sendBtnDisabled: { opacity: 0.6 },
+  chatImage: { width: 200, height: 200, borderRadius: 12 },
   menuBackdrop: {
     flex: 1,
     backgroundColor: "rgba(0,0,0,0.4)",

--- a/frontend/app/board/write.tsx
+++ b/frontend/app/board/write.tsx
@@ -357,7 +357,7 @@ export default function PostWriteScreen() {
     <SafeAreaView style={styles.safeArea} edges={["top"]}>
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={0}
       >
         {/* 헤더: 취소 | 새 게시물 | 공유 */}

--- a/frontend/app/event/[id].tsx
+++ b/frontend/app/event/[id].tsx
@@ -99,9 +99,10 @@ export default function EventDetailScreen() {
         ? {
             ...event,
             thumbnailUrl:
-              (thumbnailFromRoute as string | null | undefined) ??
-              (event as typeof event & { thumbnailUrl?: string | null }).thumbnailUrl ??
-              (event.posterUrls?.[0] ?? null),
+              thumbnailFromRoute?.trim() ||
+              (event as typeof event & { thumbnailUrl?: string | null }).thumbnailUrl?.trim() ||
+              event.posterUrls?.[0] ||
+              null,
           }
         : event,
     [event, thumbnailFromRoute]

--- a/frontend/app/notification-settings.tsx
+++ b/frontend/app/notification-settings.tsx
@@ -90,13 +90,16 @@ export default function NotificationSettingsScreen() {
           try {
             const serverSettings = await notificationService.getNotificationSettings();
             if (serverSettings) {
-              setPushEnabled(serverSettings.newEventEnabled);
+              // 로컬에 이미 설정값이 있을 때만 서버 값으로 동기화 (첫 설치 시 서버 true가 덮어쓰는 것 방지)
+              if (push !== null) {
+                setPushEnabled(serverSettings.newEventEnabled);
+                await AsyncStorage.setItem(STORAGE_KEYS.pushEnabled, String(serverSettings.newEventEnabled));
+              }
               setEventReminderOn(serverSettings.eventReminderEnabled);
               if (serverSettings.subscribedRegions) {
                 setRegionKey(serverSettings.subscribedRegions);
                 setRegionOn(true);
               }
-              await AsyncStorage.setItem(STORAGE_KEYS.pushEnabled, String(serverSettings.newEventEnabled));
               await AsyncStorage.setItem(STORAGE_KEYS.eventReminder, String(serverSettings.eventReminderEnabled));
               if (serverSettings.subscribedRegions) {
                 await AsyncStorage.setItem(STORAGE_KEYS.eventReminderRegionKey, serverSettings.subscribedRegions);

--- a/frontend/components/detail/EventDetailHeader.tsx
+++ b/frontend/components/detail/EventDetailHeader.tsx
@@ -283,6 +283,16 @@ export default function EventDetailHeader({ id, event, loading, error, onShare, 
     );
     if (notifId) {
       setHasReminder(true);
+      // 알림설정 페이지와 일치하도록 AsyncStorage 동기화
+      try {
+        await AsyncStorage.multiSet([
+          ["@mypage/notification_push_enabled", "true"],
+          ["@mypage/notification_event_reminder", "true"],
+          ["@mypage/notification_event_reminder_booked", "true"],
+        ]);
+      } catch {
+        // 설정 저장 실패해도 알림 예약 자체는 성공
+      }
       const msg =
         daysBefore === 1
           ? "행사 1일 전 오전 9시에 알림을 보내드립니다."

--- a/frontend/services/chat.service.ts
+++ b/frontend/services/chat.service.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from '../constants/api';
 import { getAccessToken } from './auth.service';
+import { createFormDataFile } from '../utils/uploadFormData';
 
 /** 인증 헤더 (JWT 토큰 필수) */
 const getAuthHeaders = async (): Promise<HeadersInit> => {
@@ -138,6 +139,32 @@ export async function sendMessage(
     body: JSON.stringify({ content, messageType: 'TEXT' }),
   });
   if (!res.ok) throw new Error(`send message failed: ${res.status}`);
+  return res.json();
+}
+
+/** 이미지 업로드 후 IMAGE 타입 메시지 전송 */
+export async function sendChatImage(roomId: number, imageUri: string): Promise<ChatMessageResponse> {
+  const token = await getAccessToken();
+  if (!token) throw new Error('로그인이 필요합니다.');
+  const formData = new FormData();
+  formData.append('file', createFormDataFile(imageUri, 'chat_photo.jpg') as unknown as Blob);
+  const uploadRes = await fetch(`${API_BASE_URL}/api/upload`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+  if (!uploadRes.ok) throw new Error(`이미지 업로드 실패: ${uploadRes.status}`);
+  const uploadData = (await uploadRes.json()) as { path?: string };
+  const path = uploadData?.path ?? '';
+  if (!path) throw new Error('업로드 응답에 path가 없습니다.');
+  const imageUrl = `${API_BASE_URL}${path}`;
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE_URL}/api/chat/rooms/${roomId}/messages`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ content: imageUrl, messageType: 'IMAGE' }),
+  });
+  if (!res.ok) throw new Error(`이미지 메시지 전송 실패: ${res.status}`);
   return res.json();
 }
 


### PR DESCRIPTION
## 개요
채팅, 게시글 작성, 관리자 페이지, 마이페이지 등 다수의 UX 버그 수정 및 기능 개선

## 관련 이슈
- Refs #

## 작업 내용
- [x] [백엔드] Gate to YEOJEONG 타임테이블 데이터 갱신 — 공연 순서 수정(식스라인·신문고·MUSE 재정렬), 밴드 동아리 연합 추가, 각 팀별 startTime 필드 추가. 서버 재시작 시 기존 행사의 extraJson을 자동 갱신하도록 시드 로직 변경
- [x] [백엔드] 관리자 페이지 행사 수정 시 zonePolygon 초기화 버그 수정 — 요청에 zonePolygon이 없을 경우 기존 값을 유지하도록 null-safe 처리
- [x] [관리자 웹] 행사 수정 모달에 extraJson 편집 기능 추가 — 타임테이블/부스 JSON을 직접 수정·저장할 수 있는 textarea 추가
- [x] [프론트] 저장한 축제 / 알림 예약한 축제 뒤로가기 애니메이션 수정 — router.replace → router.back()으로 변경해 오른쪽으로 사라지는 pop 애니메이션 적용
- [x] [프론트] 위치 권한 설정 화면 UI 개선 — 현재 권한 상태 카드(허용됨/거부됨) 표시, 화면 재진입 시 상태 자동 갱신, 상태에 따른 허용하기 버튼 표시
- [x] [프론트] 홈 탭 인기게시물 더보기 버튼 이동 수정 — navigation.navigate → router.push("/(tabs)/board?sort=popular")로 변경
- [x] [프론트] 채팅 화면 개선 — iOS 입력창 하단 safe area 여백 추가, 상대방 프로필 사진 말풍선 옆 표시, 키보드 올라올 때 최신 메시지 자동 스크롤
- [x] [프론트] 채팅·게시글 작성 화면 키보드 겹침 버그 수정 (Android) — softwareKeyboardLayoutMode: resize 설정과 KeyboardAvoidingView behavior="height" 이중 적용 문제 해결. Android에서 behavior={undefined}로 변경

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
