### PR TITLE
Google Play 배포 시 사진/영상 권한 정책 오류로 인해 `expo-media-library` 패키지 제거 및 채팅 이미지 저장 기능 비활성화

### DIFF
--- a/frontend/app/(tabs)/map/index.tsx
+++ b/frontend/app/(tabs)/map/index.tsx
@@ -2491,9 +2491,10 @@ const styles = StyleSheet.create({
   listButtonText: { color: '#ffffff', fontWeight: '700', fontSize: 15, letterSpacing: -0.3 },
   busTimetableButton: {
     paddingHorizontal: 18,
-    paddingVertical: 12,
+    paddingVertical: 8,
     borderRadius: 9999,
-    backgroundColor: '#C2C2C2',
+    backgroundColor: '#9CA3AF',
+    flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
     shadowColor: '#000',
@@ -2502,7 +2503,7 @@ const styles = StyleSheet.create({
     shadowRadius: 3,
     elevation: 4,
   },
-  busTimetableButtonText: { color: '#ffffff', fontWeight: '600', fontSize: 15, letterSpacing: -0.5 },
+  busTimetableButtonText: { color: '#ffffff', fontWeight: '700', fontSize: 15, letterSpacing: -0.3 },
   menuIcon: {
     flexDirection: 'column',
     justifyContent: 'center',

--- a/frontend/app/board/chat/[id].tsx
+++ b/frontend/app/board/chat/[id].tsx
@@ -2,8 +2,8 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import * as ImagePicker from "expo-image-picker";
-import * as MediaLibrary from "expo-media-library";
-import * as FileSystem from "expo-file-system/legacy";
+// import * as MediaLibrary from "expo-media-library";
+// import * as FileSystem from "expo-file-system/legacy";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -294,27 +294,27 @@ export default function ChatRoomScreen() {
         return;
       }
 
-      const { status } = await MediaLibrary.requestPermissionsAsync();
-      if (status !== "granted") {
-        Alert.alert("권한 필요", "사진 저장을 위해 미디어 라이브러리 접근 권한이 필요합니다.");
-        return;
-      }
+      // const { status } = await MediaLibrary.requestPermissionsAsync();
+      // if (status !== "granted") {
+      //   Alert.alert("권한 필요", "사진 저장을 위해 미디어 라이브러리 접근 권한이 필요합니다.");
+      //   return;
+      // }
 
-      let localUri = fullUri;
-      if (fullUri.startsWith("http://") || fullUri.startsWith("https://")) {
-        const docDir = FileSystem.documentDirectory;
-        if (!docDir) {
-          Alert.alert("오류", "파일 저장 경로를 찾을 수 없습니다.");
-          return;
-        }
-        const ext = (fullUri.split(".").pop()?.split("?")[0] ?? "jpg").toLowerCase();
-        const safeExt = ["jpg", "jpeg", "png", "webp"].includes(ext) ? ext : "jpg";
-        const dest = `${docDir}chat_${Date.now()}.${safeExt}`;
-        const result = await FileSystem.downloadAsync(fullUri, dest);
-        localUri = result.uri;
-      }
-      await MediaLibrary.saveToLibraryAsync(localUri);
-      Alert.alert("저장 완료", "사진이 갤러리에 저장되었습니다.");
+      // let localUri = fullUri;
+      // if (fullUri.startsWith("http://") || fullUri.startsWith("https://")) {
+      //   const docDir = FileSystem.documentDirectory;
+      //   if (!docDir) {
+      //     Alert.alert("오류", "파일 저장 경로를 찾을 수 없습니다.");
+      //     return;
+      //   }
+      //   const ext = (fullUri.split(".").pop()?.split("?")[0] ?? "jpg").toLowerCase();
+      //   const safeExt = ["jpg", "jpeg", "png", "webp"].includes(ext) ? ext : "jpg";
+      //   const dest = `${docDir}chat_${Date.now()}.${safeExt}`;
+      //   const result = await FileSystem.downloadAsync(fullUri, dest);
+      //   localUri = result.uri;
+      // }
+      // await MediaLibrary.saveToLibraryAsync(localUri);
+      // Alert.alert("저장 완료", "사진이 갤러리에 저장되었습니다.");
     } catch (e) {
       console.log("[ChatImage] save failed:", e);
       Alert.alert("오류", "저장에 실패했습니다.");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,6 @@
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-location": "~19.0.8",
-        "expo-media-library": "~18.2.1",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.21",
         "expo-splash-screen": "~31.0.13",
@@ -6919,16 +6918,6 @@
       },
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/expo-media-library": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-18.2.1.tgz",
-      "integrity": "sha512-dV1acx6Aseu+I5hmF61wY8UkD4vdt8d7YXHDfgNp6ZSs06qxayUxgrBsiG2eigLe54VLm3ycbFBbWi31lhfsCA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-location": "~19.0.8",
-    "expo-media-library": "~18.2.1",
     "expo-notifications": "~0.32.16",
     "expo-router": "~6.0.21",
     "expo-splash-screen": "~31.0.13",


### PR DESCRIPTION
## 개요
Google Play 배포 시 사진/영상 권한 정책 오류로 인해 `expo-media-library` 패키지 제거 및 채팅 이미지 저장 기능 비활성화

## 관련 이슈
- Refs #

## 작업 내용
- [x] `expo-media-library` 패키지 제거 (`package.json`, `package-lock.json`)
- [x] `app/board/chat/[id].tsx` 채팅 이미지 저장 코드 주석 처리 (`MediaLibrary` import 및 저장 로직)
- [x] 버스 시간표 버튼 스타일 수정

## 체크리스트
- [ ] 빌드가 에러 없이 수행되는가?
- [ ] 불필요한 로그(console.log 등)는 없는가?
