### PR TITLE
마커 숫자, 곡목 수정, 대시보드, 채팅시간

### DIFF
--- a/backend/src/main/java/com/dailo/backend/BackendApplication.java
+++ b/backend/src/main/java/com/dailo/backend/BackendApplication.java
@@ -3,9 +3,10 @@ package com.dailo.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.TimeZone;
 
 @EnableCaching
 @EnableAsync
@@ -14,6 +15,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class BackendApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(BackendApplication.class, args);
 	}
 

--- a/backend/src/main/java/com/dailo/backend/config/EventSeedRunner.java
+++ b/backend/src/main/java/com/dailo/backend/config/EventSeedRunner.java
@@ -98,7 +98,7 @@ public class EventSeedRunner implements ApplicationRunner {
             +     "{\"name\":\"밴드 동아리 연합\",\"genre\":\"밴드 연합\",\"startTime\":\"18:57\",\"setlist\":[]},"
             +     "{\"name\":\"4D\",\"genre\":\"댄스\",\"startTime\":\"19:14\",\"setlist\":[\"내일에서 기다릴게 - 투모로우바이투게더\",\"404 - 키키\",\"할리우드 액션 - 보이넥스트도어\",\"아브라카타브라 - 미야오\",\"페이머스 - 올데이프로젝트\",\"퓨어허니 - 비욘세\",\"마음에 따라 뛰는건 멋지지않아 - 투어스\"]},"
             +     "{\"name\":\"피날레\",\"genre\":\"댄스\",\"startTime\":\"19:31\",\"setlist\":[\"THAT'S A NO NO - ITZY\",\"Loving U - 씨스타\",\"10 Minutes - 이효리\",\"다시 만난 오늘 - TWS\",\"ZOO - NCT & aespa\",\"Supersonic - fromis_9\",\"Friday Night - Young Gunz\",\"짧은 치마 - AOA\"]},"
-            +     "{\"name\":\"바이탈싸인\",\"genre\":\"힙합/댄스\",\"startTime\":\"19:53\",\"setlist\":[\"404 - 키키\",\"Love me right + 으르렁 - EXO\",\"Bad girl good girl + 보핍보핍 (KISS OF LIFE ver.)\"]}"
+            +     "{\"name\":\"바이탈싸인\",\"genre\":\"힙합/댄스\",\"startTime\":\"19:53\",\"setlist\":[\"Pubic Enemy VAXA remix\",\"404 - KiiiKiii\",\"Black swan VAXA remix\",\"Love me right - EXO\",\"으르렁 - EXO\",\"Final - VAXA\",\"Bad girl good girl - Miss A\",\"Bo peep Bo peep - 티아라\",\"Vital xignz up - VAXA\"]}"
             +   "]}"
             + "],"
             + "\"foodBooths\":["

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,6 +8,9 @@ spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:changeme}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# Timezone (JVM 기본 타임존은 BackendApplication.main에서 Asia/Seoul로 설정)
+spring.jackson.time-zone=Asia/Seoul
+
 # JPA Settings
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/backend/src/main/resources/static/api/admin/web/index.html
+++ b/backend/src/main/resources/static/api/admin/web/index.html
@@ -6,6 +6,15 @@
   <title>Dailo Admin</title>
   <link rel="stylesheet" href="/api/admin/web/css/style.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <style>
+    .performer-card{background:#f8fafc;border:1px solid var(--border);border-radius:8px;padding:12px;margin-bottom:2px}
+    .performer-header{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px}
+    .performer-header input{padding:5px 8px;border:1px solid var(--border);border-radius:6px;font-size:13px;background:#fff}
+    .setlist-wrap{padding-left:4px}
+    .song-row{display:flex;align-items:center;gap:6px;margin-bottom:5px}
+    .song-num{font-size:12px;color:var(--muted);min-width:22px;text-align:right}
+    .song-input{flex:1;padding:4px 8px;border:1px solid var(--border);border-radius:6px;font-size:13px}
+  </style>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
@@ -243,7 +252,20 @@
   </div>
   <div class="fg"><label>설명</label><textarea id="eventDesc"></textarea></div>
   <div class="fg"><label>주최자 연락처</label><input type="text" id="eventContact"></div>
-  <div class="fg"><label>타임테이블/부스 JSON (extraJson)</label><textarea id="eventExtraJson" style="font-family:monospace;font-size:12px;height:200px;white-space:pre"></textarea></div>
+  <div class="fg">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+      <label style="margin-bottom:0">동아리 공연 팀 편집</label>
+      <button type="button" class="btn btn-g btn-sm" onclick="addPerformerRow()" style="font-size:12px">+ 팀 추가</button>
+    </div>
+    <div id="performerList"></div>
+  </div>
+  <div class="fg">
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+      <label style="margin-bottom:0;font-size:12px;color:var(--muted)">기타 JSON (extraJson)</label>
+      <button type="button" onclick="toggleExtraJsonRaw()" class="btn btn-g btn-sm" style="font-size:11px;padding:2px 8px" id="toggleJsonBtn">JSON 보기/숨기기</button>
+    </div>
+    <textarea id="eventExtraJson" style="font-family:monospace;font-size:12px;height:200px;white-space:pre;display:none"></textarea>
+  </div>
   <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('eventModal')">취소</button><button class="btn btn-p btn-sm" onclick="saveEvent()">저장</button></div>
 </div></div>
 

--- a/backend/src/main/resources/static/api/admin/web/js/app.js
+++ b/backend/src/main/resources/static/api/admin/web/js/app.js
@@ -94,23 +94,97 @@ function pagingHtml(id, page, totalPages, fn) {
 
 // ===== Dashboard =====
 async function loadDashboard() {
+  document.getElementById('dashStats').innerHTML = '<div class="stat"><div class="l" style="text-align:center;padding:20px">로딩 중…</div></div>';
   try {
-    const d = await apiJson('/api/admin/dashboard');
-    const ms = d.memberStats || d;
-    const es = d.eventStats || d;
-    const ps = d.postStats || d;
-    const rs = d.reportStats || d;
-    const is = d.inquiryStats || d;
-    document.getElementById('dashStats').innerHTML = `
-      <div class="stat"><div class="l">전체 회원</div><div class="v">${ms.totalMembers ?? '-'}</div></div>
-      <div class="stat"><div class="l">오늘 가입</div><div class="v">${ms.todaySignups ?? '-'}</div></div>
-      <div class="stat"><div class="l">전체 행사</div><div class="v">${es.totalEvents ?? '-'}</div></div>
-      <div class="stat"><div class="l">전체 게시글</div><div class="v">${ps.totalPosts ?? '-'}</div></div>
-      <div class="stat"><div class="l">미처리 신고</div><div class="v">${rs.pendingReports ?? '-'}</div></div>
-      <div class="stat"><div class="l">미처리 문의</div><div class="v">${is.pendingInquiries ?? '-'}</div></div>
-    `;
+    const [d, activity] = await Promise.all([
+      apiJson('/api/admin/dashboard'),
+      apiJson('/api/admin/dashboard/daily-activity').catch(() => null),
+    ]);
+    const ms = d.memberStats;
+    const es = d.eventStats;
+    const ps = d.postStats;
+    const rs = d.reportStats;
+    const is = d.inquiryStats;
+
+    // 1. 핵심 지표 카드
+    let html = '<div class="stats">';
+    html += '<div class="stat"><div class="l">전체 회원</div><div class="v">' + ms.total + '</div>'
+          + (ms.todaySignups > 0 ? '<div style="font-size:12px;color:var(--success);margin-top:4px">+' + ms.todaySignups + ' 오늘 가입</div>' : '') + '</div>';
+    html += '<div class="stat"><div class="l">활성 회원</div><div class="v" style="color:var(--success)">' + ms.active + '</div>'
+          + (ms.suspended > 0 ? '<div style="font-size:12px;color:var(--warn);margin-top:4px">정지 ' + ms.suspended + '명</div>' : '') + '</div>';
+    html += '<div class="stat"><div class="l">전체 행사</div><div class="v">' + es.total + '</div>'
+          + '<div style="font-size:12px;color:var(--success);margin-top:4px">ACTIVE ' + es.active + '</div></div>';
+    html += '<div class="stat"><div class="l">전체 게시글</div><div class="v">' + ps.total + '</div>'
+          + (ps.todayPosts > 0 ? '<div style="font-size:12px;color:var(--success);margin-top:4px">+' + ps.todayPosts + ' 오늘</div>' : '') + '</div>';
+    html += '<div class="stat"><div class="l">미처리 신고</div>'
+          + '<div class="v" style="' + (rs.pending > 0 ? 'color:var(--danger)' : '') + '">' + rs.pending + '</div>'
+          + '<div style="font-size:12px;color:var(--muted);margin-top:4px">전체 ' + rs.total + '</div></div>';
+    html += '<div class="stat"><div class="l">미처리 문의</div>'
+          + '<div class="v" style="' + (is.pending > 0 ? 'color:var(--danger)' : '') + '">' + is.pending + '</div>'
+          + '<div style="font-size:12px;color:var(--muted);margin-top:4px">전체 ' + is.total + '</div></div>';
+    if (activity) {
+      html += '<div class="stat"><div class="l">오늘 조회 클릭</div><div class="v">' + activity.totalClicks + '</div></div>';
+    }
+    html += '</div>';
+
+    // 2. 상세 현황 (2열)
+    html += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:20px">';
+
+    html += '<div class="card"><h3>회원 현황</h3><table>'
+          + '<tr><td>활성</td><td style="text-align:right;font-weight:700;color:var(--success)">' + ms.active + '</td></tr>'
+          + '<tr><td>정지</td><td style="text-align:right;font-weight:700;color:var(--warn)">' + ms.suspended + '</td></tr>'
+          + '<tr><td>탈퇴</td><td style="text-align:right;font-weight:700;color:var(--muted)">' + ms.deleted + '</td></tr>'
+          + '<tr><td>오늘 가입</td><td style="text-align:right;font-weight:700">' + ms.todaySignups + '</td></tr>'
+          + '</table></div>';
+
+    html += '<div class="card"><h3>행사 현황</h3><table>'
+          + '<tr><td>ACTIVE</td><td style="text-align:right;font-weight:700;color:var(--success)">' + es.active + '</td></tr>'
+          + '<tr><td>DRAFT</td><td style="text-align:right;font-weight:700;color:var(--warn)">' + es.draft + '</td></tr>'
+          + '<tr><td>ENDED</td><td style="text-align:right;font-weight:700;color:var(--muted)">' + es.ended + '</td></tr>'
+          + '<tr><td>INACTIVE</td><td style="text-align:right;font-weight:700;color:var(--muted)">' + es.inactive + '</td></tr>'
+          + '</table></div>';
+
+    html += '<div class="card"><h3>게시글 현황</h3><table>'
+          + '<tr><td>게시 중</td><td style="text-align:right;font-weight:700;color:var(--success)">' + ps.published + '</td></tr>'
+          + '<tr><td>숨김</td><td style="text-align:right;font-weight:700;color:var(--warn)">' + ps.hidden + '</td></tr>'
+          + '<tr><td>오늘 작성</td><td style="text-align:right;font-weight:700">' + ps.todayPosts + '</td></tr>'
+          + '</table></div>';
+
+    html += '<div class="card"><h3>신고 / 문의</h3><table>'
+          + '<tr><td>미처리 신고</td><td style="text-align:right;font-weight:700;color:' + (rs.pending > 0 ? 'var(--danger)' : 'inherit') + '">' + rs.pending + '</td></tr>'
+          + '<tr><td>처리된 신고</td><td style="text-align:right;font-weight:700;color:var(--muted)">' + rs.resolved + '</td></tr>'
+          + '<tr><td>미처리 문의</td><td style="text-align:right;font-weight:700;color:' + (is.pending > 0 ? 'var(--danger)' : 'inherit') + '">' + is.pending + '</td></tr>'
+          + '<tr><td>답변 완료</td><td style="text-align:right;font-weight:700;color:var(--muted)">' + is.answered + '</td></tr>'
+          + '</table></div>';
+
+    html += '</div>';
+
+    // 3. 시간대별 조회 차트
+    if (activity && activity.hourlyCounts && activity.hourlyCounts.length > 0) {
+      const maxCount = Math.max.apply(null, activity.hourlyCounts.map(function(h) { return h.count; })) || 1;
+      html += '<div class="card"><h3>오늘 시간대별 클릭 현황</h3>'
+            + '<div style="display:flex;align-items:flex-end;gap:3px;height:90px;margin-top:10px">';
+      activity.hourlyCounts.forEach(function(h) {
+        const barH = Math.round((h.count / maxCount) * 80);
+        const label = h.hour < 10 ? '0' + h.hour : '' + h.hour;
+        html += '<div style="flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;gap:2px" title="' + h.hour + '시: ' + h.count + '회">'
+              + '<div style="width:100%;background:var(--pri);border-radius:2px 2px 0 0;height:' + barH + 'px;min-height:' + (h.count > 0 ? 2 : 0) + 'px"></div>'
+              + '<div style="font-size:9px;color:var(--muted)">' + label + '</div>'
+              + '</div>';
+      });
+      html += '</div></div>';
+    }
+
+    // 생성 시각
+    if (d.generatedAt) {
+      let ts = d.generatedAt;
+      try { ts = new Date(Array.isArray(d.generatedAt) ? d.generatedAt[0] + '-' + String(d.generatedAt[1]).padStart(2,'0') + '-' + String(d.generatedAt[2]).padStart(2,'0') : d.generatedAt).toLocaleString('ko-KR'); } catch {}
+      html += '<div style="font-size:11px;color:var(--muted);text-align:right;margin-top:4px">생성시각: ' + ts + '</div>';
+    }
+
+    document.getElementById('dashStats').innerHTML = html;
   } catch (e) {
-    document.getElementById('dashStats').innerHTML = `<div class="stat"><div class="l">로드 실패: ${esc(e.message)}</div></div>`;
+    document.getElementById('dashStats').innerHTML = '<div class="stat"><div class="l">로드 실패: ' + esc(e.message) + '</div></div>';
   }
 }
 
@@ -170,9 +244,13 @@ function openEventModal(id, data) {
   document.getElementById('eventDesc').value = data?.description || '';
   document.getElementById('eventContact').value = data?.hostContact || '';
   const rawExtra = data?.extraJson;
-  document.getElementById('eventExtraJson').value = rawExtra
+  const rawExtraStr = rawExtra
     ? (typeof rawExtra === 'string' ? rawExtra : JSON.stringify(rawExtra, null, 2))
     : '';
+  document.getElementById('eventExtraJson').value = rawExtraStr;
+  let parsedForEditor = null;
+  try { parsedForEditor = rawExtraStr ? JSON.parse(rawExtraStr) : null; } catch {}
+  initPerformerEditor(parsedForEditor);
   document.getElementById('eventThumbKey').value = data?.thumbnailKey || data?.thumbnailUrl || '';
   const preview = document.getElementById('eventThumbPreview');
   const placeholder = document.getElementById('eventDropPlaceholder');
@@ -214,7 +292,7 @@ async function saveEvent() {
     thumbnailUrl: document.getElementById('eventThumbKey').value || null,
     description: document.getElementById('eventDesc').value || null,
     hostContact: document.getElementById('eventContact').value || null,
-    extraJson: document.getElementById('eventExtraJson').value.trim() || null,
+    extraJson: buildExtraJson(),
   };
   try {
     if (id) await api(`/api/admin/events/${id}`, { method: 'PUT', body: JSON.stringify(body) });
@@ -225,6 +303,127 @@ async function saveEvent() {
 async function deleteEvent(id) {
   if (!confirm('정말 삭제하시겠습니까?')) return;
   try { await api(`/api/admin/events/${id}`, { method: 'DELETE' }); loadEvents(0); } catch (e) { alert(e.message); }
+}
+
+// ===== Performer Editor =====
+let _perfTimelineIdx = -1;
+
+function initPerformerEditor(parsed) {
+  _perfTimelineIdx = -1;
+  let performers = [];
+  if (parsed && Array.isArray(parsed.timeline)) {
+    for (let i = 0; i < parsed.timeline.length; i++) {
+      if (Array.isArray(parsed.timeline[i].performers)) {
+        _perfTimelineIdx = i;
+        performers = parsed.timeline[i].performers;
+        break;
+      }
+    }
+  }
+  renderPerformerList(performers);
+}
+
+function renderPerformerList(performers) {
+  const list = document.getElementById('performerList');
+  if (!list) return;
+  if (!performers || performers.length === 0) {
+    list.innerHTML = '<p style="font-size:13px;color:var(--muted);margin:0">공연 팀이 없습니다. "+ 팀 추가"로 추가하세요.</p>';
+    return;
+  }
+  list.innerHTML = performers.map((p, i) => `
+    <div class="performer-card">
+      <div class="performer-header">
+        <input class="perf-name" type="text" placeholder="팀 이름" value="${esc(p.name||'')}" style="width:130px;font-weight:600">
+        <input class="perf-genre" type="text" placeholder="장르" value="${esc(p.genre||'')}" style="width:90px">
+        <input class="perf-time" type="text" placeholder="시작시간 예)19:53" value="${esc(p.startTime||'')}" style="width:110px">
+        <button type="button" onclick="removePerformerRow(${i})" class="btn btn-d btn-sm" style="padding:3px 10px;margin-left:auto">팀 삭제</button>
+      </div>
+      <div class="setlist-wrap">
+        <div style="font-size:12px;color:var(--muted);margin-bottom:6px">셋리스트</div>
+        ${(p.setlist||[]).map((song, si) => `
+          <div class="song-row">
+            <span class="song-num">${si+1}.</span>
+            <input class="song-input" type="text" value="${esc(song)}" placeholder="곡명 - 아티스트">
+            <button type="button" onclick="removeSongRow(${i},${si})" class="btn btn-d btn-sm" style="padding:2px 8px;font-size:12px">×</button>
+          </div>
+        `).join('')}
+        <button type="button" onclick="addSongRow(${i})" class="btn btn-g btn-sm" style="font-size:12px;margin-top:6px">+ 곡 추가</button>
+      </div>
+    </div>
+  `).join('');
+}
+
+function getPerformersFromEditor() {
+  const performers = [];
+  document.querySelectorAll('#performerList .performer-card').forEach(card => {
+    performers.push({
+      name: card.querySelector('.perf-name').value.trim(),
+      genre: card.querySelector('.perf-genre').value.trim(),
+      startTime: card.querySelector('.perf-time').value.trim(),
+      setlist: Array.from(card.querySelectorAll('.song-input')).map(i => i.value.trim()).filter(Boolean),
+    });
+  });
+  return performers;
+}
+
+function addPerformerRow() {
+  const current = getPerformersFromEditor();
+  current.push({ name: '', genre: '', startTime: '', setlist: [] });
+  if (_perfTimelineIdx < 0) _perfTimelineIdx = 0;
+  renderPerformerList(current);
+  setTimeout(() => {
+    const cards = document.querySelectorAll('#performerList .performer-card');
+    if (cards.length) cards[cards.length - 1].querySelector('.perf-name').focus();
+  }, 30);
+}
+
+function removePerformerRow(idx) {
+  const current = getPerformersFromEditor();
+  current.splice(idx, 1);
+  renderPerformerList(current);
+}
+
+function addSongRow(perfIdx) {
+  const current = getPerformersFromEditor();
+  if (!current[perfIdx]) return;
+  current[perfIdx].setlist.push('');
+  renderPerformerList(current);
+  setTimeout(() => {
+    const cards = document.querySelectorAll('#performerList .performer-card');
+    if (cards[perfIdx]) {
+      const inputs = cards[perfIdx].querySelectorAll('.song-input');
+      if (inputs.length) inputs[inputs.length - 1].focus();
+    }
+  }, 30);
+}
+
+function removeSongRow(perfIdx, songIdx) {
+  const current = getPerformersFromEditor();
+  if (!current[perfIdx]) return;
+  current[perfIdx].setlist.splice(songIdx, 1);
+  renderPerformerList(current);
+}
+
+function toggleExtraJsonRaw() {
+  const ta = document.getElementById('eventExtraJson');
+  ta.style.display = ta.style.display === 'none' ? '' : 'none';
+}
+
+function buildExtraJson() {
+  const rawText = document.getElementById('eventExtraJson').value.trim();
+  const performers = getPerformersFromEditor();
+  // 퍼포머 에디터에 데이터가 있고 timeline 인덱스가 파악된 경우
+  if (performers.length > 0 && _perfTimelineIdx >= 0) {
+    try {
+      const base = rawText ? JSON.parse(rawText) : {};
+      if (base.timeline && base.timeline[_perfTimelineIdx]) {
+        base.timeline[_perfTimelineIdx].performers = performers;
+      }
+      return JSON.stringify(base);
+    } catch { /* 파싱 실패 시 아래로 fallthrough */ }
+  }
+  // 퍼포머 없이 textarea만 있는 경우 (새 행사 또는 performers 없는 행사)
+  return rawText || null;
 }
 
 // ===== Posts =====

--- a/frontend/app/(tabs)/map/_components/NaverMap.tsx
+++ b/frontend/app/(tabs)/map/_components/NaverMap.tsx
@@ -86,12 +86,15 @@ const EVENT_ZONE_COLOR = 'rgba(239, 68, 68, 0.25)';
 const EVENT_ZONE_OUTLINE_WIDTH = 2;
 const EVENT_ZONE_OUTLINE_COLOR = 'rgba(239, 68, 68, 0.6)';
 
-/** 행사 시작일까지 남은 일수 (이미 시작했으면 0) */
+/** 행사 시작일까지 남은 일수 (날짜 기준, 오늘 자정에 감소) */
 function getDaysUntilStart(startAt: string): number {
-  const start = new Date(startAt).getTime();
-  const now = Date.now();
-  if (Number.isNaN(start)) return 0;
-  const days = Math.ceil((start - now) / (24 * 60 * 60 * 1000));
+  const startDate = new Date(startAt);
+  if (Number.isNaN(startDate.getTime())) return 0;
+  const today = new Date();
+  // 시간 제거하고 날짜만 비교 (로컬 타임존 기준)
+  const startDay = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const todayDay = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const days = Math.round((startDay.getTime() - todayDay.getTime()) / (24 * 60 * 60 * 1000));
   return Math.max(0, days);
 }
 


### PR DESCRIPTION
## 개요
알림 기록 사전 저장, 알림 탭 네비게이션, 관리자 페이지 개선, 마커 D-day 날짜 기준 수정, 서버 타임존 KST 고정

## 관련 이슈
- Refs #

## 작업 내용

**알림**
- [x] 알림 예약 시 알림 기록에 예약 시각 기준으로 미리 저장 (백그라운드 수신 시에도 기록 남도록)
- [x] 알림 예약 취소 시 미리 저장된 기록도 함께 삭제
- [x] 알림 탭 시 해당 행사 상세 화면으로 이동 (백그라운드·종료 상태 모두)
- [x] 알림 탭 기록 저장 시 eventId 타입 안전하게 처리

**지도**
- [x] 마커 D-day 카운트가 행사 시작 시각이 아닌 자정(날짜 기준)에 감소하도록 수정

**관리자 페이지**
- [x] 대시보드 실제 데이터 연동 (필드명 오류 수정)
- [x] 대시보드 회원/행사/게시글/신고·문의 상세 현황 카드 추가
- [x] 대시보드 시간대별 클릭 차트 추가 (daily-activity API 연동)
- [x] 행사 수정 모달에 동아리 공연 팀 편집 UI 추가 (팀·장르·시작시간·셋리스트 CRUD)
- [x] 바이탈싸인 셋리스트 9곡으로 업데이트

**백엔드**
- [x] JVM 기본 타임존을 Asia/Seoul(KST)로 고정
- [x] Jackson 직렬화 타임존 KST 설정

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
