### PR TITLE
Apple

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,23 @@
       "Bash(git *)",
       "Bash(grep -E \"\\\\.\\(ts|tsx|js|jsx\\)$\")",
       "Bash(./gradlew compileJava)",
-      "Bash(npx tsc *)"
+      "Bash(npx tsc *)",
+      "Bash(npx expo run:ios)",
+      "Bash(npx expo install:*)",
+      "Bash(./gradlew bootRun:*)",
+      "Bash(lsof:*)",
+      "Bash(xargs kill:*)",
+      "Bash(curl:*)",
+      "Bash(pkill:*)",
+      "Bash(python3:*)",
+      "Bash(./gradlew clean compileJava:*)",
+      "Bash(find:*)",
+      "Bash(./gradlew clean build:*)",
+      "Bash(javap:*)",
+      "Bash(ls:*)",
+      "Bash(./gradlew:*)",
+      "Bash(ps:*)",
+      "Bash(kill:*)"
     ]
   }
 }

--- a/backend/src/main/java/com/dailo/backend/dto/admin/CommentStatsDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/admin/CommentStatsDto.java
@@ -1,0 +1,17 @@
+package com.dailo.backend.dto.admin;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentStatsDto {
+    private long total;
+    private long visible;
+    private long hidden;
+    private long todayComments;
+}

--- a/backend/src/main/java/com/dailo/backend/dto/admin/DashboardResponseDto.java
+++ b/backend/src/main/java/com/dailo/backend/dto/admin/DashboardResponseDto.java
@@ -15,6 +15,7 @@ public class DashboardResponseDto {
     private MemberStatsDto memberStats;
     private EventStatsDto eventStats;
     private PostStatsDto postStats;
+    private CommentStatsDto commentStats;
     private ReportStatsDto reportStats;
     private InquiryStatsDto inquiryStats;
     private LocalDateTime generatedAt;

--- a/backend/src/main/java/com/dailo/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/dailo/backend/repository/CommentRepository.java
@@ -11,11 +11,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // 오늘 작성된 댓글 수 (삭제되지 않은 것만)
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.createdAt >= :dateTime AND c.deletedAt IS NULL")
+    long countByCreatedAtAfterAndNotDeleted(@Param("dateTime") LocalDateTime dateTime);
 
     /** 내가 댓글 단 게시글 ID 목록 (최근 댓글 기준 정렬) */
     @Query(value = "SELECT post_id FROM comments WHERE author_id = :authorId AND deleted_at IS NULL GROUP BY post_id ORDER BY MAX(created_at) DESC", nativeQuery = true)

--- a/backend/src/main/java/com/dailo/backend/service/AdminDashboardService.java
+++ b/backend/src/main/java/com/dailo/backend/service/AdminDashboardService.java
@@ -1,5 +1,6 @@
 package com.dailo.backend.service;
 
+import com.dailo.backend.domain.enums.CommentStatus;
 import com.dailo.backend.domain.enums.EventStatus;
 import com.dailo.backend.domain.enums.InquiryStatus;
 import com.dailo.backend.domain.enums.MemberStatus;
@@ -13,12 +14,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,6 +30,7 @@ public class AdminDashboardService {
     private final MemberRepository memberRepository;
     private final EventRepository eventRepository;
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
     private final ReportRepository reportRepository;
     private final InquiryRepository inquiryRepository;
     private final ClickLogRepository clickLogRepository;
@@ -57,6 +61,21 @@ public class AdminDashboardService {
                 .todayPosts(postRepository.countByCreatedAtAfter(startOfToday))
                 .build();
 
+        long commentTotal = commentRepository.count();
+        long commentVisible = commentRepository.countByStatus(CommentStatus.VISIBLE);
+        long commentHidden = commentRepository.countByStatus(CommentStatus.HIDDEN);
+        long todayComments = commentRepository.countByCreatedAtAfterAndNotDeleted(startOfToday);
+        log.info("Dashboard commentStats: total={}, visible={}, hidden={}, todayComments={}",
+                 commentTotal, commentVisible, commentHidden, todayComments);
+
+        CommentStatsDto commentStats = CommentStatsDto.builder()
+                .total(commentTotal)
+                .visible(commentVisible)
+                .hidden(commentHidden)
+                .todayComments(todayComments)
+                .build();
+        log.info("Built commentStats: {}", commentStats);
+
         ReportStatsDto reportStats = ReportStatsDto.builder()
                 .total(reportRepository.count())
                 .pending(reportRepository.countByStatus(ReportStatus.PENDING))
@@ -70,14 +89,17 @@ public class AdminDashboardService {
                 .answered(inquiryRepository.countByStatus(InquiryStatus.ANSWERED))
                 .build();
 
-        return DashboardResponseDto.builder()
+        DashboardResponseDto response = DashboardResponseDto.builder()
                 .memberStats(memberStats)
                 .eventStats(eventStats)
                 .postStats(postStats)
+                .commentStats(commentStats)
                 .reportStats(reportStats)
                 .inquiryStats(inquiryStats)
                 .generatedAt(LocalDateTime.now())
                 .build();
+        log.info("Dashboard response commentStats: {}", response.getCommentStats());
+        return response;
     }
 
     /**

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -12,7 +12,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.knut.dailo",
       "buildNumber": "9",
-      "usesAppleSignIn": false,
+      "usesAppleSignIn": true,
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
@@ -87,7 +87,8 @@
           "ios": { "handleKakaoOpenUrl": true }
         }
       ],
-      "expo-notifications"
+      "expo-notifications",
+      "expo-apple-authentication"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "다일로",
     "slug": "app",
-    "version": "4.2.2",
+    "version": "4.2.3",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "app",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.knut.dailo",
-      "buildNumber": "9",
+      "buildNumber": "14",
       "usesAppleSignIn": true,
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {

--- a/frontend/app/(tabs)/board/index.tsx
+++ b/frontend/app/(tabs)/board/index.tsx
@@ -76,13 +76,14 @@ function toPost(item: { id: number; authorId?: number; author_id?: number; autho
   const urls = (raw.imageUrls ?? item.imageUrls ?? raw.image_urls) as string[] | undefined;
   const firstImage = Array.isArray(urls) && urls.length > 0 ? urls[0] : undefined;
   const eventTitle = (raw.eventTitle ?? item.eventTitle ?? raw.event_title ?? item.event_title) as string | null | undefined;
+  const createdAt = (raw.createdAt ?? raw.created_at ?? item.createdAt) as string | undefined;
   return {
     id: String(item.id),
     authorId,
     author: authorName,
     authorProfileImageUrl: profileUrl && typeof profileUrl === "string" && profileUrl.trim() ? profileUrl.trim() : null,
     title: item.title,
-    time: formatRelativeTime(item.createdAt),
+    time: formatRelativeTime(createdAt),
     tag: item.categoryType ?? "",
     content: contentStr,
     likes: item.likeCount ?? 0,

--- a/frontend/app/(tabs)/home/index.tsx
+++ b/frontend/app/(tabs)/home/index.tsx
@@ -426,9 +426,9 @@ export default function HomeScreen() {
                     try {
                       const created = new Date(createdAt).getTime();
                       const now = Date.now();
-                      const diffDays = (now - created) / (24 * 60 * 60 * 1000);
-                      // 3일 이상 지난 글은 N 배지 숨김
-                      if (diffDays >= 3) return null;
+                      const diffMinutes = (now - created) / (60 * 1000);
+                      // 5분 이상 지난 글은 N 배지 숨김
+                      if (diffMinutes >= 5) return null;
                     } catch {
                       return null;
                     }

--- a/frontend/app/(tabs)/mypage/admin-dashboard.tsx
+++ b/frontend/app/(tabs)/mypage/admin-dashboard.tsx
@@ -129,6 +129,10 @@ export default function AdminDashboardScreen() {
         <StatCard icon="person-add-outline" label="오늘 가입" value={data.todaySignups} color="#10B981" />
         <StatCard icon="create-outline" label="오늘 게시글" value={data.todayPosts} color="#3B82F6" />
       </View>
+      <View style={styles.row}>
+        <StatCard icon="chatbubble-outline" label="오늘 댓글" value={data.todayComments} color="#EC4899" />
+        <View style={{ flex: 1 }} />
+      </View>
 
       {/* 시간대별 사용자 활동 */}
       <Text style={styles.sectionTitle}>시간대별 사용자 활동</Text>

--- a/frontend/app/(tabs)/mypage/block-list.tsx
+++ b/frontend/app/(tabs)/mypage/block-list.tsx
@@ -113,7 +113,7 @@ export default function BlockListScreen() {
                     )}
                   </Pressable>
                 </View>
-                <Text style={styles.date}>{formatRelativeTime(b.createdAt)}</Text>
+                <Text style={styles.date}>{formatRelativeTime((b as Record<string, unknown>).createdAt as string ?? (b as Record<string, unknown>).created_at as string)}</Text>
               </View>
             ))
           )}

--- a/frontend/app/(tabs)/mypage/board-commented.tsx
+++ b/frontend/app/(tabs)/mypage/board-commented.tsx
@@ -48,11 +48,12 @@ function toPostRow(item: PostListItem): PostRow {
   let contentStr = typeof preview === "string" ? preview.trim() : "";
   if (contentStr.length > 120) contentStr = contentStr.slice(0, 120) + "…";
   const authorName = (item.authorNickname ?? (raw.author_nickname as string) ?? "").trim() || `user_${item.authorId}`;
+  const createdAt = (raw.createdAt ?? raw.created_at ?? item.createdAt) as string | undefined;
   return {
     id: String(item.id),
     author: authorName,
     title: item.title,
-    time: formatRelativeTime(item.createdAt),
+    time: formatRelativeTime(createdAt),
     tag: item.categoryType ?? "",
     content: contentStr,
     likes: item.likeCount ?? 0,

--- a/frontend/app/(tabs)/mypage/board-history.tsx
+++ b/frontend/app/(tabs)/mypage/board-history.tsx
@@ -51,11 +51,12 @@ function toPostRow(item: PostListItem): PostRow {
     `user_${item.authorId}`;
   const firstImage =
     Array.isArray(item.imageUrls) && item.imageUrls.length > 0 ? item.imageUrls[0] ?? "" : "";
+  const createdAt = (raw.createdAt ?? raw.created_at ?? item.createdAt) as string | undefined;
   return {
     id: String(item.id),
     author: authorName,
     title: item.title,
-    time: formatRelativeTime(item.createdAt),
+    time: formatRelativeTime(createdAt),
     tag: item.categoryType ?? "",
     content: contentStr,
     likes: item.likeCount ?? 0,

--- a/frontend/app/(tabs)/mypage/liked-posts.tsx
+++ b/frontend/app/(tabs)/mypage/liked-posts.tsx
@@ -34,11 +34,12 @@ function toPostRow(item: PostListItem): PostRow {
   let contentStr = typeof preview === "string" ? preview.trim() : "";
   if (contentStr.length > 120) contentStr = contentStr.slice(0, 120) + "…";
   const authorName = (item.authorNickname ?? (raw.author_nickname as string) ?? "").trim() || `user_${item.authorId}`;
+  const createdAt = (raw.createdAt ?? raw.created_at ?? item.createdAt) as string | undefined;
   return {
     id: String(item.id),
     author: authorName,
     title: item.title,
-    time: formatRelativeTime(item.createdAt),
+    time: formatRelativeTime(createdAt),
     tag: item.categoryType ?? "",
     content: contentStr,
     likes: item.likeCount ?? 0,

--- a/frontend/app/(tabs)/mypage/my-reports.tsx
+++ b/frontend/app/(tabs)/mypage/my-reports.tsx
@@ -107,7 +107,7 @@ export default function MyReportsScreen() {
                   사유: {REASON_LABEL[r.reason] ?? r.reason}
                   {r.description ? ` - ${r.description}` : ""}
                 </Text>
-                <Text style={styles.date}>{formatRelativeTime(r.createdAt)}</Text>
+                <Text style={styles.date}>{formatRelativeTime((r as Record<string, unknown>).createdAt as string ?? (r as Record<string, unknown>).created_at as string)}</Text>
               </View>
             ))
           )}

--- a/frontend/app/(tabs)/mypage/saved-posts.tsx
+++ b/frontend/app/(tabs)/mypage/saved-posts.tsx
@@ -53,12 +53,16 @@ export default function SavedPostsScreen() {
     try {
       const data = await savedPostService.getSavedPostSummaries();
       const rows: SavedRow[] =
-        (data ?? []).map((p) => ({
-          id: String(p.id),
-          title: p.title || `게시글 #${p.id}`,
-          time: p.createdAt ? formatRelativeTime(p.createdAt) : "",
-          imageUri: p.imageUrl,
-        }));
+        (data ?? []).map((p) => {
+          const raw = p as Record<string, unknown>;
+          const createdAt = (raw.createdAt ?? raw.created_at) as string | undefined;
+          return {
+            id: String(p.id),
+            title: p.title || `게시글 #${p.id}`,
+            time: createdAt ? formatRelativeTime(createdAt) : "",
+            imageUri: p.imageUrl,
+          };
+        });
       setList(rows);
 
       // 썸네일이 비어 있는 항목들은 백엔드에서 한 번 더 가져와 채운다.

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -749,7 +749,10 @@ export default function PostDetailScreen() {
                   const list = Array.isArray(urls) ? urls : [];
                   if (list.length === 0) return null;
                   const gap = 8;
-                  const size = Math.floor((winWidth - 32 - gap * 2) / 3);
+                  const contentWidth = winWidth - 32;
+                  // 1장: 전체 너비, 2장: 절반씩, 3장 이상: 2열
+                  const cols = list.length === 1 ? 1 : 2;
+                  const size = Math.floor((contentWidth - gap * (cols - 1)) / cols);
                   return (
                     <View style={styles.postImagesWrap}>
                       {list.map((uri, index) => (

--- a/frontend/app/board/[id].tsx
+++ b/frontend/app/board/[id].tsx
@@ -57,17 +57,19 @@ function toCommentDisplay(c: { id: number; authorId: number | null; authorNickna
   const profileUrl = (raw.authorProfileImageUrl ?? raw.author_profile_image_url ?? c.authorProfileImageUrl) as string | null | undefined;
   const authorProfileImageUrl = isDeleted ? null : (profileUrl && typeof profileUrl === "string" && profileUrl.trim() ? profileUrl.trim() : null);
   const replies = (c.replies ?? []).map((r: unknown) => toCommentDisplay(r as Parameters<typeof toCommentDisplay>[0]));
+  const createdAt = (raw.createdAt ?? raw.created_at ?? c.createdAt) as string;
+  const updatedAt = (raw.updatedAt ?? raw.updated_at ?? c.updatedAt ?? createdAt) as string;
 
   return {
     id: String(c.id),
     authorId: isDeleted ? null : c.authorId,
     author,
     authorProfileImageUrl,
-    time: formatRelativeTime(c.createdAt),
+    time: formatRelativeTime(createdAt),
     content: isDeleted ? null : c.content,
     likes: isDeleted ? 0 : (c.likeCount ?? 0),
-    createdAt: c.createdAt,
-    updatedAt: c.updatedAt ?? c.createdAt,
+    createdAt: createdAt,
+    updatedAt: updatedAt,
     deleted: isDeleted,
     replies,
   };
@@ -720,7 +722,7 @@ export default function PostDetailScreen() {
                   )}
                   <View style={styles.postMeta}>
                     <Text style={styles.author}>{authorDisplayName}</Text>
-                    <Text style={styles.timeText}>{formatRelativeTime(post.createdAt)}</Text>
+                    <Text style={styles.timeText}>{formatRelativeTime((post as Record<string, unknown>).createdAt as string ?? (post as Record<string, unknown>).created_at as string)}</Text>
                   </View>
                 </Pressable>
                 {post.title ? <Text style={styles.postTitle}>{post.title}</Text> : null}

--- a/frontend/app/board/chat/index.tsx
+++ b/frontend/app/board/chat/index.tsx
@@ -20,38 +20,11 @@ import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as chatService from "../../../services/chat.service";
 import * as authService from "../../../services/auth.service";
+import { formatChatTime } from "../../../utils/formatDate";
 
 const CHAT_NOTIFICATION_KEY = "@chat/notification_enabled";
 
 const AVATAR_COLORS = ["#E0E7FF", "#FCE7F3", "#D1FAE5", "#FEF3C7", "#E5E7EB", "#F3E8FF", "#DBEAFE"];
-
-function formatRoomTime(iso: string): string {
-  try {
-    if (!iso) return "";
-
-    let parsedDate: Date;
-
-    // 🔥 타임존 있는 경우 그대로 사용
-    if (iso.includes("Z") || iso.includes("+")) {
-      parsedDate = new Date(iso);
-    } 
-    // 🔥 타임존 없는 경우 → UTC로 강제
-    else {
-      parsedDate = new Date(iso + "Z");
-    }
-
-    const now = new Date();
-    const diff = now.getTime() - parsedDate.getTime();
-
-    if (diff < 60000) return "방금 전";
-    if (diff < 3600000) return `${Math.floor(diff / 60000)}분 전`;
-    if (diff < 86400000) return `${Math.floor(diff / 3600000)}시간 전`;
-    if (diff < 172800000) return "어제";
-    return `${Math.floor(diff / 86400000)}일 전`;
-  } catch {
-    return "";
-  }
-}
 
 export default function ChatListScreen() {
   const router = useRouter();
@@ -192,7 +165,7 @@ export default function ChatListScreen() {
             const partnerImageUri = rawImageUrl
               ? (rawImageUrl.startsWith("/") ? `${API_BASE_URL}${rawImageUrl}` : rawImageUrl)
               : null;
-            const timeStr = (item.lastMessageAt ?? item.updatedAt) ? formatRoomTime((item.lastMessageAt ?? item.updatedAt)!) : "";
+            const timeStr = (item.lastMessageAt ?? item.updatedAt) ? formatChatTime((item.lastMessageAt ?? item.updatedAt)!) : "";
             const colorIndex = (item.id ?? 0) % AVATAR_COLORS.length;
             const unread = Math.max(0, (item as { unreadCount?: number }).unreadCount ?? 0);
             const preview = (item.lastMessageContent ?? "").trim() || "대화를 시작해 보세요";

--- a/frontend/app/board/search.tsx
+++ b/frontend/app/board/search.tsx
@@ -34,11 +34,12 @@ function toPostRow(item: PostListItem): PostRow {
   let contentStr = typeof preview === "string" ? preview.trim() : "";
   if (contentStr.length > 120) contentStr = contentStr.slice(0, 120) + "…";
   const authorName = (item.authorNickname ?? (raw.author_nickname as string) ?? (raw.authorNickname as string) ?? "").trim() || `user_${item.authorId}`;
+  const createdAt = (raw.createdAt ?? raw.created_at ?? item.createdAt) as string | undefined;
   return {
     id: String(item.id),
     author: authorName,
     title: item.title,
-    time: formatRelativeTime(item.createdAt),
+    time: formatRelativeTime(createdAt),
     tag: item.categoryType ?? "",
     content: contentStr,
     likes: item.likeCount ?? 0,

--- a/frontend/app/login/index.tsx
+++ b/frontend/app/login/index.tsx
@@ -174,9 +174,10 @@ export default function LoginScreen() {
         user: requestBody.user,
         email: requestBody.email ?? null,
         fullName: requestBody.fullName ?? null,
+        fullNameType: typeof requestBody.fullName,
       };
 
-      console.log('[handleAppleLogin] debugRequest:', JSON.stringify(debugRequest, null, 2));
+      console.log('[Apple Login] request body debug:', debugRequest);
 
       const tokenDto = await authService.getAppleTokenDto(requestBody);
 

--- a/frontend/app/login/index.tsx
+++ b/frontend/app/login/index.tsx
@@ -120,8 +120,13 @@ export default function LoginScreen() {
     }
   }, []);
 
+  // Apple login debug temporary code - START
   const handleAppleLogin = async () => {
     setAppleLoading(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let debugRequest: any = null;
+
     try {
       const credential = await AppleAuthentication.signInAsync({
         requestedScopes: [
@@ -130,22 +135,50 @@ export default function LoginScreen() {
         ],
       });
 
+      console.log('[handleAppleLogin] credential received');
+      console.log('[handleAppleLogin] identityToken exists:', !!credential.identityToken);
+      console.log('[handleAppleLogin] user:', credential.user);
+      console.log('[handleAppleLogin] email:', credential.email);
+      console.log('[handleAppleLogin] fullName raw:', JSON.stringify(credential.fullName));
+
       if (!credential.identityToken) {
         Alert.alert('Apple 로그인', 'Apple 로그인을 취소했거나 토큰을 받지 못했습니다.');
         return;
       }
 
-      const tokenDto = await authService.getAppleTokenDto({
+      if (!credential.user) {
+        Alert.alert('Apple 로그인', 'Apple 사용자 ID를 받지 못했습니다.');
+        return;
+      }
+
+      // fullName을 문자열로 변환 (familyName + givenName 순서, 한국식)
+      const fullName = credential.fullName
+        ? [credential.fullName.familyName, credential.fullName.givenName]
+            .filter(Boolean)
+            .join('')
+        : undefined;
+
+      const requestBody = {
         identityToken: credential.identityToken,
         user: credential.user,
         email: credential.email ?? undefined,
-        fullName: credential.fullName
-          ? {
-              givenName: credential.fullName.givenName ?? undefined,
-              familyName: credential.fullName.familyName ?? undefined,
-            }
-          : undefined,
-      });
+        fullName: fullName || undefined,
+      };
+
+      // 디버그용 요청 정보 (민감정보 제거)
+      debugRequest = {
+        hasIdentityToken: !!requestBody.identityToken,
+        identityTokenPreview: requestBody.identityToken
+          ? requestBody.identityToken.slice(0, 20) + '...'
+          : null,
+        user: requestBody.user,
+        email: requestBody.email ?? null,
+        fullName: requestBody.fullName ?? null,
+      };
+
+      console.log('[handleAppleLogin] debugRequest:', JSON.stringify(debugRequest, null, 2));
+
+      const tokenDto = await authService.getAppleTokenDto(requestBody);
 
       const user = await authService.loginWithSocialToken(tokenDto);
 
@@ -162,12 +195,25 @@ export default function LoginScreen() {
       if (e.code === 'ERR_REQUEST_CANCELED') {
         return;
       }
-      const msg = e instanceof Error ? e.message : 'Apple 로그인에 실패했습니다.';
-      Alert.alert('Apple 로그인 실패', msg);
+
+      // 디버그용 Alert - 상세 오류 정보 표시
+      Alert.alert(
+        'Apple 로그인 실패 (디버그)',
+        JSON.stringify(
+          {
+            code: e?.code ?? null,
+            message: e?.message ?? String(e),
+            request: debugRequest,
+          },
+          null,
+          2
+        )
+      );
     } finally {
       setAppleLoading(false);
     }
   };
+  // Apple login debug temporary code - END
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>

--- a/frontend/app/login/index.tsx
+++ b/frontend/app/login/index.tsx
@@ -14,7 +14,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
-// import * as AppleAuthentication from 'expo-apple-authentication';
+import * as AppleAuthentication from 'expo-apple-authentication';
 import { useAuth } from '../../hooks/useAuth';
 import { useSafeBack } from '../../hooks/useSafeBack';
 import * as authService from '../../services/auth.service';
@@ -110,17 +110,64 @@ export default function LoginScreen() {
     }
   };
 
-  // Apple 로그인 (iOS만 지원) - 임시 비활성화
-  // const [appleLoading, setAppleLoading] = useState(false);
-  // const [isAppleAvailable, setIsAppleAvailable] = useState(false);
+  // Apple 로그인 (iOS만 지원)
+  const [appleLoading, setAppleLoading] = useState(false);
+  const [isAppleAvailable, setIsAppleAvailable] = useState(false);
 
-  // useEffect(() => {
-  //   if (Platform.OS === 'ios') {
-  //     AppleAuthentication.isAvailableAsync().then(setIsAppleAvailable);
-  //   }
-  // }, []);
+  useEffect(() => {
+    if (Platform.OS === 'ios') {
+      AppleAuthentication.isAvailableAsync().then(setIsAppleAvailable);
+    }
+  }, []);
 
-  // const handleAppleLogin = async () => { ... };
+  const handleAppleLogin = async () => {
+    setAppleLoading(true);
+    try {
+      const credential = await AppleAuthentication.signInAsync({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+        ],
+      });
+
+      if (!credential.identityToken) {
+        Alert.alert('Apple 로그인', 'Apple 로그인을 취소했거나 토큰을 받지 못했습니다.');
+        return;
+      }
+
+      const tokenDto = await authService.getAppleTokenDto({
+        identityToken: credential.identityToken,
+        user: credential.user,
+        email: credential.email ?? undefined,
+        fullName: credential.fullName
+          ? {
+              givenName: credential.fullName.givenName ?? undefined,
+              familyName: credential.fullName.familyName ?? undefined,
+            }
+          : undefined,
+      });
+
+      const user = await authService.loginWithSocialToken(tokenDto);
+
+      login({
+        name: user.name,
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        profileImageUrl: user.profileImageUrl,
+      });
+
+      router.replace('/(tabs)/home');
+    } catch (e: any) {
+      if (e.code === 'ERR_REQUEST_CANCELED') {
+        return;
+      }
+      const msg = e instanceof Error ? e.message : 'Apple 로그인에 실패했습니다.';
+      Alert.alert('Apple 로그인 실패', msg);
+    } finally {
+      setAppleLoading(false);
+    }
+  };
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
@@ -192,7 +239,6 @@ export default function LoginScreen() {
             )}
           </Pressable>
 
-          {/* 소셜 로그인 임시 비활성화 (App Store 심사용)
           <Pressable
             style={({ pressed }) => [
               styles.kakaoLoginButton,
@@ -212,25 +258,14 @@ export default function LoginScreen() {
           </Pressable>
 
           {Platform.OS === 'ios' && isAppleAvailable && (
-            <Pressable
-              style={({ pressed }) => [
-                styles.appleLoginButton,
-                (pressed || appleLoading) && styles.appleLoginButtonPressed,
-              ]}
+            <AppleAuthentication.AppleAuthenticationButton
+              buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+              buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+              cornerRadius={8}
+              style={styles.appleLoginButton}
               onPress={handleAppleLogin}
-              disabled={appleLoading}
-            >
-              {appleLoading ? (
-                <ActivityIndicator color="#FFFFFF" />
-              ) : (
-                <>
-                  <Ionicons name="logo-apple" size={20} color="#FFFFFF" />
-                  <Text style={styles.appleLoginButtonText}>Apple로 로그인</Text>
-                </>
-              )}
-            </Pressable>
+            />
           )}
-          */}
 
           <Pressable
             style={styles.signupLink}
@@ -341,8 +376,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: 8,
-    paddingVertical: 14,
-    borderRadius: 4,
+    height: 44,
+    borderRadius: 8,
     backgroundColor: '#FEE500',
     marginTop: 12,
   },
@@ -356,21 +391,8 @@ const styles = StyleSheet.create({
   },
   // Apple 로그인 버튼 스타일 (Apple HIG 준수)
   appleLoginButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 14,
-    borderRadius: 4,
-    backgroundColor: '#000000',
+    width: '100%',
+    height: 44,
     marginTop: 12,
-  },
-  appleLoginButtonPressed: {
-    opacity: 0.9,
-  },
-  appleLoginButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#FFFFFF',
   },
 });

--- a/frontend/app/login/index.tsx
+++ b/frontend/app/login/index.tsx
@@ -389,7 +389,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#111827',
   },
-  // Apple 로그인 버튼 스타일 (Apple HIG 준수)
+  // Apple 로그인 버튼 스타일 (Apple 공식 버튼)
   appleLoginButton: {
     width: '100%',
     height: 44,

--- a/frontend/app/profile/[id].tsx
+++ b/frontend/app/profile/[id].tsx
@@ -293,7 +293,7 @@ export default function MemberProfileScreen() {
           <Text style={styles.postTitle} numberOfLines={1}>{item.title}</Text>
           <Text style={styles.postExcerpt} numberOfLines={2}>{item.contentPreview}</Text>
           <View style={styles.postMeta}>
-            <Text style={styles.postTime}>{formatRelativeTime(item.createdAt)}</Text>
+            <Text style={styles.postTime}>{formatRelativeTime((item as Record<string, unknown>).createdAt as string ?? (item as Record<string, unknown>).created_at as string)}</Text>
             <View style={styles.postStats}>
               <Ionicons name="heart-outline" size={12} color="#9CA3AF" />
               <Text style={styles.postStatText}>{item.likeCount ?? 0}</Text>
@@ -321,7 +321,7 @@ export default function MemberProfileScreen() {
           )}
           <Text style={styles.commentText} numberOfLines={2}>{item.content}</Text>
           <View style={styles.postMeta}>
-            <Text style={styles.postTime}>{formatRelativeTime(item.createdAt)}</Text>
+            <Text style={styles.postTime}>{formatRelativeTime((item as Record<string, unknown>).createdAt as string ?? (item as Record<string, unknown>).created_at as string)}</Text>
             <View style={styles.postStats}>
               <Ionicons name="heart-outline" size={12} color="#9CA3AF" />
               <Text style={styles.postStatText}>{item.likeCount ?? 0}</Text>

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 // contexts/AuthContext.tsx
 import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import * as authService from '../services/auth.service';
+import { registerPushToken } from '../services/notification.service';
 
 export type AuthUser = {
   name: string;
@@ -53,6 +54,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const profileImageUrl = (me.profileImageUrl ?? meAny.profile_image_url ?? '')?.toString?.()?.trim() || undefined;
       if (id != null) await authService.setStoredUserId(id);
       setUser({ name, id, role, email, profileImageUrl: profileImageUrl || undefined, profileImageVersion: Date.now() });
+      // 앱 시작 시 로그인 상태면 푸시 토큰 등록 (토큰 갱신 대비)
+      registerPushToken().catch(() => {});
     })();
   }, []);
 
@@ -61,6 +64,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       ...u,
       profileImageVersion: u.profileImageVersion ?? Date.now(),
     });
+    // 로그인 후 푸시 토큰 등록 (비동기, 실패해도 로그인은 진행)
+    registerPushToken().catch(() => {});
   }, []);
 
   const logout = useCallback(async () => {

--- a/frontend/hooks/useBoard.ts
+++ b/frontend/hooks/useBoard.ts
@@ -5,6 +5,39 @@ import * as boardService from '../services/board.service';
 type Category = '전체' | '후기' | '질문' | '자유';
 type SortType = 'latest' | 'popular';
 
+/** 인기글 필터: 좋아요 5개 이상 + 최근 7일 */
+function filterPopularPosts(content: PostListItem[]): PostListItem[] {
+  const now = new Date();
+  const cutoffDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  return content.filter((post) => {
+    const likes = post.likeCount ?? 0;
+    if (likes < MIN_LIKES_FOR_POPULAR) return false;
+
+    try {
+      const createdAt = (post as Record<string, unknown>).createdAt ?? (post as Record<string, unknown>).created_at;
+      if (!createdAt) return false;
+      const postDate = new Date(createdAt as string);
+      return postDate >= cutoffDate;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** 인기글 정렬: 좋아요 > 댓글 > 최신 */
+function sortPopularPosts(content: PostListItem[]): PostListItem[] {
+  return [...content].sort((a, b) => {
+    const la = a.likeCount ?? 0;
+    const lb = b.likeCount ?? 0;
+    if (lb !== la) return lb - la;
+    const ca = a.commentCount ?? 0;
+    const cb = b.commentCount ?? 0;
+    if (cb !== ca) return cb - ca;
+    return new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime();
+  });
+}
+
 /** 게시글 목록 (카테고리 + 정렬). 후기일 때 reviewEventId 있으면 해당 행사 후기만 */
 export function usePostList(
   selectedCategory: Category,
@@ -24,57 +57,39 @@ export function usePostList(
       if (selectedCategory === '전체') {
         data = await boardService.getPostList({
           page: 0,
-          size: 50,
+          size: 100,
           sort: sortType === 'popular' ? 'likeCount' : 'createdAt',
           direction: 'DESC',
         });
         if (sortType === 'popular' && data.content?.length) {
+          const filtered = filterPopularPosts(data.content);
           data = {
             ...data,
-            content: [...data.content].sort((a, b) => {
-              const la = a.likeCount ?? 0;
-              const lb = b.likeCount ?? 0;
-              if (lb !== la) return lb - la;
-              const ca = a.commentCount ?? 0;
-              const cb = b.commentCount ?? 0;
-              if (cb !== ca) return cb - ca;
-              return new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime();
-            }),
+            content: sortPopularPosts(filtered),
+            totalElements: filtered.length,
           };
         }
       } else if (selectedCategory === '후기' && reviewEventId != null && reviewEventId > 0) {
-        data = await boardService.getPostsByEventId(reviewEventId, { page: 0, size: 50 });
+        data = await boardService.getPostsByEventId(reviewEventId, { page: 0, size: 100 });
         if (sortType === 'popular') {
+          const filtered = filterPopularPosts(data.content);
           data = {
             ...data,
-            content: [...data.content].sort((a, b) => {
-              const la = a.likeCount ?? 0;
-              const lb = b.likeCount ?? 0;
-              if (lb !== la) return lb - la;
-              const ca = a.commentCount ?? 0;
-              const cb = b.commentCount ?? 0;
-              if (cb !== ca) return cb - ca;
-              return new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime();
-            }),
+            content: sortPopularPosts(filtered),
+            totalElements: filtered.length,
           };
         }
       } else {
         data = await boardService.getPostListByCategory(selectedCategory, {
           page: 0,
-          size: 50,
+          size: 100,
         });
         if (sortType === 'popular') {
+          const filtered = filterPopularPosts(data.content);
           data = {
             ...data,
-            content: [...data.content].sort((a, b) => {
-              const la = a.likeCount ?? 0;
-              const lb = b.likeCount ?? 0;
-              if (lb !== la) return lb - la;
-              const ca = a.commentCount ?? 0;
-              const cb = b.commentCount ?? 0;
-              if (cb !== ca) return cb - ca;
-              return new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime();
-            }),
+            content: sortPopularPosts(filtered),
+            totalElements: filtered.length,
           };
         }
       }
@@ -231,8 +246,10 @@ export function useLikedPostList(enabled: boolean = true) {
   return { posts, totalElements, loading, error, refetch: fetchList };
 }
 
-/** 홈 인기 게시물: 카테고리별 좋아요 최다 1개씩 (후기, 질문, 자유) */
+/** 홈 인기 게시물: 좋아요 5개 이상 + 최근 7일 내 게시물, 카테고리별 1개씩 (후기, 질문, 자유) */
 const HOME_CATEGORIES = ['후기', '질문', '자유'] as const;
+const MIN_LIKES_FOR_POPULAR = 5;
+const POPULAR_DAYS_LIMIT = 7;
 
 export function useHomePopularPosts() {
   const [posts, setPosts] = useState<PostListItem[]>([]);
@@ -245,13 +262,33 @@ export function useHomePopularPosts() {
     try {
       const data = await boardService.getPostList({
         page: 0,
-        size: 80,
+        size: 100,
         sort: 'likeCount',
         direction: 'DESC',
       });
       const content = data.content ?? [];
-      // 좋아요 많은 순, 같으면 댓글 많은 순
-      content.sort((a, b) => {
+
+      // 최근 7일 기준 날짜 계산
+      const now = new Date();
+      const cutoffDate = new Date(now.getTime() - POPULAR_DAYS_LIMIT * 24 * 60 * 60 * 1000);
+
+      // 좋아요 10개 이상 + 최근 7일 내 게시물만 필터
+      const filtered = content.filter((post) => {
+        const likes = post.likeCount ?? 0;
+        if (likes < MIN_LIKES_FOR_POPULAR) return false;
+
+        try {
+          const createdAt = (post as Record<string, unknown>).createdAt ?? (post as Record<string, unknown>).created_at;
+          if (!createdAt) return false;
+          const postDate = new Date(createdAt as string);
+          return postDate >= cutoffDate;
+        } catch {
+          return false;
+        }
+      });
+
+      // 좋아요 많은 순, 같으면 댓글 많은 순, 같으면 최신순
+      filtered.sort((a, b) => {
         const la = a.likeCount ?? 0;
         const lb = b.likeCount ?? 0;
         if (lb !== la) return lb - la;
@@ -260,8 +297,10 @@ export function useHomePopularPosts() {
         if (cb !== ca) return cb - ca;
         return new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime();
       });
+
+      // 카테고리별 1개씩 선정
       const byCategory: Record<string, PostListItem> = {};
-      for (const post of content) {
+      for (const post of filtered) {
         const cat = post.categoryType ?? '';
         if (HOME_CATEGORIES.includes(cat as typeof HOME_CATEGORIES[number]) && !byCategory[cat]) {
           byCategory[cat] = post;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "expo": "~54.0.31",
+        "expo-apple-authentication": "~8.0.8",
         "expo-build-properties": "~1.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
@@ -6603,6 +6604,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-8.0.8.tgz",
+      "integrity": "sha512-TwCHWXYR1kS0zaeV7QZKLWYluxsvqL31LFJubzK30njZqeWoWO89HZ8nZVaeXbFV1LrArKsze4BmMb+94wS0AQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-application": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.31",
+    "expo-apple-authentication": "~8.0.8",
     "expo-build-properties": "~1.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",

--- a/frontend/services/admin.service.ts
+++ b/frontend/services/admin.service.ts
@@ -599,12 +599,36 @@ export type DashboardResponse = {
   pendingInquiries: number;
   todaySignups: number;
   todayPosts: number;
+  todayComments: number;
+};
+
+/** 백엔드 실제 응답 구조 (중첩) */
+type DashboardRawResponse = {
+  memberStats?: { total?: number; active?: number; todaySignups?: number };
+  eventStats?: { total?: number };
+  postStats?: { total?: number; todayPosts?: number };
+  commentStats?: { total?: number; todayComments?: number };
+  reportStats?: { pending?: number };
+  inquiryStats?: { pending?: number };
 };
 
 export async function getDashboard(): Promise<DashboardResponse> {
   const res = await adminFetch('/api/admin/dashboard');
   if (!res.ok) throw new Error(await res.text().then((t) => t || '대시보드 조회 실패'));
-  return res.json();
+  const raw: DashboardRawResponse = await res.json();
+
+  // 중첩 구조를 평탄화
+  return {
+    totalMembers: raw.memberStats?.total ?? 0,
+    totalPosts: raw.postStats?.total ?? 0,
+    totalComments: raw.commentStats?.total ?? 0,
+    totalEvents: raw.eventStats?.total ?? 0,
+    pendingReports: raw.reportStats?.pending ?? 0,
+    pendingInquiries: raw.inquiryStats?.pending ?? 0,
+    todaySignups: raw.memberStats?.todaySignups ?? 0,
+    todayPosts: raw.postStats?.todayPosts ?? 0,
+    todayComments: raw.commentStats?.todayComments ?? 0,
+  };
 }
 
 // --- 일일 활동 통계 ---

--- a/frontend/services/admin.service.ts
+++ b/frontend/services/admin.service.ts
@@ -617,6 +617,9 @@ export async function getDashboard(): Promise<DashboardResponse> {
   if (!res.ok) throw new Error(await res.text().then((t) => t || '대시보드 조회 실패'));
   const raw: DashboardRawResponse = await res.json();
 
+  // DEBUG: API 응답 확인
+  console.log('[Dashboard] raw response:', JSON.stringify(raw, null, 2));
+
   // 중첩 구조를 평탄화
   return {
     totalMembers: raw.memberStats?.total ?? 0,

--- a/frontend/services/auth.service.ts
+++ b/frontend/services/auth.service.ts
@@ -543,6 +543,7 @@ export type AppleLoginRequest = {
 /**
  * Apple 로그인 - identityToken을 백엔드로 전송하여 JWT 발급
  */
+// Apple login debug temporary code - START
 export async function getAppleTokenDto(request: AppleLoginRequest): Promise<TokenDto> {
   console.log('[getAppleTokenDto] API_BASE_URL:', API_BASE_URL);
   console.log('[getAppleTokenDto] request url:', `${API_BASE_URL}/api/auth/apple`);
@@ -560,9 +561,13 @@ export async function getAppleTokenDto(request: AppleLoginRequest): Promise<Toke
     console.error('[getAppleTokenDto] fetch error:', e);
     const msg = e instanceof Error ? e.message : '';
     if (/failed to fetch|network request failed|network error/i.test(msg)) {
-      throw new Error('서버에 연결할 수 없습니다. 네트워크 연결을 확인해 주세요.');
+      throw new Error(
+        `[Apple API Error]\nstatus: NETWORK_ERROR\nresponse: ${msg || '서버에 연결할 수 없습니다.'}`
+      );
     }
-    throw e;
+    throw new Error(
+      `[Apple API Error]\nstatus: FETCH_ERROR\nresponse: ${msg || String(e)}`
+    );
   }
 
   console.log('[getAppleTokenDto] response status:', res.status);
@@ -571,13 +576,16 @@ export async function getAppleTokenDto(request: AppleLoginRequest): Promise<Toke
   console.log('[getAppleTokenDto] response text:', text);
 
   if (!res.ok) {
-    throw new Error(getErrorMessage(text, res.status, 'Apple 로그인에 실패했습니다.'));
+    throw new Error(
+      `[Apple API Error]\nstatus: ${res.status}\nresponse: ${text || '(empty response)'}`
+    );
   }
 
   const parsed = JSON.parse(text) as TokenDto;
-  console.log('[getAppleTokenDto] parsed success:', parsed);
+  console.log('[getAppleTokenDto] parsed success (tokens hidden)');
   return parsed;
 }
+// Apple login debug temporary code - END
 
 export async function withdrawApi(): Promise<void> {
   const token = await getAccessToken();

--- a/frontend/services/notification.service.ts
+++ b/frontend/services/notification.service.ts
@@ -1,3 +1,6 @@
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
 import { API_BASE_URL } from '../constants/api';
 import { getAccessToken } from './auth.service';
 
@@ -12,6 +15,80 @@ const getAuthHeaders = async (): Promise<HeadersInit> => {
   }
   return headers;
 };
+
+/** FCM 푸시 토큰 획득 */
+async function getExpoPushToken(): Promise<string | null> {
+  try {
+    // 알림 권한 확인
+    const { status: existingStatus } = await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+
+    if (existingStatus !== 'granted') {
+      const { status } = await Notifications.requestPermissionsAsync();
+      finalStatus = status;
+    }
+
+    if (finalStatus !== 'granted') {
+      console.log('[PushToken] 알림 권한이 거부되었습니다.');
+      return null;
+    }
+
+    // Android 알림 채널 설정
+    if (Platform.OS === 'android') {
+      await Notifications.setNotificationChannelAsync('default', {
+        name: 'default',
+        importance: Notifications.AndroidImportance.MAX,
+        vibrationPattern: [0, 250, 250, 250],
+        lightColor: '#FF231F7C',
+      });
+    }
+
+    // 푸시 토큰 획득
+    const projectId = Constants.expoConfig?.extra?.eas?.projectId;
+    const tokenData = await Notifications.getExpoPushTokenAsync({
+      projectId,
+    });
+
+    return tokenData.data;
+  } catch (e) {
+    // 시뮬레이터/에뮬레이터에서는 푸시 토큰 획득 실패
+    console.log('[PushToken] 푸시 토큰 획득 실패 (시뮬레이터이거나 설정 문제):', e);
+    return null;
+  }
+}
+
+/** 서버에 푸시 토큰 등록 - POST /api/notification/token */
+export async function registerPushToken(): Promise<boolean> {
+  try {
+    const pushToken = await getExpoPushToken();
+    if (!pushToken) {
+      console.log('[PushToken] 푸시 토큰을 획득하지 못했습니다.');
+      return false;
+    }
+
+    const deviceType = Platform.OS === 'ios' ? 'IOS' : 'ANDROID';
+
+    const res = await fetch(`${API_BASE_URL}/api/notification/token`, {
+      method: 'POST',
+      headers: await getAuthHeaders(),
+      body: JSON.stringify({
+        token: pushToken,
+        deviceType,
+      }),
+    });
+
+    if (!res.ok) {
+      console.log(`[PushToken] 토큰 등록 실패: ${res.status}`);
+      return false;
+    }
+
+    console.log('[PushToken] 푸시 토큰 등록 성공');
+    return true;
+  } catch (e) {
+    console.log('[PushToken] 토큰 등록 중 오류:', e);
+    return false;
+  }
+}
 
 export type NotificationSettings = {
   memberId: number;

--- a/frontend/services/notification.service.ts
+++ b/frontend/services/notification.service.ts
@@ -1,6 +1,5 @@
 import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import Constants from 'expo-constants';
 import { API_BASE_URL } from '../constants/api';
 import { getAccessToken } from './auth.service';
 
@@ -16,8 +15,20 @@ const getAuthHeaders = async (): Promise<HeadersInit> => {
   return headers;
 };
 
-/** FCM 푸시 토큰 획득 */
-async function getExpoPushToken(): Promise<string | null> {
+/**
+ * FCM Registration Token 획득
+ *
+ * 서버가 Firebase Admin SDK로 FCM에 직접 발송하므로
+ * Expo Push Token이 아닌 FCM Registration Token이 필요합니다.
+ *
+ * app.json에 googleServicesFile이 설정되어 있으므로:
+ * - Android: FCM Registration Token 반환
+ * - iOS: FCM Registration Token 반환 (GoogleService-Info.plist 연동)
+ *
+ * 참고: googleServicesFile이 없으면 iOS는 APNs 토큰을 반환하며,
+ * 이 경우 Firebase Admin SDK로 직접 발송할 수 없습니다.
+ */
+async function getDevicePushToken(): Promise<string | null> {
   try {
     // 알림 권한 확인
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
@@ -43,11 +54,10 @@ async function getExpoPushToken(): Promise<string | null> {
       });
     }
 
-    // 푸시 토큰 획득
-    const projectId = Constants.expoConfig?.extra?.eas?.projectId;
-    const tokenData = await Notifications.getExpoPushTokenAsync({
-      projectId,
-    });
+    // FCM Registration Token 획득
+    // getDevicePushTokenAsync()는 projectId가 필요 없음
+    const tokenData = await Notifications.getDevicePushTokenAsync();
+    console.log('[PushToken] FCM 토큰 획득 성공, type:', tokenData.type);
 
     return tokenData.data;
   } catch (e) {
@@ -60,7 +70,7 @@ async function getExpoPushToken(): Promise<string | null> {
 /** 서버에 푸시 토큰 등록 - POST /api/notification/token */
 export async function registerPushToken(): Promise<boolean> {
   try {
-    const pushToken = await getExpoPushToken();
+    const pushToken = await getDevicePushToken();
     if (!pushToken) {
       console.log('[PushToken] 푸시 토큰을 획득하지 못했습니다.');
       return false;

--- a/frontend/utils/formatDate.ts
+++ b/frontend/utils/formatDate.ts
@@ -46,22 +46,133 @@ export function formatDateTimeAdmin(iso: string): string {
   return `${y}.${m}.${day} ${h}:${min}`;
 }
 
-/** 상대 시간 (24시간 미만: 방금 전, N분/시간 전 / 24시간 이상: 작성 날짜·시간) */
+/** 상대 시간 표시
+ * - 5분 이내: 방금 전
+ * - 1시간 이내: N분 전
+ * - 오늘 내 1시간 이상: N시간 전
+ * - 어제~6일: N일 전
+ * - 7일~: N주 전
+ * - 4주~: N달 전
+ * - 12달~: N년 전
+ */
 export function formatRelativeTime(iso?: string): string {
   try {
     if (!iso) return '';
 
-    // 🔥 UTC → KST 변환
-    const d = new Date(iso.endsWith('Z') ? iso : iso + 'Z');
-
+    // 서버가 KST로 보내므로 타임존 없으면 KST(+09:00)로 해석
+    let d: Date;
+    if (iso.includes('Z') || iso.includes('+') || iso.includes('-', 10)) {
+      d = new Date(iso);
+    } else {
+      d = new Date(iso + '+09:00');
+    }
     const now = new Date();
-    const diff = now.getTime() - d.getTime();
+    const diffMs = now.getTime() - d.getTime();
 
-    if (diff < 60000) return '방금 전';
-    if (diff < 3600000) return `${Math.floor(diff / 60000)}분 전`;
-    if (diff < 86400000) return `${Math.floor(diff / 3600000)}시간 전`;
-    if (diff < 172800000) return '어제';
-    return `${Math.floor(diff / 86400000)}일 전`;
+    // 음수(미래)는 "방금 전"으로 표시 (서버 시간 오차 허용)
+    if (diffMs < 0) return '방금 전';
+
+    const diffMinutes = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+
+    // 5분 이내: 방금 전
+    if (diffMinutes < 5) return '방금 전';
+
+    // 1시간 이내: N분 전
+    if (diffMinutes < 60) return `${diffMinutes}분 전`;
+
+    // 날짜 비교를 위해 자정 기준 계산
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const targetDate = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    const diffDays = Math.floor((todayStart.getTime() - targetDate.getTime()) / 86400000);
+
+    // 오늘 (자정 이전): N시간 전
+    if (diffDays === 0) {
+      return `${diffHours}시간 전`;
+    }
+
+    // 1~6일 전: N일 전
+    if (diffDays < 7) {
+      return `${diffDays}일 전`;
+    }
+
+    // 7일 이상 ~ 4주 미만: N주 전
+    const diffWeeks = Math.floor(diffDays / 7);
+    if (diffWeeks < 4) {
+      return `${diffWeeks}주 전`;
+    }
+
+    // 4주 이상 ~ 12달 미만: N달 전
+    const diffMonths = Math.floor(diffDays / 30);
+    if (diffMonths < 12) {
+      return `${diffMonths}달 전`;
+    }
+
+    // 12달 이상: N년 전
+    const diffYears = Math.floor(diffDays / 365);
+    return `${diffYears}년 전`;
+  } catch {
+    return '';
+  }
+}
+
+/** 채팅용 시간 표시
+ * - 당일: 오전/오후 H:MM (예: 오후 3:45)
+ * - 1~6일 전: N일 전
+ * - 7일~4주 미만: N주 전
+ * - 4주~12달 미만: N달 전
+ * - 12달 이상: N년 전
+ */
+export function formatChatTime(iso?: string): string {
+  try {
+    if (!iso) return '';
+
+    // 서버가 KST로 보내므로 타임존 없으면 KST(+09:00)로 해석
+    let d: Date;
+    if (iso.includes('Z') || iso.includes('+') || iso.includes('-', 10)) {
+      d = new Date(iso);
+    } else {
+      d = new Date(iso + '+09:00');
+    }
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+
+    if (diffMs < 0) return '방금 전';
+
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const targetDate = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    const diffDays = Math.floor((todayStart.getTime() - targetDate.getTime()) / 86400000);
+
+    // 당일: 오전/오후 H:MM 형식
+    if (diffDays === 0) {
+      const hours = d.getHours();
+      const minutes = d.getMinutes();
+      const period = hours < 12 ? '오전' : '오후';
+      const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+      const displayMinutes = String(minutes).padStart(2, '0');
+      return `${period} ${displayHours}:${displayMinutes}`;
+    }
+
+    // 1~6일 전: N일 전
+    if (diffDays < 7) {
+      return `${diffDays}일 전`;
+    }
+
+    // 7일 이상 ~ 4주 미만: N주 전
+    const diffWeeks = Math.floor(diffDays / 7);
+    if (diffWeeks < 4) {
+      return `${diffWeeks}주 전`;
+    }
+
+    // 4주 이상 ~ 12달 미만: N달 전
+    const diffMonths = Math.floor(diffDays / 30);
+    if (diffMonths < 12) {
+      return `${diffMonths}달 전`;
+    }
+
+    // 12달 이상: N년 전
+    const diffYears = Math.floor(diffDays / 365);
+    return `${diffYears}년 전`;
   } catch {
     return '';
   }


### PR DESCRIPTION
## 개요
관리자 대시보드에서 댓글 통계 정보를 확인할 수 있도록 백엔드 응답 DTO와 통계 조회 로직을 추가했습니다.

## 관련 이슈
- Refs #이슈번호

## 작업 내용
- [x] 댓글 통계 응답 DTO `CommentStatsDto` 추가
- [x] `DashboardResponseDto`에 `commentStats` 필드 추가
- [x] `CommentRepository`에 댓글 통계 조회 메서드 추가
- [x] `AdminDashboardService`에서 전체 댓글 수, 노출 댓글 수, 숨김 댓글 수, 오늘 작성된 댓글 수 계산 로직 추가
- [x] 관리자 대시보드 응답에 댓글 통계 포함

## 체크리스트
- [x] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
- [x] 변경된 DTO와 서비스 로직이 기존 대시보드 응답 구조를 깨뜨리지 않는가?
- [x] 새로 추가된 파일이 Git에 정상적으로 포함되었는가?