### PR TITLE
feat: 행사 소식에 줄바꿈·이미지 첨부 지원 (앱·웹 관리자)

### DIFF
--- a/backend/src/main/resources/static/api/admin/web/index.html
+++ b/backend/src/main/resources/static/api/admin/web/index.html
@@ -243,6 +243,11 @@
   </div>
   <div class="fg"><label>설명</label><textarea id="eventDesc"></textarea></div>
   <div class="fg"><label>주최자 연락처</label><input type="text" id="eventContact"></div>
+  <div class="fg">
+    <label>최신 소식 <span style="font-weight:400;color:var(--muted)">(여러 줄·이미지 가능, 행사 상세 [소식] 탭에 표시)</span></label>
+    <div id="eventNewsList" style="display:flex;flex-direction:column;gap:10px;margin-bottom:8px"></div>
+    <button type="button" class="btn btn-g btn-sm" onclick="addNewsItem()">+ 소식 추가</button>
+  </div>
   <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('eventModal')">취소</button><button class="btn btn-p btn-sm" onclick="saveEvent()">저장</button></div>
 </div></div>
 

--- a/backend/src/main/resources/static/api/admin/web/js/app.js
+++ b/backend/src/main/resources/static/api/admin/web/js/app.js
@@ -181,6 +181,18 @@ function openEventModal(id, data) {
     preview.style.display = 'none';
     placeholder.style.display = '';
   }
+  // 최신 소식 (extraJson.news) 로드
+  let news = [];
+  try {
+    if (data?.extraJson) {
+      const parsed = JSON.parse(data.extraJson);
+      if (Array.isArray(parsed?.news)) news = parsed.news;
+    }
+  } catch (_) { news = []; }
+  _eventExtraCache = (() => {
+    try { return data?.extraJson ? JSON.parse(data.extraJson) : {}; } catch (_) { return {}; }
+  })();
+  renderNewsList(news);
   document.querySelectorAll('#eventCategories input[type=checkbox]').forEach(cb => {
     cb.checked = (data?.categories || []).includes(cb.value);
   });
@@ -210,6 +222,7 @@ async function saveEvent() {
     thumbnailUrl: document.getElementById('eventThumbKey').value || null,
     description: document.getElementById('eventDesc').value || null,
     hostContact: document.getElementById('eventContact').value || null,
+    extraJson: collectExtraJson(),
   };
   try {
     if (id) await api(`/api/admin/events/${id}`, { method: 'PUT', body: JSON.stringify(body) });
@@ -546,6 +559,126 @@ function initEventMap(lat, lng) {
 function updateLatLngInputs(lat, lng) {
   document.getElementById('eventLat').value = Math.round(lat * 1e7) / 1e7;
   document.getElementById('eventLng').value = Math.round(lng * 1e7) / 1e7;
+}
+
+// ===== Event News (extraJson.news) =====
+let _eventExtraCache = {};
+
+function escAttr(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+
+function renderNewsList(news) {
+  const wrap = document.getElementById('eventNewsList');
+  if (!wrap) return;
+  wrap.innerHTML = '';
+  (news || []).forEach((n) => wrap.appendChild(buildNewsRow(n)));
+}
+
+function buildNewsRow(item) {
+  const row = document.createElement('div');
+  row.className = 'news-row';
+  row.dataset.id = item.id || String(Date.now()) + Math.random().toString(36).slice(2, 6);
+  row.style.cssText = 'border:1px solid var(--border);border-radius:10px;padding:10px;background:#fafafa';
+  const imgs = Array.isArray(item.imageUrls) ? item.imageUrls : [];
+  row.innerHTML = `
+    <div style="display:grid;grid-template-columns:1fr 160px;gap:10px">
+      <div>
+        <input type="text" class="news-title" placeholder="소식 제목" value="${escAttr(item.title || '')}" style="width:100%;margin-bottom:6px">
+        <textarea class="news-body" placeholder="내용 (줄바꿈 가능)" rows="4" style="width:100%;margin-bottom:6px;resize:vertical">${escAttr(item.body || '')}</textarea>
+        <input type="text" class="news-date" placeholder="날짜 (예: 2025.05.10)" value="${escAttr(item.date || '')}" style="width:100%">
+      </div>
+      <div>
+        <div class="news-dropzone" style="border:1px dashed var(--border);border-radius:8px;padding:10px;text-align:center;cursor:pointer;font-size:12px;color:var(--muted)">이미지 드래그 또는 클릭</div>
+        <input type="file" class="news-file" accept="image/*" style="display:none">
+        <div class="news-thumbs" style="display:flex;flex-wrap:wrap;gap:4px;margin-top:6px"></div>
+      </div>
+    </div>
+    <div style="text-align:right;margin-top:8px">
+      <button type="button" class="btn btn-d btn-sm news-remove">삭제</button>
+    </div>
+  `;
+  // 이미지 썸네일
+  const thumbs = row.querySelector('.news-thumbs');
+  imgs.forEach((url) => thumbs.appendChild(buildNewsThumb(url)));
+  // 드래그/드롭/클릭 업로드
+  const zone = row.querySelector('.news-dropzone');
+  const fileInput = row.querySelector('.news-file');
+  zone.addEventListener('click', () => fileInput.click());
+  zone.addEventListener('dragover', (e) => { e.preventDefault(); zone.style.background = '#eef2ff'; });
+  zone.addEventListener('dragleave', () => { zone.style.background = ''; });
+  zone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    zone.style.background = '';
+    const file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith('image/')) uploadNewsImage(file, thumbs, zone);
+  });
+  fileInput.addEventListener('change', () => {
+    if (fileInput.files[0]) uploadNewsImage(fileInput.files[0], thumbs, zone);
+    fileInput.value = '';
+  });
+  row.querySelector('.news-remove').addEventListener('click', () => row.remove());
+  return row;
+}
+
+function buildNewsThumb(url) {
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'position:relative;width:54px;height:54px';
+  wrap.innerHTML = `
+    <img src="${escAttr(url)}" data-url="${escAttr(url)}" style="width:54px;height:54px;border-radius:6px;object-fit:cover;background:#e5e7eb">
+    <button type="button" style="position:absolute;top:-6px;right:-6px;width:18px;height:18px;border-radius:9px;border:none;background:#111827;color:#fff;font-size:11px;line-height:1;cursor:pointer">×</button>
+  `;
+  wrap.querySelector('button').addEventListener('click', () => wrap.remove());
+  return wrap;
+}
+
+async function uploadNewsImage(file, thumbsEl, zoneEl) {
+  const original = zoneEl.textContent;
+  zoneEl.textContent = '업로드 중...';
+  try {
+    const fd = new FormData();
+    fd.append('file', file);
+    const res = await fetch('/api/admin/upload', {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + getToken(), 'X-User-Id': localStorage.getItem('admin_id') || '' },
+      body: fd,
+    });
+    if (!res.ok) throw new Error('업로드 실패 (' + res.status + ')');
+    const data = await res.json();
+    thumbsEl.appendChild(buildNewsThumb(data.url));
+  } catch (e) {
+    alert(e.message);
+  } finally {
+    zoneEl.textContent = original;
+  }
+}
+
+function addNewsItem() {
+  const wrap = document.getElementById('eventNewsList');
+  if (!wrap) return;
+  wrap.appendChild(buildNewsRow({ id: String(Date.now()), title: '', body: '', date: '', imageUrls: [] }));
+}
+
+function collectExtraJson() {
+  const wrap = document.getElementById('eventNewsList');
+  const news = [];
+  if (wrap) {
+    wrap.querySelectorAll('.news-row').forEach((row) => {
+      const title = row.querySelector('.news-title').value.trim();
+      const body = row.querySelector('.news-body').value;
+      const date = row.querySelector('.news-date').value.trim();
+      const imageUrls = Array.from(row.querySelectorAll('.news-thumbs img')).map((img) => img.dataset.url || img.src);
+      if (!title && !body && imageUrls.length === 0) return;
+      news.push({
+        id: row.dataset.id,
+        title,
+        body,
+        date,
+        ...(imageUrls.length > 0 ? { imageUrls } : {}),
+      });
+    });
+  }
+  // 다른 키(timeline, foodBooths 등)는 캐시 그대로 보존
+  const merged = { ..._eventExtraCache, news };
+  return JSON.stringify(merged);
 }
 
 // ===== Dropzone Upload =====

--- a/frontend/app/(tabs)/mypage/admin-event-edit-detail.tsx
+++ b/frontend/app/(tabs)/mypage/admin-event-edit-detail.tsx
@@ -86,7 +86,7 @@ const REGION_CITIES_BY_PROVINCE: Record<string, string[]> = {
 };
 
 // --- 소식/타임테이블/부스 (extraJson으로 API 저장) ---
-export type NewsItemEdit = { id: string; title: string; body: string; date: string };
+export type NewsItemEdit = { id: string; title: string; body: string; date: string; imageUrls?: string[] };
 export type TimelineItemEdit = {
   id: string;
   dateLabel?: string;
@@ -761,7 +761,14 @@ function AdminNewsSection({
         items.map((item) => (
           <Pressable key={item.id} style={styles.newsCard} onPress={() => onEdit(item)}>
             <Text style={styles.newsTitle}>{item.title}</Text>
-            <Text style={styles.newsBody} numberOfLines={2}>{item.body}</Text>
+            <Text style={styles.newsBody} numberOfLines={3}>{item.body}</Text>
+            {Array.isArray(item.imageUrls) && item.imageUrls.length > 0 && (
+              <View style={styles.newsThumbRow}>
+                {item.imageUrls.slice(0, 4).map((url, i) => (
+                  <Image key={`${url}-${i}`} source={{ uri: url }} style={styles.newsThumbItem} />
+                ))}
+              </View>
+            )}
             <Text style={styles.newsDate}>{item.date}</Text>
           </Pressable>
         ))
@@ -961,6 +968,8 @@ function EditModal({
   const [text4, setText4] = useState("");
   const [text5, setText5] = useState(""); // 푸드트럭 메뉴-가격 (한 줄에 하나, 예: 타코야끼(6pcs) - 5,000원)
   const [text6, setText6] = useState(""); // 부스/푸드트럭 외부 링크
+  const [newsImages, setNewsImages] = useState<string[]>([]); // 소식 첨부 이미지 URL 목록
+  const [newsUploading, setNewsUploading] = useState(false);
   const [coordsGeocoding, setCoordsGeocoding] = useState(false);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedFilterGroup, setSelectedFilterGroup] = useState("");
@@ -1043,10 +1052,12 @@ function EditModal({
         setText(n.title);
         setText2(n.body);
         setText3(n.date);
+        setNewsImages(Array.isArray(n.imageUrls) ? [...n.imageUrls] : []);
       } else {
         setText("");
         setText2("");
         setText3("");
+        setNewsImages([]);
       }
     }
     if (editTarget.type === "timeline") {
@@ -1172,10 +1183,11 @@ function EditModal({
     if (editTarget.type === "news") {
       const list = (values.newsList as NewsItemEdit[]) ?? [];
       const existing = editTarget.item as NewsItemEdit | undefined;
+      const imageUrls = newsImages.length > 0 ? [...newsImages] : undefined;
       if (existing) {
-        onSave.setNewsList(list.map((n) => (n.id === existing.id ? { ...n, title: text, body: text2, date: text3 } : n)));
+        onSave.setNewsList(list.map((n) => (n.id === existing.id ? { ...n, title: text, body: text2, date: text3, imageUrls } : n)));
       } else {
-        onSave.setNewsList([...list, { id: String(Date.now()), title: text, body: text2, date: text3 }]);
+        onSave.setNewsList([...list, { id: String(Date.now()), title: text, body: text2, date: text3, imageUrls }]);
       }
     }
     if (editTarget.type === "timeline") {
@@ -1520,16 +1532,19 @@ function EditModal({
             )}
             {(editTarget?.type === "news" || editTarget?.type === "timeline" || editTarget?.type === "booth") && (
               <TextInput
-                style={styles.modalInput}
+                style={[styles.modalInput, editTarget?.type === "news" && styles.modalInputMultiline]}
                 value={text2}
                 onChangeText={setText2}
                 placeholder={
-                  editTarget?.type === "news" ? "내용" :
+                  editTarget?.type === "news" ? "내용 (줄바꿈 가능)" :
                   editTarget?.type === "timeline" ? "시작 시간 (예: 12:00)" : "운영시간"
                 }
                 placeholderTextColor="#9CA3AF"
-              keyboardType="default"
-            />
+                keyboardType="default"
+                multiline={editTarget?.type === "news"}
+                numberOfLines={editTarget?.type === "news" ? 6 : 1}
+                textAlignVertical={editTarget?.type === "news" ? "top" : "center"}
+              />
             )}
             {editTarget?.type === "coords" && onPressMapPick && (
               <TouchableOpacity style={styles.modalMapPickButton} onPress={onPressMapPick} activeOpacity={0.85}>
@@ -1548,6 +1563,56 @@ function EditModal({
                 }
                 placeholderTextColor="#9CA3AF"
               />
+            )}
+            {editTarget?.type === "news" && (
+              <View style={styles.newsImagesWrap}>
+                <View style={styles.newsImagesRow}>
+                  {newsImages.map((url, i) => (
+                    <View key={`${url}-${i}`} style={styles.newsImageItem}>
+                      <Image source={{ uri: url }} style={styles.newsImageThumb} />
+                      <Pressable
+                        style={styles.newsImageRemove}
+                        onPress={() => setNewsImages((prev) => prev.filter((_, idx) => idx !== i))}
+                      >
+                        <Ionicons name="close" size={14} color="#FFF" />
+                      </Pressable>
+                    </View>
+                  ))}
+                  <Pressable
+                    style={[styles.newsImageAddBtn, newsUploading && { opacity: 0.5 }]}
+                    onPress={async () => {
+                      try {
+                        const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+                        if (status !== "granted") {
+                          Alert.alert("권한 필요", "갤러리 접근 권한이 필요합니다.");
+                          return;
+                        }
+                        const result = await ImagePicker.launchImageLibraryAsync({
+                          mediaTypes: ImagePicker.MediaTypeOptions.Images,
+                          allowsEditing: false,
+                          quality: 0.8,
+                        });
+                        if (result.canceled || !result.assets?.[0]?.uri) return;
+                        setNewsUploading(true);
+                        try {
+                          const url = await adminService.uploadAdminEventImage(result.assets[0].uri);
+                          setNewsImages((prev) => [...prev, url]);
+                        } catch (e) {
+                          Alert.alert("업로드 실패", e instanceof Error ? e.message : "사진 업로드에 실패했습니다.");
+                        } finally {
+                          setNewsUploading(false);
+                        }
+                      } catch (e) {
+                        Alert.alert("오류", e instanceof Error ? e.message : String(e));
+                      }
+                    }}
+                    disabled={newsUploading}
+                  >
+                    <Ionicons name="add" size={20} color="#4C8BF5" />
+                    <Text style={styles.newsImageAddText}>{newsUploading ? "업로드 중" : "사진 추가"}</Text>
+                  </Pressable>
+                </View>
+              </View>
             )}
             {(editTarget?.type === "timeline" || editTarget?.type === "booth") && (
               <TextInput
@@ -1684,6 +1749,23 @@ const styles = StyleSheet.create({
   newsTitle: { fontSize: 14, fontWeight: "bold", marginBottom: 4 },
   newsBody: { fontSize: 13, color: "#555", marginBottom: 4 },
   newsDate: { fontSize: 11, color: "#9CA3AF" },
+  newsThumbRow: { flexDirection: "row", gap: 6, marginTop: 6, marginBottom: 6 },
+  newsThumbItem: { width: 56, height: 56, borderRadius: 8, backgroundColor: "#E5E7EB" },
+  newsImagesWrap: { marginTop: 8, marginBottom: 8 },
+  newsImagesRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  newsImageItem: { position: "relative" },
+  newsImageThumb: { width: 72, height: 72, borderRadius: 8, backgroundColor: "#E5E7EB" },
+  newsImageRemove: {
+    position: "absolute", top: -6, right: -6,
+    width: 22, height: 22, borderRadius: 11,
+    backgroundColor: "#111827", alignItems: "center", justifyContent: "center",
+  },
+  newsImageAddBtn: {
+    width: 72, height: 72, borderRadius: 8,
+    borderWidth: 1, borderStyle: "dashed", borderColor: "#9CA3AF",
+    alignItems: "center", justifyContent: "center", gap: 2,
+  },
+  newsImageAddText: { fontSize: 11, color: "#4C8BF5" },
   dateRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 12, paddingVertical: 8 },
   dateRowText: { fontSize: 16, fontWeight: "600" },
   timelineCard: { flexDirection: "row", alignItems: "flex-start", marginBottom: 12 },

--- a/frontend/components/detail/EventNewsTab.tsx
+++ b/frontend/components/detail/EventNewsTab.tsx
@@ -1,6 +1,6 @@
 // frontend/components/detail/EventNewsTab.tsx
 import React, { useEffect, useState } from "react";
-import { View, Text, StyleSheet, Pressable, ActivityIndicator } from "react-native";
+import { View, Text, StyleSheet, Pressable, ActivityIndicator, Image, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import type { EventNewsItem } from "../../types/event";
 import type { PostListItem } from "../../types/board";
@@ -70,6 +70,7 @@ export default function EventNewsTab({ news, eventId }: EventNewsTabProps) {
             title={item.title}
             body={item.body}
             date={item.date}
+            imageUrls={item.imageUrls}
           />
         ))
       )}
@@ -107,9 +108,11 @@ interface NewsCardProps {
   title: string;
   body: string;
   date: string;
+  imageUrls?: string[];
 }
 
-function NewsCard({ title, body, date }: NewsCardProps) {
+function NewsCard({ title, body, date, imageUrls }: NewsCardProps) {
+  const hasImages = Array.isArray(imageUrls) && imageUrls.length > 0;
   return (
     <View style={styles.newsCard}>
       <View style={styles.newsRow}>
@@ -124,6 +127,23 @@ function NewsCard({ title, body, date }: NewsCardProps) {
 
         <Text style={styles.newsDate}>{date}</Text>
       </View>
+      {hasImages && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.newsImagesScroll}
+          contentContainerStyle={styles.newsImagesContent}
+        >
+          {imageUrls!.map((url, i) => (
+            <Image
+              key={`${url}-${i}`}
+              source={{ uri: url }}
+              style={styles.newsImage}
+              resizeMode="cover"
+            />
+          ))}
+        </ScrollView>
+      )}
     </View>
   );
 }
@@ -168,6 +188,21 @@ const styles = StyleSheet.create({
   newsBody: {
     fontSize: 13,
     color: "#555",
+    lineHeight: 18,
+  },
+  newsImagesScroll: {
+    marginTop: 10,
+  },
+  newsImagesContent: {
+    gap: 8,
+    paddingRight: 4,
+  },
+  newsImage: {
+    width: 160,
+    height: 160,
+    borderRadius: 10,
+    backgroundColor: "#E5E7EB",
+    marginRight: 8,
   },
   newsDate: {
     fontSize: 11,

--- a/frontend/types/event.ts
+++ b/frontend/types/event.ts
@@ -41,6 +41,8 @@ export interface EventNewsItem {
   title: string;
   body: string;
   date: string;
+  /** 첨부 이미지 URL 목록 (없으면 undefined 또는 빈 배열) */
+  imageUrls?: string[];
 }
 
 /** 타임테이블 한 건 (extraJson 내 timeline[]) */

--- a/frontend/utils/eventExtra.ts
+++ b/frontend/utils/eventExtra.ts
@@ -27,10 +27,24 @@ export function parseEventExtra(extraJson: string | null | undefined): EventExtr
     const raw = JSON.parse(extraJson) as Record<string, unknown>;
     const result: EventExtra = {};
     if (Array.isArray(raw.news)) {
-      result.news = raw.news.filter(
-        (n): n is EventNewsItem =>
-          n != null && typeof n === 'object' && typeof (n as EventNewsItem).id === 'string'
-      ) as EventNewsItem[];
+      result.news = raw.news
+        .filter(
+          (n): n is EventNewsItem =>
+            n != null && typeof n === 'object' && typeof (n as EventNewsItem).id === 'string'
+        )
+        .map((n) => {
+          const item = n as Record<string, unknown>;
+          const imageUrls = Array.isArray(item.imageUrls)
+            ? (item.imageUrls.filter((u) => typeof u === 'string' && u) as string[])
+            : undefined;
+          return {
+            id: String(item.id),
+            title: typeof item.title === 'string' ? item.title : '',
+            body: typeof item.body === 'string' ? item.body : '',
+            date: typeof item.date === 'string' ? item.date : '',
+            imageUrls,
+          } as EventNewsItem;
+        });
     }
     if (Array.isArray(raw.timeline)) {
       result.timeline = raw.timeline.filter(


### PR DESCRIPTION
- EventNewsItem에 imageUrls 추가, extraJson 파서/저장에 이미지 보존
- 앱 편집 모달: 본문 multiline + 사진 추가/삭제(S3 업로드 재사용)
- 앱 상세 [소식] 탭: 줄바꿈 출력 + 첨부 이미지 가로 스크롤 표시
- 웹 행사 모달에 '최신 소식' 섹션 신설 (textarea + 드래그/클릭 이미지 업로드)
