### PR TITLE
fix: 행사 모달 레이아웃·소식 이미지 절대 URL 변환

### DIFF
--- a/backend/src/main/resources/static/api/admin/web/index.html
+++ b/backend/src/main/resources/static/api/admin/web/index.html
@@ -205,7 +205,7 @@
   <div class="modal-actions"><button class="btn btn-g btn-sm" onclick="closeModal('inquiryModal')">닫기</button><button class="btn btn-p btn-sm" onclick="saveInquiryAnswer()">답변 저장</button></div>
 </div></div>
 
-<div class="modal-bg" id="eventModal"><div class="modal" style="width:600px">
+<div class="modal-bg" id="eventModal"><div class="modal" style="width:720px;max-width:95vw;max-height:90vh;overflow-y:auto">
   <h3 id="eventModalTitle">행사 추가</h3>
   <input type="hidden" id="eventEditId">
   <div class="fg"><label>제목 *</label><input type="text" id="eventTitle"></div>

--- a/backend/src/main/resources/static/api/admin/web/js/app.js
+++ b/backend/src/main/resources/static/api/admin/web/js/app.js
@@ -806,22 +806,18 @@ function buildNewsRow(item) {
   const row = document.createElement('div');
   row.className = 'news-row';
   row.dataset.id = item.id || String(Date.now()) + Math.random().toString(36).slice(2, 6);
-  row.style.cssText = 'border:1px solid var(--border);border-radius:10px;padding:10px;background:#fafafa';
+  row.style.cssText = 'border:1px solid var(--border);border-radius:10px;padding:12px;background:#fafafa;box-sizing:border-box';
   const imgs = Array.isArray(item.imageUrls) ? item.imageUrls : [];
   row.innerHTML = `
-    <div style="display:grid;grid-template-columns:1fr 160px;gap:10px">
-      <div>
-        <input type="text" class="news-title" placeholder="소식 제목" value="${escAttr(item.title || '')}" style="width:100%;margin-bottom:6px">
-        <textarea class="news-body" placeholder="내용 (줄바꿈 가능)" rows="4" style="width:100%;margin-bottom:6px;resize:vertical">${escAttr(item.body || '')}</textarea>
-        <input type="text" class="news-date" placeholder="날짜 (예: 2025.05.10)" value="${escAttr(item.date || '')}" style="width:100%">
-      </div>
-      <div>
-        <div class="news-dropzone" style="border:1px dashed var(--border);border-radius:8px;padding:10px;text-align:center;cursor:pointer;font-size:12px;color:var(--muted)">이미지 드래그 또는 클릭</div>
-        <input type="file" class="news-file" accept="image/*" style="display:none">
-        <div class="news-thumbs" style="display:flex;flex-wrap:wrap;gap:4px;margin-top:6px"></div>
-      </div>
+    <div style="display:flex;flex-direction:column;gap:6px">
+      <input type="text" class="news-title" placeholder="소식 제목" value="${escAttr(item.title || '')}" style="width:100%;box-sizing:border-box">
+      <textarea class="news-body" placeholder="내용 (줄바꿈 가능)" rows="4" style="width:100%;box-sizing:border-box;resize:vertical">${escAttr(item.body || '')}</textarea>
+      <input type="text" class="news-date" placeholder="날짜 (예: 2025.05.10)" value="${escAttr(item.date || '')}" style="width:100%;box-sizing:border-box">
+      <div class="news-dropzone" style="border:1px dashed var(--border);border-radius:8px;padding:14px;text-align:center;cursor:pointer;font-size:12px;color:var(--muted);background:#fff">이미지 드래그하거나 클릭하여 업로드</div>
+      <input type="file" class="news-file" accept="image/*" style="display:none">
+      <div class="news-thumbs" style="display:flex;flex-wrap:wrap;gap:6px"></div>
     </div>
-    <div style="text-align:right;margin-top:8px">
+    <div style="text-align:right;margin-top:10px">
       <button type="button" class="btn btn-d btn-sm news-remove">삭제</button>
     </div>
   `;
@@ -850,13 +846,21 @@ function buildNewsRow(item) {
 
 function buildNewsThumb(url) {
   const wrap = document.createElement('div');
-  wrap.style.cssText = 'position:relative;width:54px;height:54px';
+  wrap.style.cssText = 'position:relative;width:80px;height:80px';
   wrap.innerHTML = `
-    <img src="${escAttr(url)}" data-url="${escAttr(url)}" style="width:54px;height:54px;border-radius:6px;object-fit:cover;background:#e5e7eb">
-    <button type="button" style="position:absolute;top:-6px;right:-6px;width:18px;height:18px;border-radius:9px;border:none;background:#111827;color:#fff;font-size:11px;line-height:1;cursor:pointer">×</button>
+    <img src="${escAttr(url)}" data-url="${escAttr(url)}" style="width:80px;height:80px;border-radius:8px;object-fit:cover;background:#e5e7eb;display:block">
+    <button type="button" style="position:absolute;top:-6px;right:-6px;width:20px;height:20px;border-radius:10px;border:none;background:#111827;color:#fff;font-size:12px;line-height:1;cursor:pointer">×</button>
   `;
   wrap.querySelector('button').addEventListener('click', () => wrap.remove());
   return wrap;
+}
+
+/** 업로드 응답의 상대경로(/static/...)를 앱·웹 모두에서 보이도록 절대 URL로 변환 */
+function toAbsoluteUrl(pathOrUrl) {
+  if (!pathOrUrl) return '';
+  if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
+  if (pathOrUrl.startsWith('/')) return window.location.origin + pathOrUrl;
+  return pathOrUrl;
 }
 
 async function uploadNewsImage(file, thumbsEl, zoneEl) {
@@ -872,7 +876,8 @@ async function uploadNewsImage(file, thumbsEl, zoneEl) {
     });
     if (!res.ok) throw new Error('업로드 실패 (' + res.status + ')');
     const data = await res.json();
-    thumbsEl.appendChild(buildNewsThumb(data.url));
+    const absUrl = toAbsoluteUrl(data.url);
+    thumbsEl.appendChild(buildNewsThumb(absUrl));
   } catch (e) {
     alert(e.message);
   } finally {

--- a/frontend/app/(tabs)/mypage/admin-event-edit-detail.tsx
+++ b/frontend/app/(tabs)/mypage/admin-event-edit-detail.tsx
@@ -26,6 +26,14 @@ import { Ionicons } from "@expo/vector-icons";
 import EventDetailTabs, { TabKey } from "../../../components/detail/EventDetailTabs";
 import * as adminService from "../../../services/admin.service";
 import { parseEventExtra, stringifyEventExtra } from "../../../utils/eventExtra";
+import { API_BASE_URL } from "../../../constants/api";
+
+function resolveNewsImageUrl(url: string): string {
+  if (!url) return "";
+  if (/^https?:\/\//i.test(url)) return url;
+  if (url.startsWith("/")) return `${API_BASE_URL}${url}`;
+  return url;
+}
 import { MAP_UI } from "../../../constants/colors";
 import { geocodeAddress, reverseGeocode } from "../../../services/geocoding.service";
 import {
@@ -810,7 +818,7 @@ function AdminNewsSection({
             {Array.isArray(item.imageUrls) && item.imageUrls.length > 0 && (
               <View style={styles.newsThumbRow}>
                 {item.imageUrls.slice(0, 4).map((url, i) => (
-                  <Image key={`${url}-${i}`} source={{ uri: url }} style={styles.newsThumbItem} />
+                  <Image key={`${url}-${i}`} source={{ uri: resolveNewsImageUrl(url) }} style={styles.newsThumbItem} />
                 ))}
               </View>
             )}
@@ -1614,7 +1622,7 @@ function EditModal({
                 <View style={styles.newsImagesRow}>
                   {newsImages.map((url, i) => (
                     <View key={`${url}-${i}`} style={styles.newsImageItem}>
-                      <Image source={{ uri: url }} style={styles.newsImageThumb} />
+                      <Image source={{ uri: resolveNewsImageUrl(url) }} style={styles.newsImageThumb} />
                       <Pressable
                         style={styles.newsImageRemove}
                         onPress={() => setNewsImages((prev) => prev.filter((_, idx) => idx !== i))}

--- a/frontend/components/detail/EventNewsTab.tsx
+++ b/frontend/components/detail/EventNewsTab.tsx
@@ -5,6 +5,15 @@ import { useRouter } from "expo-router";
 import type { EventNewsItem } from "../../types/event";
 import type { PostListItem } from "../../types/board";
 import * as boardService from "../../services/board.service";
+import { API_BASE_URL } from "../../constants/api";
+
+/** 상대 경로(/static/...)로 저장된 이미지를 RN에서 가져올 절대 URL로 변환 */
+function resolveImageUrl(url: string): string {
+  if (!url) return "";
+  if (/^https?:\/\//i.test(url)) return url;
+  if (url.startsWith("/")) return `${API_BASE_URL}${url}`;
+  return url;
+}
 
 interface EventNewsTabProps {
   /** 저장된 소식 목록 (없으면 빈 화면) */
@@ -137,7 +146,7 @@ function NewsCard({ title, body, date, imageUrls }: NewsCardProps) {
           {imageUrls!.map((url, i) => (
             <Image
               key={`${url}-${i}`}
-              source={{ uri: url }}
+              source={{ uri: resolveImageUrl(url) }}
               style={styles.newsImage}
               resizeMode="cover"
             />


### PR DESCRIPTION
- 웹 모달: width 720px + 가로 스크롤 방지, 소식 행을 1열 세로 레이아웃으로 변경(textarea·드롭존이 짜부라지지 않게)
- 웹 업로드 응답 /static/...을 window.location.origin 붙여 절대 URL로 저장 → 앱에서 RN Image가 호스트를 알 수 있음
- 앱 EventNewsTab/편집 화면 썸네일도 상대 경로 들어오면 API_BASE_URL prefix로 정규화
